### PR TITLE
moved 2 assign statments into depth for loop after averaging loop

### DIFF
--- a/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/Use Case 1 - Two qubit RB with cross-resonance gates/run_two_qubit_rb_CR_CNOT.py
+++ b/Quantum-Control-Applications/Superconducting/Two-Fixed-Coupled-Transmons/Use Case 1 - Two qubit RB with cross-resonance gates/run_two_qubit_rb_CR_CNOT.py
@@ -287,11 +287,11 @@ with program() as rb:
                 save(state1, state1_st)
                 assign(state2, I[1] > ge_threshold_q2)
                 save(state2, state2_st)
-
-                assign(start, start + len_list_qua[run])
-                assign(run, run + 1)
-                # Go to the next depth
                 align()
+
+            assign(start, start + len_list_qua[run])
+            assign(run, run + 1)
+            # Go to the next depth
         save(m, m_st)
 
     with stream_processing():


### PR DESCRIPTION
The bug: These two lines are inside the n (averaging) loop but should be inside the depth loop:

assign(start, start + len_list_qua[run])
assign(run, run + 1)They advance the sequence pointer on every averaging shot instead of once per (sequence, depth) pair. This means each averaging shot plays a different circuit, and run quickly exceeds the len_list array bounds, producing bad data.

The fix: Move those two assign statements out of the for_(n, ...) loop into the for_(depth, ...) loop, and save/restore start so the same sequence replays for all averaging shots:

with for_(depth, 0, depth < len(depth_list), depth + 1):
    assign(saved_start, start)  # new variable, declared at program level
    with for_(n, 0, n < n_avg_, n + 1):
        ...
        play_sequence(sequence_qua, saved_start, len_list_qua[run])
        ...
    assign(start, start + len_list_qua[run])
    assign(run, run + 1)