### PR TITLE
Ql 156/update time of flight to 32ns

### DIFF
--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration.py
@@ -68,7 +68,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 32
+time_of_flight = 28
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration.py
@@ -1,9 +1,10 @@
 from pathlib import Path
+
 import numpy as np
-from scipy.signal.windows import gaussian
+import plotly.io as pio
 from qualang_tools.units import unit
 from qualang_tools.voltage_gates import VoltageGateSequence
-import plotly.io as pio
+from scipy.signal.windows import gaussian
 
 pio.renderers.default = "browser"
 
@@ -67,7 +68,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 24
+time_of_flight = 32
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem.py
@@ -80,7 +80,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 32
+time_of_flight = 28
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem.py
@@ -3,11 +3,12 @@ QUA-Config supporting OPX1000 w/ LF-FEM & External Mixers
 """
 
 from pathlib import Path
+
 import numpy as np
-from scipy.signal.windows import gaussian
+import plotly.io as pio
 from qualang_tools.units import unit
 from qualang_tools.voltage_gates import VoltageGateSequence
-import plotly.io as pio
+from scipy.signal.windows import gaussian
 
 pio.renderers.default = "browser"
 
@@ -79,7 +80,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 24
+time_of_flight = 32
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_mw_fem.py
@@ -66,7 +66,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 32
+time_of_flight = 28
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_mw_fem.py
@@ -3,11 +3,12 @@ QUA-Config supporting OPX1000 w/ LF-FEM & MW-FEM
 """
 
 from pathlib import Path
+
 import numpy as np
-from scipy.signal.windows import gaussian
+import plotly.io as pio
 from qualang_tools.units import unit
 from qualang_tools.voltage_gates import VoltageGateSequence
-import plotly.io as pio
+from scipy.signal.windows import gaussian
 
 pio.renderers.default = "browser"
 
@@ -65,7 +66,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 24
+time_of_flight = 32
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_octave.py
@@ -3,12 +3,13 @@ QUA-Config supporting OPX1000 w/ LF-FEM & Octave
 """
 
 from pathlib import Path
+
 import numpy as np
-from scipy.signal.windows import gaussian
-from qualang_tools.units import unit
-from set_octave import OctaveUnit, octave_declaration
-from qualang_tools.voltage_gates import VoltageGateSequence
 import plotly.io as pio
+from qualang_tools.units import unit
+from qualang_tools.voltage_gates import VoltageGateSequence
+from scipy.signal.windows import gaussian
+from set_octave import OctaveUnit, octave_declaration
 
 pio.renderers.default = "browser"
 
@@ -80,7 +81,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 24
+time_of_flight = 32
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_lf_fem_and_octave.py
@@ -81,7 +81,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 32
+time_of_flight = 28
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_octave.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_octave.py
@@ -1,10 +1,11 @@
 from pathlib import Path
+
 import numpy as np
-from scipy.signal.windows import gaussian
-from qualang_tools.units import unit
-from set_octave import OctaveUnit, octave_declaration
-from qualang_tools.voltage_gates import VoltageGateSequence
 import plotly.io as pio
+from qualang_tools.units import unit
+from qualang_tools.voltage_gates import VoltageGateSequence
+from scipy.signal.windows import gaussian
+from set_octave import OctaveUnit, octave_declaration
 
 pio.renderers.default = "browser"
 
@@ -70,7 +71,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 24
+time_of_flight = 32
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_octave.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Single_Spin_EDSR/configuration_with_octave.py
@@ -71,7 +71,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 32
+time_of_flight = 28
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Singlet_Triplet_Qubit/configuration.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Singlet_Triplet_Qubit/configuration.py
@@ -54,7 +54,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 32
+time_of_flight = 28
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Singlet_Triplet_Qubit/configuration.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Singlet_Triplet_Qubit/configuration.py
@@ -1,7 +1,7 @@
 import numpy as np
+import plotly.io as pio
 from qualang_tools.units import unit
 from qualang_tools.voltage_gates import VoltageGateSequence
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 
@@ -54,7 +54,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 24
+time_of_flight = 32
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Singlet_Triplet_Qubit/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Singlet_Triplet_Qubit/configuration_with_lf_fem.py
@@ -64,7 +64,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 32
+time_of_flight = 28
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Quantum-Dots/Singlet_Triplet_Qubit/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Quantum-Dots/Singlet_Triplet_Qubit/configuration_with_lf_fem.py
@@ -5,9 +5,9 @@ QUA-Config supporting OPX1000 w/ LF-FEM
 from pathlib import Path
 
 import numpy as np
+import plotly.io as pio
 from qualang_tools.units import unit
 from qualang_tools.voltage_gates import VoltageGateSequence
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 
@@ -64,7 +64,7 @@ reflectometry_readout_length = 1 * u.us
 reflectometry_readout_amp = 30 * u.mV
 
 # Time of flight
-time_of_flight = 24
+time_of_flight = 32
 
 ######################
 #      DC GATES      #

--- a/Quantum-Control-Applications/Superconducting/3D-storage-cavity/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/3D-storage-cavity/configuration.py
@@ -3,11 +3,12 @@ Octave configuration working for QOP222 and qm-qua==1.1.5 and newer.
 """
 
 from pathlib import Path
