### PR TITLE
Update configs 3.2 mw fem

### DIFF
--- a/Quantum-Control-Applications/Optically addressable spin qubits/Cryogenic nanophotonic cavity/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Optically addressable spin qubits/Cryogenic nanophotonic cavity/configuration_with_lf_fem.py
@@ -88,6 +88,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "direct",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Optically addressable spin qubits/Electron Spin Resonance/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Optically addressable spin qubits/Electron Spin Resonance/configuration_with_lf_fem.py
@@ -129,6 +129,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "direct",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Optically addressable spin qubits/NV center in a confocal setup/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Optically addressable spin qubits/NV center in a confocal setup/configuration_with_lf_fem.py
@@ -107,6 +107,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "direct",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Optically addressable spin qubits/NV center in a confocal setup/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Optically addressable spin qubits/NV center in a confocal setup/configuration_with_lf_fem_and_octave.py
@@ -109,6 +109,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "direct",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem.py
@@ -376,6 +376,7 @@ config = {
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
                             "output_mode": "amplified",
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)
                             #   2 GS/s: uses two cores per output

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_mw_fem.py
@@ -361,7 +361,7 @@ config = {
                     # Its range is -41dBm to +10dBm with 3dBm steps.
                     "type": "MW",
                     "analog_outputs": {
-                        1: {"band": 1, "full_scale_power_dbm": qubit_power},  # qubit
+                        1: {"band": 1, "full_scale_power_dbm": qubit_power, "upconverters": { 1: {"frequency": qubit_LO} } },  # qubit
                     },
                     "digital_outputs": {},
                 },
