### PR TITLE
add DC calibrations with QDAC folder to README file

### DIFF
--- a/Quantum-Control-Applications/README.md
+++ b/Quantum-Control-Applications/README.md
@@ -78,6 +78,9 @@ Set-ups including the Octave and/or QDAC2 are also supported.
 These files showcase various experiments that can be done on a singlet-triplet qubit.
 Set-ups including the QDAC2 are also supported.
 
+### [DC calibrations with QDAC](https://github.com/qua-platform/qua-libs/tree/main/Quantum-Control-Applications/Quantum-Dots/DC%20calibrations%20with%20QDAC)
+These files provide guidance on establishing communication with the QDAC and performing various DC calibrations using its internal current sensor.
+
 #### <u> Advanced use-cases: </u>
 * [Fast 2D scans using a spiral pattern](https://github.com/qua-platform/qua-libs/tree/main/Quantum-Control-Applications/Quantum-Dots/Use%20Case%201%20-%20Fast%202D%20Scans#fast-two-dimensional-scans-using-a-spiral-pattern)
   performed in the lab of Prof. Natalia Ares in the University of Oxford.


### PR DESCRIPTION
Hey, I just added the link to DC calibrations with QDAC  in the Quantum Control Applications README file.