### PR TITLE
Fix typo in active reset condition.

### DIFF
--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/09c_active_reset.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/09c_active_reset.py
@@ -140,7 +140,7 @@ def active_reset_fast(threshold_g: float):
     # Wait for the resonator to deplete
     wait(depletion_time * u.ns, "qubit")
     # Play a conditional pi-pulse to actively reset the qubit
-    play("x180", "qubit", condition=(I > threshold_g))
+    play("x180", "qubit", condition=(I_reset > threshold_g))
     return 1
 
 


### PR DESCRIPTION
Here it looks like a copy paste caused the condition for the x180 active reset pulse to refer to a variable `I`, instead of the intended variable `I_reset`. 