### PR TITLE
Add pip and uv configuration for prerelease in pyproject.toml

### DIFF
--- a/qualibration_graphs/superconducting/pyproject.toml
+++ b/qualibration_graphs/superconducting/pyproject.toml
@@ -45,3 +45,10 @@ allow-direct-references = true
 # [tool.uv.sources]
 # quam-builder = { git = "https://github.com/qua-platform/quam-builder.git" }
 # qualibration-libs = { git = "https://github.com/qua-platform/qualibration-libs.git" }
+
+
+[tool.uv.pip]
+prerelease = "allow"
+
+[tool.uv]
+prerelease = "allow"


### PR DESCRIPTION
Automatically approve prerelease when using `uv`, e.g. `uv pip install .` or `uv sync`