### PR TITLE
Fix qualibrate pyproject readme

### DIFF
--- a/qualibration_graphs/nv_center/pyproject.toml
+++ b/qualibration_graphs/nv_center/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nv-calibrations"
 version = "0.1.0"
 description = "QM NV Calibration Graphs"
-readme = "README.md"
+readme = "../README.md"
 license = { text = "BSD-3-Clause" }
 requires-python = ">=3.9,<3.13"
 classifiers = [

--- a/qualibration_graphs/superconducting/pyproject.toml
+++ b/qualibration_graphs/superconducting/pyproject.toml
@@ -2,7 +2,7 @@
 name = "superconducting-calibrations"
 version = "0.1.0"
 description = "QM Superconducting Calibration Graphs"
-readme = "README.md"
+readme = "../README.md"
 license = { text = "BSD-3-Clause" }
 requires-python = ">=3.9,<3.13"
 classifiers = [


### PR DESCRIPTION
With PR #357 we have moved the `README.md` for the qualibrate documentation one level higher from `qualibration_graphs/superconducting` directory to directly `qualibration_graphs`. This has not been accounted for in the `pyproject.toml` files for both the superconducting and NV center structure. Installing the projects in these subdirectories will fail because the readme file is not found. 

A simple solution is to indicate the correct location of the readme file, one level above. We can argue whether this is good practice or each sub-project should have their own readme. 