### PR TITLE
fix: maxtime for timetagging is too short

### DIFF
--- a/Quantum-Control-Applications/Optically addressable spin qubits/Cryogenic nanophotonic cavity/cw_odmr.py
+++ b/Quantum-Control-Applications/Optically addressable spin qubits/Cryogenic nanophotonic cavity/cw_odmr.py
@@ -48,7 +48,7 @@ with program() as cw_odmr:
             align()  # global align
 
             # decay readout
-            measure("long_readout", "SNSPD", None, time_tagging.analog(times, meas_len, counts))
+            measure("long_readout", "SNSPD", None, time_tagging.analog(times, long_meas_len, counts))
 
             save(counts, counts_st)  # save counts on stream
             save(n, n_st)  # save number of iteration inside for_loop


### PR DESCRIPTION
wrong measure len causes compilation error