### PR TITLE
Fix: Data fetcher retrieving 'n' failure

### DIFF
--- a/qualibration_graphs/superconducting/calibrations/00_hello_qua.py
+++ b/qualibration_graphs/superconducting/calibrations/00_hello_qua.py
@@ -114,7 +114,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/01a_time_of_flight.py
+++ b/qualibration_graphs/superconducting/calibrations/01a_time_of_flight.py
@@ -156,7 +156,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/01b_time_of_flight_mw_fem.py
+++ b/qualibration_graphs/superconducting/calibrations/01b_time_of_flight_mw_fem.py
@@ -156,7 +156,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/02a_resonator_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/02a_resonator_spectroscopy.py
@@ -149,7 +149,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/02b_resonator_spectroscopy_vs_power.py
+++ b/qualibration_graphs/superconducting/calibrations/02b_resonator_spectroscopy_vs_power.py
@@ -181,7 +181,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/02c_resonator_spectroscopy_vs_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/02c_resonator_spectroscopy_vs_flux.py
@@ -175,7 +175,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/03a_qubit_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/03a_qubit_spectroscopy.py
@@ -174,7 +174,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/03b_qubit_spectroscopy_vs_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/03b_qubit_spectroscopy_vs_flux.py
@@ -189,7 +189,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/04a_rabi_chevron.py
+++ b/qualibration_graphs/superconducting/calibrations/04a_rabi_chevron.py
@@ -184,7 +184,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/04b_power_rabi.py
+++ b/qualibration_graphs/superconducting/calibrations/04b_power_rabi.py
@@ -193,7 +193,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/05_T1.py
+++ b/qualibration_graphs/superconducting/calibrations/05_T1.py
@@ -161,7 +161,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/06a_ramsey.py
+++ b/qualibration_graphs/superconducting/calibrations/06a_ramsey.py
@@ -180,7 +180,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/06b_echo.py
+++ b/qualibration_graphs/superconducting/calibrations/06b_echo.py
@@ -164,7 +164,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/07_iq_blobs.py
+++ b/qualibration_graphs/superconducting/calibrations/07_iq_blobs.py
@@ -178,7 +178,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/08a_readout_frequency_optimization.py
+++ b/qualibration_graphs/superconducting/calibrations/08a_readout_frequency_optimization.py
@@ -175,7 +175,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/08b_readout_power_optimization.py
+++ b/qualibration_graphs/superconducting/calibrations/08b_readout_power_optimization.py
@@ -163,7 +163,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/09_ramsey_vs_flux_calibration.py
+++ b/qualibration_graphs/superconducting/calibrations/09_ramsey_vs_flux_calibration.py
@@ -186,7 +186,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/10b_drag_calibration_180_minus_180.py
+++ b/qualibration_graphs/superconducting/calibrations/10b_drag_calibration_180_minus_180.py
@@ -206,7 +206,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/11a_single_qubit_randomized_benchmarking.py
+++ b/qualibration_graphs/superconducting/calibrations/11a_single_qubit_randomized_benchmarking.py
@@ -308,7 +308,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_random_sequences,
                 start_time=data_fetcher.t_start,
             )

--- a/qualibration_graphs/superconducting/calibrations/11b_single_qubit_randomized_benchmarking_interleaved.py
+++ b/qualibration_graphs/superconducting/calibrations/11b_single_qubit_randomized_benchmarking_interleaved.py
@@ -318,7 +318,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_random_sequences,
                 start_time=data_fetcher.t_start,
             )


### PR DESCRIPTION
As noted by @pauljamet, if the data fetcher tries to get variable `n` before the program has reached one iteration, an error is thrown. This PR is supposed to fix this by providing a default value if unable to retrieve.

Haven't been able to test this, can someone else try it out?