+
 import numpy as np
-from set_octave import OctaveUnit, octave_declaration
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
+from set_octave import OctaveUnit, octave_declaration
 
 pio.renderers.default = "browser"
 #######################
@@ -214,7 +215,7 @@ resonator_off_pump_amp = 0.45
 readout_len = 1000
 readout_amp = 0.05
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/3D-storage-cavity/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/3D-storage-cavity/configuration.py
@@ -215,7 +215,7 @@ resonator_off_pump_amp = 0.45
 readout_len = 1000
 readout_amp = 0.05
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration.py
@@ -3,10 +3,11 @@ QUA-Config supporting OPX+ & External Mixers
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 #######################
@@ -166,7 +167,7 @@ mixer_resonator_phi = 0.0
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration.py
@@ -167,7 +167,7 @@ mixer_resonator_phi = 0.0
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem.py
@@ -3,10 +3,11 @@ QUA-Config supporting OPX1000 w/ LF-FEM & External Mixers
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 #######################
@@ -184,7 +185,7 @@ mixer_resonator_phi = 0.0
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem.py
@@ -185,7 +185,7 @@ mixer_resonator_phi = 0.0
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem_and_octave.py
@@ -184,7 +184,7 @@ resonator_IF = 60 * u.MHz
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_lf_fem_and_octave.py
@@ -3,11 +3,12 @@ QUA-Config supporting OPX1000 w/ LF-FEM & Octave
 """
 
 from pathlib import Path
+
 import numpy as np
-from set_octave import OctaveUnit, octave_declaration
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
+from set_octave import OctaveUnit, octave_declaration
 
 pio.renderers.default = "browser"
 #######################
@@ -183,7 +184,7 @@ resonator_IF = 60 * u.MHz
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_mw_fem.py
@@ -3,10 +3,11 @@ QUA-Config supporting OPX1000 w/ MW-FEM
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 
@@ -154,7 +155,7 @@ resonator_power = 1  # power in dBm at waveform amp = 1 (steps of 3 dB)
 readout_len = 5000
 readout_amp = 0.6
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_mw_fem.py
@@ -155,7 +155,7 @@ resonator_power = 1  # power in dBm at waveform amp = 1 (steps of 3 dB)
 readout_len = 5000
 readout_amp = 0.6
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_octave.py
@@ -165,7 +165,7 @@ resonator_IF = 60 * u.MHz
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Fixed-Transmon/configuration_with_octave.py
@@ -3,12 +3,12 @@ QUA-Config supporting OPX+ & Octave
 """
 
 from pathlib import Path
-import numpy as np
 
-from set_octave import OctaveUnit, octave_declaration
+import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
+from set_octave import OctaveUnit, octave_declaration
 
 pio.renderers.default = "browser"
 #######################
@@ -165,7 +165,7 @@ resonator_IF = 60 * u.MHz
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/Use Case 4 - Paraoanu Lab - Robust qubit control using phase-modulated pulses/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/Use Case 4 - Paraoanu Lab - Robust qubit control using phase-modulated pulses/configuration.py
@@ -1,8 +1,8 @@
 from pathlib import Path
