### PR TITLE
fixed signs in <X>

### DIFF
--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/cr_hamiltonian_tomography.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/cr_hamiltonian_tomography.py
@@ -57,7 +57,7 @@ class CRHamiltonianTomographyFunctions:
         """
         m2 = self._compute_omega_squared(d, mx, my)
         m = np.sqrt(m2)
-        return (-d * mx + d * mx * np.cos(m * ts) + m * my * np.sin(m * ts)) / m2
+        return (+d * mx - d * mx * np.cos(m * ts) + m * my * np.sin(m * ts)) / m2
 
     def _compute_Y(self, ts, d, mx, my):
         """


### PR DESCRIPTION
Fix signs in <X>.

before: [cr_hamiltonian_tomography.py#L60](https://github.com/qua-platform/qua-libs/blob/main/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/cr_hamiltonian_tomography.py#L60)
```
(-d * mx + d * mx * np.cos(m * ts) + m * my * np.sin(m * ts)) / m2
```

after: 
```
(+d * mx - d * mx * np.cos(m * ts) + m * my * np.sin(m * ts)) / m2
```

This can be verified in the section `Rotation matrix from axis and angle` in https://en.wikipedia.org/wiki/Rotation_matrix

The (0, 2) component corresponds to the expression above. 
```
ux uz (1-cos(theta)) + uy sin(theta)
= +uz * ux - uz * ux * cos(theta) + uy * sin(theta) 
```
by mapping `ux -> mx/m`, `uy -> my/m`, `uz -> d/m`.