@@ -506,8 +506,10 @@ config = {
             },
         },
         "qubit": {
-            "RF_inputs": {"port": (con, mw_fem, 1)},
-            "intermediate_frequency": qubit_IF,
+            "MWInput": {
+                "port": (con, mw_fem, 1),
+                "upconverter": 1,
+            },            "intermediate_frequency": qubit_IF,
             "operations": {
                 "cw": "cw_pulse",
                 "pi": "pi_pulse",

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_mw_fem.py
@@ -375,6 +375,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "amplified",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_mw_fem.py
@@ -20,8 +20,8 @@ qop_port = None  # Write the QOP port if version < QOP220
 # OPX configuration #
 #####################
 con = "con1"
-lf_fem = 1  # Should be the LF-FEM index, e.g., 1
-mw_fem = 5  # Should be the MW-FEM index, e.g., 5
+lf_fem = 5  # Should be the LF-FEM index, e.g., 1
+mw_fem = 1  # Should be the MW-FEM index, e.g., 5
 
 octave_config = None
 

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_octave.py
@@ -371,6 +371,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "amplified",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Quantum-Dots/Singlet_Triplet_Qubit/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Singlet_Triplet_Qubit/configuration_with_lf_fem.py
@@ -347,6 +347,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "amplified",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem.py
@@ -211,6 +211,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "direct",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem_and_octave.py
@@ -210,6 +210,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "direct",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_mw_fem.py
@@ -17,7 +17,7 @@ qop_port = None  # Write the QOP port if version < QOP220
 octave_config = None
 
 con = "con1"
-fem = 5
+fem = 1
 
 # Path to save data
 save_dir = Path().absolute() / "QM" / "INSTALLATION" / "data"

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_mw_fem.py
@@ -179,12 +179,12 @@ config = {
                     # Its range is -41dBm to +10dBm with 3dBm steps.
                     "type": "MW",
                     "analog_outputs": {
-                        1: {"band": 2, "full_scale_power_dbm": resonator_power},  # resonator
-                        2: {"band": 2, "full_scale_power_dbm": qubit_power},  # qubit
+                        1: {"band": 2, "full_scale_power_dbm": resonator_power, "upconverters": { 1: {"frequency": resonator_LO} } },  # resonator
+                        2: {"band": 2, "full_scale_power_dbm": qubit_power, "upconverters": { 1: {"frequency": qubit_LO}}},  # qubit
                     },
                     "digital_outputs": {},
                     "analog_inputs": {
-                        1: {"band": 2},  # I from down-conversion
+                        1: {"band": 2, "downconverter_frequency": resonator_LO},  # for down-conversion
                     },
                 }
             },
@@ -194,10 +194,7 @@ config = {
         "resonator": {
             "MWInput": {
                 "port": (con, fem, 1),
-                # Note the 'oscillator_frequency' field will be renamed 'upconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                # The ability to use multiple upconverters in the same output will also be added.
-                "oscillator_frequency": resonator_LO,
+                "upconverter": 1,
             },
             "intermediate_frequency": resonator_IF,
             "operations": {
@@ -206,9 +203,6 @@ config = {
             },
             "MWOutput": {
                 "port": (con, fem, 1),
-                # Note the 'oscillator_frequency' field will be renamed 'downconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                "oscillator_frequency": resonator_LO,
             },
             "time_of_flight": time_of_flight,
             "smearing": 0,
@@ -216,10 +210,7 @@ config = {
         "qubit": {
             "MWInput": {
                 "port": (con, fem, 2),
-                # Note the 'oscillator_frequency' field will be renamed 'upconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                # The ability to use multiple upconverters in the same output will also be added.
-                "oscillator_frequency": qubit_LO,
+                "upconverter": 1,
             },
             "intermediate_frequency": qubit_IF,
             "operations": {

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem.py
@@ -224,6 +224,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "direct",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_mw_fem.py
@@ -203,12 +203,12 @@ config = {
                     # Its range is -41dBm to +10dBm with 3dBm steps.
                     "type": "MW",
                     "analog_outputs": {
-                        1: {"band": 2, "full_scale_power_dbm": resonator_power},  # resonator
-                        2: {"band": 2, "full_scale_power_dbm": qubit_power},  # qubit
+                        1: {"band": 2, "full_scale_power_dbm": resonator_power, "upconverters": { 1: {"frequency": resonator_LO} } },  # resonator
+                        2: {"band": 2, "full_scale_power_dbm": qubit_power, "upconverters": { 1: {"frequency": qubit_LO}}},  # qubit
                     },
                     "digital_outputs": {},
                     "analog_inputs": {
-                        1: {"band": 2},  # I from down-conversion
+                        1: {"band": 2, "downconverter_frequency": resonator_LO},  # for down-conversion
                     },
                 },
                 lf_fem: {
@@ -245,10 +245,7 @@ config = {
         "qubit": {
             "MWInput": {
                 "port": (con, mw_fem, 1),
-                # Note the 'oscillator_frequency' field will be renamed 'upconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                # The ability to use multiple upconverters in the same output will also be added.
-                "oscillator_frequency": qubit_LO,
+                "upconverter": 1,
             },
             "intermediate_frequency": qubit_IF,
             "operations": {
@@ -267,10 +264,7 @@ config = {
         "resonator": {
             "MWInput": {
                 "port": (con, mw_fem, 2),
-                # Note the 'oscillator_frequency' field will be renamed 'upconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                # The ability to use multiple upconverters in the same output will also be added.
-                "oscillator_frequency": resonator_LO,
+                "upconverter": 1,
             },
             "intermediate_frequency": resonator_IF,
             "operations": {
@@ -279,9 +273,6 @@ config = {
             },
             "MWOutput": {
                 "port": (con, mw_fem, 1),
-                # Note the 'oscillator_frequency' field will be renamed 'downconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                "oscillator_frequency": resonator_LO,
             },
             "time_of_flight": time_of_flight,
             "smearing": 0,

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_mw_fem.py
@@ -220,6 +220,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "amplified",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_mw_fem.py
@@ -22,8 +22,8 @@ save_dir = Path().absolute() / "QM" / "INSTALLATION" / "data"
 # OPX configuration #
 #####################
 con = "con1"
-lf_fem = 1
-mw_fem = 5
+lf_fem = 5
+mw_fem = 1
 
 # Set octave_config to None if no octave are present
 octave_config = None

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_octave.py
@@ -223,6 +223,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "direct",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Transmons/Standard Configuration/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Transmons/Standard Configuration/configuration_with_lf_fem.py
@@ -324,6 +324,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "direct",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Transmons/Standard Configuration/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Transmons/Standard Configuration/configuration_with_lf_fem_and_mw_fem.py
@@ -330,6 +330,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "amplified",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Transmons/Standard Configuration/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Transmons/Standard Configuration/configuration_with_lf_fem_and_mw_fem.py
@@ -310,15 +310,15 @@ config = {
                     "type": "MW",
                     "analog_outputs": {
                         # Resonator XY
-                        1: {"band": 2, "full_scale_power_dbm": resonator_power},
+                        1: {"band": 2, "full_scale_power_dbm": resonator_power, "upconverters": { 1: {"frequency": resonator_LO} } },
                         # Qubit 1 XY
-                        2: {"band": 1, "full_scale_power_dbm": qubit_power},
+                        2: {"band": 1, "full_scale_power_dbm": qubit_power, "upconverters": { 1: {"frequency": qubit_LO_q1}}},
                         # Qubit 2 XY
-                        3: {"band": 1, "full_scale_power_dbm": qubit_power},
+                        3: {"band": 1, "full_scale_power_dbm": qubit_power, "upconverters": { 1: {"frequency": qubit_LO_q2}}},
                     },
                     "digital_outputs": {},
                     "analog_inputs": {
-                        1: {"band": 2},  # I from down-conversion
+                        1: {"band": 2, "downconverter_frequency": resonator_LO},  # for down-conversion
                     },
                 },
                 lf_fem: {
@@ -362,10 +362,7 @@ config = {
         "rr1": {
             "MWInput": {
                 "port": (con, mw_fem, 1),
-                # Note the 'oscillator_frequency' field will be renamed 'upconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                # The ability to use multiple upconverters in the same output will also be added.
-                "oscillator_frequency": resonator_LO,
+                "upconverter": 1,
             },
             "intermediate_frequency": resonator_IF_q1,  # frequency at offset ch7
             "operations": {
@@ -374,9 +371,6 @@ config = {
             },
             "MWOutput": {
                 "port": (con, mw_fem, 1),
-                # Note the 'oscillator_frequency' field will be renamed 'downconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                "oscillator_frequency": resonator_LO,
             },
             "time_of_flight": time_of_flight,
             "smearing": 0,
@@ -384,10 +378,7 @@ config = {
         "rr2": {
             "MWInput": {
                 "port": (con, mw_fem, 1),
-                # Note the 'oscillator_frequency' field will be renamed 'upconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                # The ability to use multiple upconverters in the same output will also be added.
-                "oscillator_frequency": resonator_LO,
+                "upconverter": 1,
             },
             "intermediate_frequency": resonator_IF_q2,  # frequency at offset ch8
             "operations": {
@@ -396,9 +387,6 @@ config = {
             },
             "MWOutput": {
                 "port": (con, mw_fem, 1),
-                # Note the 'oscillator_frequency' field will be renamed 'downconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                "oscillator_frequency": resonator_LO,
             },
             "time_of_flight": time_of_flight,
             "smearing": 0,
@@ -406,10 +394,7 @@ config = {
         "q1_xy": {
             "MWInput": {
                 "port": (con, mw_fem, 2),
-                # Note the 'oscillator_frequency' field will be renamed 'upconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                # The ability to use multiple upconverters in the same output will also be added.
-                "oscillator_frequency": qubit_LO_q1,
+                "upconverter": 1,
             },
             "intermediate_frequency": qubit_IF_q1,  # frequency at offset ch7 (max freq)
             "operations": {
@@ -426,10 +411,7 @@ config = {
         "q2_xy": {
             "MWInput": {
                 "port": (con, mw_fem, 3),
-                # Note the 'oscillator_frequency' field will be renamed 'upconverter_frequency'
-                # and will be moved to the port definition in QOP 3.2.
-                # The ability to use multiple upconverters in the same output will also be added.
-                "oscillator_frequency": qubit_LO_q2,
+                "upconverter": 1,
             },
             "intermediate_frequency": qubit_IF_q2,  # frequency at offset ch8 (max freq)
             "operations": {

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Transmons/Standard Configuration/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Transmons/Standard Configuration/configuration_with_lf_fem_and_mw_fem.py
@@ -21,8 +21,8 @@ save_dir = Path().absolute() / "QM" / "INSTALLATION" / "data"
 # OPX configuration #
 #####################
 con = "con1"
-lf_fem = 1
-mw_fem = 5
+lf_fem = 5
+mw_fem = 1
 
 # Set octave_config to None if no octave are present
 octave_config = None

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Transmons/Standard Configuration/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Transmons/Standard Configuration/configuration_with_lf_fem_and_octave.py
@@ -326,6 +326,7 @@ config = {
                             # The "output_mode" can be used to tailor the max voltage and frequency bandwidth, i.e.,
                             #   "direct":    1Vpp (-0.5V to 0.5V), 750MHz bandwidth (default)
                             #   "amplified": 5Vpp (-2.5V to 2.5V), 330MHz bandwidth
+                            # Note, 'offset' takes absolute values, e.g., if in amplified mode and want to output 2.0 V, then set "offset": 2.0
                             "output_mode": "direct",
                             # The "sampling_rate" can be adjusted by using more FEM cores, i.e.,
                             #   1 GS/s: uses one core per output (default)


### PR DESCRIPTION
Updated LF-FEM comment that `offset` should be absolute values, and in MW-FEM now
upconverters is part of analog ouputs as well as in the elements the upconverters.

Tested in Beta_8, the mw- and lf-fem's programs