+
 import numpy as np
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-
 
 #######################
 # AUXILIARY FUNCTIONS #
@@ -151,7 +151,7 @@ mixer_resonator_phi = 0.0
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/Use Case 4 - Paraoanu Lab - Robust qubit control using phase-modulated pulses/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/Use Case 4 - Paraoanu Lab - Robust qubit control using phase-modulated pulses/configuration.py
@@ -151,7 +151,7 @@ mixer_resonator_phi = 0.0
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration.py
@@ -1,8 +1,9 @@
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 
@@ -162,7 +163,7 @@ mixer_resonator_phi = 0.0
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration.py
@@ -163,7 +163,7 @@ mixer_resonator_phi = 0.0
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem.py
@@ -188,7 +188,7 @@ mixer_resonator_phi = 0.0
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem.py
@@ -3,10 +3,11 @@ QUA-Config supporting OPX1000 w/ LF-FEM & External Mixers
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 
@@ -187,7 +188,7 @@ mixer_resonator_phi = 0.0
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_mw_fem.py
@@ -3,10 +3,11 @@ QUA-Config supporting OPX1000 w/ LF-FEM + MW-FEM
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 #######################
@@ -154,7 +155,7 @@ resonator_power = 1  # power in dBm at waveform amp = 1
 readout_len = 5000
 readout_amp = 0.6
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_mw_fem.py
@@ -155,7 +155,7 @@ resonator_power = 1  # power in dBm at waveform amp = 1
 readout_len = 5000
 readout_amp = 0.6
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_octave.py
@@ -3,11 +3,12 @@ QUA-Config supporting OPX1000 w/ LF-FEM & Octave
 """
 
 from pathlib import Path
+
 import numpy as np
-from set_octave import OctaveUnit, octave_declaration
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
+from set_octave import OctaveUnit, octave_declaration
 
 pio.renderers.default = "browser"
 #######################
@@ -182,7 +183,7 @@ resonator_IF = 60 * u.MHz
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_lf_fem_and_octave.py
@@ -183,7 +183,7 @@ resonator_IF = 60 * u.MHz
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_octave.py
@@ -3,11 +3,12 @@ Octave configuration working for QOP222 and qm-qua==1.1.5 and newer.
 """
 
 from pathlib import Path
+
 import numpy as np
-from set_octave import OctaveUnit, octave_declaration
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
+from set_octave import OctaveUnit, octave_declaration
 
 pio.renderers.default = "browser"
 
@@ -163,7 +164,7 @@ resonator_IF = 60 * u.MHz
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 24
+time_of_flight = 32
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Single-Flux-Tunable-Transmon/configuration_with_octave.py
@@ -164,7 +164,7 @@ resonator_IF = 60 * u.MHz
 readout_len = 5000
 readout_amp = 0.2
 
-time_of_flight = 32
+time_of_flight = 28
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/Use Case 1 - Two qubit RB with cross-resonance gates/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/Use Case 1 - Two qubit RB with cross-resonance gates/configuration.py
@@ -4,11 +4,10 @@ Octave configuration working for QOP222 and qm-qua==1.1.5 and newer.
 """
 
 from pathlib import Path
-import numpy as np
-from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
-from qualang_tools.config.waveform_tools import flattop_blackman_waveform
-from qualang_tools.units import unit
 
+import numpy as np
+from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms, flattop_blackman_waveform
+from qualang_tools.units import unit
 
 #######################
 # AUXILIARY FUNCTIONS #
@@ -310,7 +309,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 # Mixer parameters

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/Use Case 1 - Two qubit RB with cross-resonance gates/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/Use Case 1 - Two qubit RB with cross-resonance gates/configuration.py
@@ -309,7 +309,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 # Mixer parameters

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration.py
@@ -4,10 +4,11 @@ Octave configuration working for QOP222 and qm-qua==1.1.5 and newer.
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 
@@ -254,7 +255,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 # Mixer parameters

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration.py
@@ -255,7 +255,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 # Mixer parameters

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_lf_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_lf_fem.py
@@ -3,10 +3,11 @@ Octave configuration working for QOP222 and qm-qua==1.1.5 and newer.
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 
@@ -261,7 +262,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 # Mixer parameters

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_lf_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_lf_fem.py
@@ -262,7 +262,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 # Mixer parameters

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_lf_fem_and_octave.py
@@ -3,11 +3,12 @@ Octave configuration working for QOP222 and qm-qua==1.1.5 and newer.
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
 from set_octave import OctaveUnit, octave_declaration
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 
@@ -275,7 +276,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 # Mixer parameters

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_lf_fem_and_octave.py
@@ -276,7 +276,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 # Mixer parameters

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_mw_fem.py
@@ -252,7 +252,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_mw_fem.py
@@ -4,10 +4,11 @@ Octave configuration working for QOP222 and qm-qua==1.1.5 and newer.
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 
@@ -251,7 +252,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_with_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_with_octave.py
@@ -4,11 +4,12 @@ Octave configuration working for QOP222 and qm-qua==1.1.5 and newer.
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
 from set_octave import OctaveUnit, octave_declaration
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 #######################
@@ -273,7 +274,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 # Mixer parameters

--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_with_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/configuration_with_octave.py
@@ -274,7 +274,7 @@ readout_amp_q1 = 0.1
 readout_amp_q2 = 0.1
 
 # TOF and depletion time
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 # Mixer parameters

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration.py
@@ -208,7 +208,7 @@ readout_amp_q1 = 0.125
 readout_amp_q2 = 0.125
 
 # TOF and depletion time
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration.py
@@ -1,8 +1,9 @@
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 #######################
@@ -207,7 +208,7 @@ readout_amp_q1 = 0.125
 readout_amp_q2 = 0.125
 
 # TOF and depletion time
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem.py
@@ -288,7 +288,7 @@ readout_amp_q1 = 0.125
 readout_amp_q2 = 0.125
 
 # TOF and depletion time
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem.py
@@ -3,10 +3,11 @@ QUA-Config supporting OPX1000 w/ LF-FEM & External Mixers
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 
@@ -287,7 +288,7 @@ readout_amp_q1 = 0.125
 readout_amp_q2 = 0.125
 
 # TOF and depletion time
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem_and_mw_fem.py
@@ -265,7 +265,7 @@ readout_amp_q1 = 0.35
 readout_amp_q2 = 0.35
 
 # TOF and depletion time
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem_and_mw_fem.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem_and_mw_fem.py
@@ -3,10 +3,11 @@ QUA-Config supporting OPX1000 w/ LF-FEM + MW-FEM
 """
 
 from pathlib import Path
+
 import numpy as np
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
 
 pio.renderers.default = "browser"
 
@@ -264,7 +265,7 @@ readout_amp_q1 = 0.35
 readout_amp_q2 = 0.35
 
 # TOF and depletion time
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem_and_octave.py
@@ -289,7 +289,7 @@ readout_amp_q1 = 0.07
 readout_amp_q2 = 0.07
 
 # TOF and depletion time
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem_and_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_lf_fem_and_octave.py
@@ -3,11 +3,12 @@ QUA-Config supporting OPX1000 w/ LF-FEM & Octave
 """
 
 from pathlib import Path
+
 import numpy as np
-from set_octave import OctaveUnit, octave_declaration
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
+from set_octave import OctaveUnit, octave_declaration
 
 pio.renderers.default = "browser"
 
@@ -288,7 +289,7 @@ readout_amp_q1 = 0.07
 readout_amp_q2 = 0.07
 
 # TOF and depletion time
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_octave.py
@@ -214,7 +214,7 @@ readout_amp_q1 = 0.07
 readout_amp_q2 = 0.07
 
 # TOF and depletion time
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_octave.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Standard Configuration/configuration_with_octave.py
@@ -3,11 +3,12 @@ Octave configuration working for QOP222 and qm-qua==1.1.5 and newer.
 """
 
 from pathlib import Path
+
 import numpy as np
-from set_octave import OctaveUnit, octave_declaration
+import plotly.io as pio
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-import plotly.io as pio
+from set_octave import OctaveUnit, octave_declaration
 
 pio.renderers.default = "browser"
 
@@ -213,7 +214,7 @@ readout_amp_q1 = 0.07
 readout_amp_q2 = 0.07
 
 # TOF and depletion time
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 depletion_time = 2 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 2 - Two-Qubit-Randomized-Benchmarking/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 2 - Two-Qubit-Randomized-Benchmarking/configuration.py
@@ -1,8 +1,8 @@
 from pathlib import Path
+
 import numpy as np
-from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
+from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms, flattop_gaussian_waveform
 from qualang_tools.units import unit
-from qualang_tools.config.waveform_tools import flattop_gaussian_waveform
 
 #######################
 # AUXILIARY FUNCTIONS #
@@ -169,7 +169,7 @@ readout_len = 4000
 readout_amp_q1 = 0.07
 readout_amp_q2 = 0.07
 
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 
 # state discrimination
 rotation_angle_q1 = (0.0 / 180) * np.pi

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 2 - Two-Qubit-Randomized-Benchmarking/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 2 - Two-Qubit-Randomized-Benchmarking/configuration.py
@@ -169,7 +169,7 @@ readout_len = 4000
 readout_amp_q1 = 0.07
 readout_amp_q2 = 0.07
 
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 
 # state discrimination
 rotation_angle_q1 = (0.0 / 180) * np.pi

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 2 - Two-Qubit-Randomized-Benchmarking/two_qubit_rb/test/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 2 - Two-Qubit-Randomized-Benchmarking/two_qubit_rb/test/configuration.py
@@ -1,8 +1,8 @@
 from pathlib import Path
+
 import numpy as np
-from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
+from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms, flattop_gaussian_waveform
 from qualang_tools.units import unit
-from qualang_tools.config.waveform_tools import flattop_gaussian_waveform
 
 #######################
 # AUXILIARY FUNCTIONS #
@@ -169,7 +169,7 @@ readout_len = 4000
 readout_amp_q1 = 0.07
 readout_amp_q2 = 0.07
 
-time_of_flight = 24  # must be a multiple of 4
+time_of_flight = 32  # must be a multiple of 4
 
 # state discrimination
 rotation_angle_q1 = (0.0 / 180) * np.pi

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 2 - Two-Qubit-Randomized-Benchmarking/two_qubit_rb/test/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 2 - Two-Qubit-Randomized-Benchmarking/two_qubit_rb/test/configuration.py
@@ -169,7 +169,7 @@ readout_len = 4000
 readout_amp_q1 = 0.07
 readout_amp_q2 = 0.07
 
-time_of_flight = 32  # must be a multiple of 4
+time_of_flight = 28  # must be a multiple of 4
 
 # state discrimination
 rotation_angle_q1 = (0.0 / 180) * np.pi

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 4 - Single- and Two-Qubit State and Process Tomography/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 4 - Single- and Two-Qubit State and Process Tomography/configuration.py
@@ -3,11 +3,11 @@ Octave configuration working for QOP222 and qm-qua==1.1.5 and newer.
 """
 
 from pathlib import Path
+
 import numpy as np
-from set_octave import OctaveUnit, octave_declaration
 from qualang_tools.config.waveform_tools import drag_gaussian_pulse_waveforms
 from qualang_tools.units import unit
-
+from set_octave import OctaveUnit, octave_declaration
 
 #######################
 # AUXILIARY FUNCTIONS #
@@ -226,7 +226,7 @@ readout_amp_q1 = 0.01
 readout_amp_q2 = 0.01
 
 # TOF and depletion time
-time_of_flight = 240  # must be a multiple of 4
+time_of_flight = 320  # must be a multiple of 4
 depletion_time = 50 * u.us
 
 opt_weights = False

--- a/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 4 - Single- and Two-Qubit State and Process Tomography/configuration.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Flux-Tunable-Coupled-Transmons/Use Case 4 - Single- and Two-Qubit State and Process Tomography/configuration.py
@@ -226,7 +226,7 @@ readout_amp_q1 = 0.01
 readout_amp_q2 = 0.01
 
 # TOF and depletion time
-time_of_flight = 320  # must be a multiple of 4
+time_of_flight = 240  # must be a multiple of 4
 depletion_time = 50 * u.us
 
 opt_weights = False


### PR DESCRIPTION
I did it in 2 commits, one for opx1000 and one for opx+.

Should we fix it to 32ns for both or keep the opx+ configs to 24ns? 