### PR TITLE
Resonator frequency vs coupler flux calibration 

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/pair_grid.py
+++ b/qualibration_graphs/superconducting/calibration_utils/pair_grid.py
@@ -31,10 +31,7 @@ def grid_pair_names(qubit_pairs) -> Tuple[List[str], List[str]]:
         One entry per pair, the pair's ``.name`` attribute.
     """
     return (
-        [
-            f"{qp.qubit_control.grid_location}-{qp.qubit_target.grid_location}"
-            for qp in qubit_pairs
-        ],
+        [f"{qp.qubit_control.grid_location}-{qp.qubit_target.grid_location}" for qp in qubit_pairs],
         [qp.name for qp in qubit_pairs],
     )
 
@@ -68,9 +65,7 @@ class QubitPairGrid:
     def _list_clean(self, list_input_string):
         return [self._clean_up(s) for s in list_input_string]
 
-    def __init__(
-        self, grid_names: list[str], qubit_pair_names: list[str], size: int = 4
-    ):
+    def __init__(self, grid_names: list[str], qubit_pair_names: list[str], size: int = 4):
         qubit_indices = [
             (
                 tuple(map(int, self._list_clean(gp.split("-")[0].split(",")))),
@@ -99,9 +94,7 @@ class QubitPairGrid:
             max(grid_col_idxs) - min_grid_col + 1,
         )
 
-        figure, all_axes = plt.subplots(
-            *shape, figsize=(shape[1] * size, shape[0] * size), squeeze=False
-        )
+        figure, all_axes = plt.subplots(*shape, figsize=(shape[1] * size, shape[0] * size), squeeze=False)
 
         axes_grid = all_axes.reshape(shape)
 

--- a/qualibration_graphs/superconducting/calibration_utils/pair_grid.py
+++ b/qualibration_graphs/superconducting/calibration_utils/pair_grid.py
@@ -1,0 +1,125 @@
+"""Shared grid utilities for qubit-pair (coupler) calibration plots.
+
+Ported from flagship_qua/quam_libs/lib/plot_utils.py.  Provides
+``QubitPairGrid`` which auto-computes a chip-topology subplot layout
+from qubit grid locations, and ``grid_pair_names`` which extracts the
+required metadata from qubit-pair objects.
+
+Iteration over the resulting grid is done with the existing
+``grid_iter`` from ``qualibration_libs.plotting``.
+"""
+
+import re
+from typing import List, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def grid_pair_names(qubit_pairs) -> Tuple[List[str], List[str]]:
+    """Return grid-location strings and pair names for a list of qubit pairs.
+
+    Each grid-location string has the form
+    ``"<control_grid_location>-<target_grid_location>"``
+    (e.g. ``"0,0-1,0"``).
+
+    Returns
+    -------
+    grid_names : list[str]
+        One entry per pair, encoding both qubits' grid locations.
+    qubit_pair_names : list[str]
+        One entry per pair, the pair's ``.name`` attribute.
+    """
+    return (
+        [
+            f"{qp.qubit_control.grid_location}-{qp.qubit_target.grid_location}"
+            for qp in qubit_pairs
+        ],
+        [qp.name for qp in qubit_pairs],
+    )
+
+
+class QubitPairGrid:
+    """Subplot grid that places coupler pairs at their physical chip positions.
+
+    The layout is computed automatically: qubits sit on a doubled integer
+    grid (even indices) and couplers sit between them (odd indices for
+    nearest-neighbour pairs).  This produces the familiar staggered layout
+    without any hardcoded position mapping.
+
+    The resulting object exposes ``.fig``, ``.axes``, and ``.name_dicts``
+    with the same structure as ``qualibration_libs.plotting.QubitGrid``,
+    so it works with the existing ``grid_iter`` helper.
+
+    Parameters
+    ----------
+    grid_names : list[str]
+        Grid-location strings as returned by ``grid_pair_names``.
+    qubit_pair_names : list[str]
+        Pair name strings (used as ``qubit`` coordinate labels).
+    size : int
+        Size of each subplot in inches.
+    """
+
+    @staticmethod
+    def _clean_up(input_string: str) -> str:
+        return re.sub("[^0-9]", "", input_string)
+
+    def _list_clean(self, list_input_string):
+        return [self._clean_up(s) for s in list_input_string]
+
+    def __init__(
+        self, grid_names: list[str], qubit_pair_names: list[str], size: int = 4
+    ):
+        qubit_indices = [
+            (
+                tuple(map(int, self._list_clean(gp.split("-")[0].split(",")))),
+                tuple(map(int, self._list_clean(gp.split("-")[1].split(",")))),
+            )
+            for gp in grid_names
+        ]
+
+        row_diffs = [pair[1][0] - pair[0][0] for pair in qubit_indices]
+        col_diffs = [pair[1][1] - pair[0][1] for pair in qubit_indices]
+
+        # Place each coupler on a doubled grid so that qubits occupy even
+        # positions and couplers fall in between.
+        coupler_indices = [[2 * pair[0][1], 2 * pair[0][0]] for pair in qubit_indices]
+        for k, (col_diff, row_diff) in enumerate(zip(col_diffs, row_diffs)):
+            coupler_indices[k][0] += col_diff
+            coupler_indices[k][1] += row_diff
+        coupler_indices = [tuple(c) for c in coupler_indices]
+
+        grid_row_idxs = [idx[0] for idx in coupler_indices]
+        grid_col_idxs = [idx[1] for idx in coupler_indices]
+        min_grid_row = min(grid_row_idxs)
+        min_grid_col = min(grid_col_idxs)
+        shape = (
+            max(grid_row_idxs) - min_grid_row + 1,
+            max(grid_col_idxs) - min_grid_col + 1,
+        )
+
+        figure, all_axes = plt.subplots(
+            *shape, figsize=(shape[1] * size, shape[0] * size), squeeze=False
+        )
+
+        axes_grid = all_axes.reshape(shape)
+
+        axes = []
+        qubit_names = []
+
+        for row, axis_row in enumerate(axes_grid):
+            for col, ax in enumerate(axis_row):
+                grid_row = row + min_grid_row
+                grid_col = col + min_grid_col
+                if (grid_row, grid_col) in coupler_indices:
+                    axes.append(ax)
+                    index = coupler_indices.index((grid_row, grid_col))
+                    qubit_names.append(qubit_pair_names[index])
+                else:
+                    ax.axis("off")
+
+        self.fig = figure
+        self.all_axes = all_axes
+        self.axes = [axes]
+        self.name_dicts = [[{"qubit": name} for name in qubit_names]]

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/__init__.py
@@ -1,0 +1,13 @@
+"""Resonator spectroscopy versus coupler flux calibration utilities."""
+
+from .analysis import process_raw_dataset, fit_raw_data, log_fitted_results
+from .plotting import plot_raw_data_with_fit
+from .parameters import Parameters
+
+__all__ = [
+    "Parameters",
+    "process_raw_dataset",
+    "fit_raw_data",
+    "log_fitted_results",
+    "plot_raw_data_with_fit",
+]

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/analysis.py
@@ -36,9 +36,7 @@ def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode) -> xr.Dataset:
     # Add the amplitude and phase to the raw dataset
     ds = add_amplitude_and_phase(ds, "detuning", subtract_slope_flag=True)
     # Add the RF frequency as a per-(qubit, detuning) coordinate.
-    full_freq = np.array(
-        [ds.detuning.values + q.resonator.RF_frequency for q in measured_qubits]
-    )
+    full_freq = np.array([ds.detuning.values + q.resonator.RF_frequency for q in measured_qubits])
     ds = ds.assign_coords(full_freq=(["qubit", "detuning"], full_freq))
     ds.full_freq.attrs = {"long_name": "RF frequency", "units": "Hz"}
     # Add the coupler current axis as a per-flux_bias coordinate.
@@ -48,9 +46,7 @@ def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode) -> xr.Dataset:
     # Add attenuated current to dataset
     attenuation_factor = 10 ** (-node.parameters.line_attenuation_in_db / 20)
     attenuated_current = ds.current * attenuation_factor
-    ds = ds.assign_coords(
-        {"attenuated_current": (["flux_bias"], attenuated_current.values)}
-    )
+    ds = ds.assign_coords({"attenuated_current": (["flux_bias"], attenuated_current.values)})
     ds.attenuated_current.attrs = {"long_name": "Attenuated Current", "units": "A"}
 
     return ds

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/analysis.py
@@ -1,0 +1,56 @@
+"""Analysis functions for resonator spectroscopy versus coupler flux calibration."""
+
+import numpy as np
+import xarray as xr
+from qualibrate import QualibrationNode
+from qualibration_libs.data import add_amplitude_and_phase
+
+from calibration_utils.resonator_spectroscopy_vs_flux.analysis import (
+    fit_raw_data,
+    log_fitted_results,
+)
+
+__all__ = ["process_raw_dataset", "fit_raw_data", "log_fitted_results"]
+
+
+def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode) -> xr.Dataset:
+    """Process the raw dataset for coupler flux spectroscopy.
+
+    Identical in purpose to the qubit-flux version, but the IQ→V conversion
+    is indexed by qubit-pair (coupler) names rather than measured-qubit names.
+    This avoids a duplicate-index error when two different qubit pairs share
+    the same measured qubit.
+    """
+    qubit_pairs = node.namespace["qubit_pairs"]
+    measured_qubits = node.namespace["measured_qubits"]
+
+    # Build readout lengths keyed by the coupler name so the coordinate
+    # matches the 'qubit' dimension already in ds (which uses coupler names).
+    readout_lengths = xr.DataArray(
+        [q.resonator.operations["readout"].length for q in measured_qubits],
+        coords=[("qubit", [qp.name for qp in qubit_pairs])],
+    )
+    # Convert I and Q from demodulation units to Volts (same formula as
+    # convert_IQ_to_V with single_demod=False).
+    ds = ds.assign({key: ds[key] * 2**12 / readout_lengths for key in ("I", "Q")})
+    # Add the amplitude and phase to the raw dataset
+    ds = add_amplitude_and_phase(ds, "detuning", subtract_slope_flag=True)
+    # Add the RF frequency as a per-(qubit, detuning) coordinate.
+    full_freq = np.array(
+        [ds.detuning.values + q.resonator.RF_frequency for q in measured_qubits]
+    )
+    ds = ds.assign_coords(full_freq=(["qubit", "detuning"], full_freq))
+    ds.full_freq.attrs = {"long_name": "RF frequency", "units": "Hz"}
+    # Add the coupler current axis as a per-flux_bias coordinate.
+    current = ds.flux_bias / node.parameters.input_line_impedance_in_ohm
+    ds = ds.assign_coords({"current": (["flux_bias"], current.data)})
+    ds.current.attrs = {"long_name": "Current", "units": "A"}
+    # Add attenuated current to dataset
+    attenuation_factor = 10 ** (-node.parameters.line_attenuation_in_db / 20)
+    attenuated_current = ds.current * attenuation_factor
+    ds = ds.assign_coords(
+        {"attenuated_current": (["flux_bias"], attenuated_current.values)}
+    )
+    ds.attenuated_current.attrs = {"long_name": "Attenuated Current", "units": "A"}
+
+    return ds

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/parameters.py
@@ -26,8 +26,6 @@ class NodeSpecificParameters(RunnableParameters):
     """Input line impedance in ohms. Default is 50 Ohm."""
     line_attenuation_in_db: float = 0
     """Line attenuation in dB. Default is 0 dB."""
-    update_flux_min: bool = False
-    """Flag to update flux minimum frequency point. Default is False."""
     settle_time_in_ns: int = 20000
     """Settle time in ns. Default is 20000 ns."""
     measure_qubit: Literal["control", "target"] = "target"

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/parameters.py
@@ -1,0 +1,45 @@
+"""Parameter definitions for resonator spectroscopy versus coupler flux calibration."""
+
+from typing import ClassVar, Literal, Optional
+
+from qualibrate import NodeParameters
+from qualibrate.core.parameters import RunnableParameters
+from qualibration_libs.parameters import CommonNodeParameters, QubitPairExperimentNodeParameters
+
+
+class NodeSpecificParameters(RunnableParameters):
+    """Node-specific parameters for resonator spectroscopy versus coupler flux."""
+
+    num_shots: int = 100
+    """Number of averages to perform. Default is 100."""
+    min_flux_offset_in_v: float = -0.5
+    """Minimum flux bias offset in volts. Default is -0.5 V."""
+    max_flux_offset_in_v: float = 0.5
+    """Maximum flux bias offset in volts. Default is 0.5 V."""
+    num_flux_points: int = 101
+    """Number of flux points. Default is 101."""
+    frequency_span_in_mhz: float = 15
+    """Frequency span in MHz. Default is 15 MHz."""
+    frequency_step_in_mhz: float = 0.1
+    """Frequency step in MHz. Default is 0.1 MHz."""
+    input_line_impedance_in_ohm: float = 50
+    """Input line impedance in ohms. Default is 50 Ohm."""
+    line_attenuation_in_db: float = 0
+    """Line attenuation in dB. Default is 0 dB."""
+    update_flux_min: bool = False
+    """Flag to update flux minimum frequency point. Default is False."""
+    settle_time_in_ns: int = 20000
+    """Settle time in ns. Default is 20000 ns."""
+    measure_qubit: Literal["control", "target"] = "target"
+    """Which qubit to measure: 'control' or 'target'. Default is 'target'."""
+
+
+class Parameters(
+    NodeParameters,
+    CommonNodeParameters,
+    NodeSpecificParameters,
+    QubitPairExperimentNodeParameters,
+):
+    """Combined parameters for resonator spectroscopy versus coupler flux calibration."""
+
+    targets_name: ClassVar[str] = "qubit_pairs"

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy_vs_coupler_flux/plotting.py
@@ -1,0 +1,119 @@
+"""Plotting functions for resonator spectroscopy versus coupler flux calibration."""
+
+from typing import List
+
+import xarray as xr
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+from qualibration_libs.plotting import grid_iter
+from calibration_utils.pair_grid import QubitPairGrid, grid_pair_names
+from quam_builder.architecture.superconducting.qubit import AnyTransmon
+from quam_builder.architecture.superconducting.qubit_pair import AnyTransmonPair
+
+
+def plot_raw_data_with_fit(
+    ds: xr.Dataset,
+    qubit_pairs: List[AnyTransmonPair],
+    measured_qubits: List[AnyTransmon],
+    fits: xr.Dataset = None,
+) -> Figure:
+    """Plot raw data with fitted curves for all qubit pairs.
+
+    Subplots are arranged using ``QubitPairGrid``, which positions each
+    coupler between its two qubits on a doubled integer grid.  This reflects
+    the physical chip topology and leaves intentional gaps where the
+    intermediate qubits would sit.
+
+    The title of each subplot shows both the measured qubit and the coupler
+    name so that duplicate measured-qubit situations are unambiguous.
+
+    Parameters
+    ----------
+    ds:
+        Raw dataset whose ``qubit`` coordinate contains coupler names.
+    qubit_pairs:
+        Ordered list of qubit-pair objects (same order as ``ds.qubit``).
+    measured_qubits:
+        Ordered list of the qubit being measured in each pair.
+    fits:
+        Fit dataset whose ``qubit`` coordinate also contains coupler names.
+        If ``None``, only the raw data is plotted.
+    """
+    measured_by_coupler = {qp.name: q for qp, q in zip(qubit_pairs, measured_qubits)}
+
+    grid_names, pair_names = grid_pair_names(qubit_pairs)
+    grid = QubitPairGrid(grid_names, pair_names, size=6)
+
+    for ax, qubit in grid_iter(grid):
+        coupler_name = qubit["qubit"]
+        q = measured_by_coupler[coupler_name]
+        fit_q = fits.sel(qubit=coupler_name) if fits is not None else None
+        plot_individual_raw_data_with_fit(ax, ds.sel(qubit=coupler_name), fit_q)
+        ax.set_title(f"Measured qubit: {q.name}\nCoupler: {coupler_name}")
+
+    grid.fig.suptitle("Resonator spectroscopy vs coupler flux")
+    grid.fig.tight_layout()
+    return grid.fig
+
+
+def plot_individual_raw_data_with_fit(ax: Axes, ds_q: xr.Dataset, fit_q: xr.Dataset = None) -> None:
+    """Plot data for a individual coupler qubit on a given axis with optional fit.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The axis on which to plot the data.
+    ds_q : xr.Dataset
+        Dataset already selected for one coupler.
+    fit_q : xr.Dataset
+        Fit dataset already selected for the same coupler.
+    """
+    ax2 = ax.twiny()
+
+    ds_q.assign_coords(freq_GHz=ds_q.full_freq / 1e9).IQ_abs.plot(
+        ax=ax2,
+        add_colorbar=False,
+        x="attenuated_current",
+        y="freq_GHz",
+        robust=True,
+    )
+    ax2.set_xlabel("Current (A)")
+    ax2.set_ylabel("Freq (GHz)")
+    ax2.set_title("")
+    ax2.set_zorder(ax.get_zorder() - 1)
+    ax.patch.set_visible(False)
+
+    ds_q.assign_coords(freq_GHz=ds_q.full_freq / 1e9).IQ_abs.plot(
+        ax=ax,
+        add_colorbar=False,
+        x="flux_bias",
+        y="freq_GHz",
+        robust=True,
+    )
+
+    if fit_q is not None and fit_q.fit_results.success.values:
+        ax.axvline(
+            fit_q.fit_results.idle_offset,
+            linestyle="dashed",
+            linewidth=2,
+            color="r",
+            label="idle offset",
+        )
+        ax.axvline(
+            fit_q.fit_results.flux_min,
+            linestyle="dashed",
+            linewidth=2,
+            color="orange",
+            label="min offset",
+        )
+        ax.plot(
+            fit_q.fit_results.idle_offset.values,
+            fit_q.fit_results.sweet_spot_frequency.values * 1e-9,
+            "r*",
+            markersize=10,
+        )
+        ax.legend(fontsize=8)
+
+    ax.set_xlabel("Coupler flux (V)")
+    ax.set_ylabel("Freq (GHz)")

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
@@ -1,0 +1,310 @@
+"""Resonator spectroscopy versus coupler flux calibration."""
+
+# %% {Imports}
+from dataclasses import asdict
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from calibration_utils.resonator_spectroscopy_vs_coupler_flux import (
+    Parameters,
+    process_raw_dataset,
+    fit_raw_data,
+    log_fitted_results,
+    plot_raw_data_with_fit,
+)
+from qm.qua import *
+from qualang_tools.loops import from_array
+from qualang_tools.multi_user import qm_session
+from qualang_tools.results import progress_counter
+from qualang_tools.units import unit
+from qualibrate import QualibrationNode
+from qualibration_libs.data import XarrayDataFetcher
+from qualibration_libs.parameters import get_qubit_pairs
+from qualibration_libs.runtime import simulate_and_plot
+from quam_config import Quam
+# %% {Node initialisation}
+description = """
+        RESONATOR SPECTROSCOPY VERSUS COUPLER FLUX
+This sequence involves measuring the resonator by sending a readout pulse and demodulating the signals to
+extract the 'I' and 'Q' quadratures. This is done across various readout frequencies and coupler flux biases.
+The resonator frequency as a function of coupler flux bias is then extracted and fitted in order to extract the relevant
+coupler flux biases and corresponding readout frequency.
+
+This information can then be used to adjust the readout frequency for different coupler flux points.
+
+Prerequisites:
+    - Having calibrated the resonator frequency (nodes 02a, 02b and/or 02c).
+    - Having specified the desired flux point (qubit.z.flux_point).
+
+
+State update:
+    - update coupler flux biases
+"""
+
+
+# Be sure to include [Parameters, Quam] so the node has proper type hinting
+node = QualibrationNode[Parameters, Quam](
+    name="02d_resonator_spectroscopy_vs_coupler_flux",  # Name should be unique
+    description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
+    parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+)
+
+
+# Any parameters that should change for debugging purposes only should go in here
+# These parameters are ignored when run through the GUI or as part of a graph
+@node.run_action(skip_if=node.modes.external)
+def custom_param(node: QualibrationNode[Parameters, Quam]):
+    """Allow the user to locally set the node parameters for debugging purposes, or execution in the Python IDE."""
+    # You can get type hinting in your IDE by typing node.parameters.
+    # node.parameters.qubit_pairs = ["coupler_q1_q2", "coupler_q2_q3"]
+    pass
+
+
+# Instantiate the QUAM class from the state file
+node.machine = Quam.load()
+
+
+# %% {Create_QUA_program}
+@node.run_action(skip_if=node.parameters.load_data_id is not None)
+def create_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Create the sweep axes and generate the QUA program from the pulse sequence and the node parameters."""
+    # Class containing tools to help handle units and conversions.
+    u = unit(coerce_to_integer=True)
+
+    # Get the active qubit pairs from the node and organize them by batches
+    node.namespace["qubit_pairs"] = qubit_pairs = get_qubit_pairs(node)
+    num_qubit_pairs = len(qubit_pairs)
+
+    # Extract the measured qubits based on measure_qubit parameter
+    measured_qubits = []
+    for qp in qubit_pairs:
+        if node.parameters.measure_qubit == "control":
+            measured_qubits.append(qp.qubit_control)
+        else:
+            measured_qubits.append(qp.qubit_target)
+    node.namespace["measured_qubits"] = measured_qubits
+    # Also set in qubits for compatibility with utility functions
+    node.namespace["qubits"] = measured_qubits
+
+    # Extract the sweep parameters and axes from the node parameters
+    n_avg = node.parameters.num_shots
+    # Coupler flux bias sweep in V
+    dcs = np.linspace(
+        node.parameters.min_flux_offset_in_v,
+        node.parameters.max_flux_offset_in_v,
+        node.parameters.num_flux_points,
+    )
+    # The frequency sweep around the resonator resonance frequency
+    span = node.parameters.frequency_span_in_mhz * u.MHz
+    step = node.parameters.frequency_step_in_mhz * u.MHz
+    dfs = np.arange(-span / 2, +span / 2, step)
+
+    # Buffer time for flux to wait (in unit of clock cycle)
+    settle_time = node.parameters.settle_time_in_ns // 4
+
+    # Register the sweep axes to be added to the dataset when fetching data
+    node.namespace["sweep_axes"] = {
+        "qubit_pair": xr.DataArray(qubit_pairs.get_names()),
+        "flux_bias": xr.DataArray(dcs, attrs={"long_name": "coupler flux bias", "units": "V"}),
+        "detuning": xr.DataArray(dfs, attrs={"long_name": "readout frequency", "units": "Hz"}),
+    }
+
+    # The QUA program stored in the node namespace to be transfer to the simulation and execution run_actions
+    with program() as node.namespace["qua_program"]:
+        I, I_st, Q, Q_st, n, n_st = node.machine.declare_qua_variables()
+        dc = declare(fixed)  # QUA variable for the coupler flux bias
+        df = declare(int)  # QUA variable for the readout frequency detuning
+
+        for multiplexed_qubit_pairs in qubit_pairs.batch():
+            # Initialize the QPU for all qubits in the batch
+            for qp in multiplexed_qubit_pairs.values():
+                node.machine.initialize_qpu(target=qp.qubit_control)
+                node.machine.initialize_qpu(target=qp.qubit_target)
+            align()
+
+            with for_(n, 0, n < n_avg, n + 1):
+                save(n, n_st)
+                with for_(*from_array(dc, dcs)):
+                    # Apply coupler flux bias via DC offset for EACH qubit pair's coupler
+                    for ii, qp in multiplexed_qubit_pairs.items():
+                        qp.coupler.set_dc_offset(dc)
+                    # Wait for coupler to settle
+                    qp.coupler.wait(settle_time)
+                    # Measure all qubits in the batch
+                    for ii, qp in multiplexed_qubit_pairs.items():
+                        if node.parameters.measure_qubit == "control":
+                            measured_qubit = qp.qubit_control
+                        else:
+                            measured_qubit = qp.qubit_target
+                        rr = measured_qubit.resonator
+                        measured_qubit.align()
+                        with for_(*from_array(df, dfs)):
+                            # Update the resonator frequency
+                            rr.update_frequency(df + rr.intermediate_frequency)
+                            # Readout the resonator
+                            rr.measure("readout", qua_vars=(I[ii], Q[ii]))
+                            # Wait for the resonator to deplete
+                            rr.wait(rr.depletion_time * u.ns)
+                            # Save data
+                            save(I[ii], I_st[ii])
+                            save(Q[ii], Q_st[ii])
+
+            # Measure sequentially if not multiplexed
+            if not node.parameters.multiplexed:
+                align()
+
+        with stream_processing():
+            n_st.save("n")
+            for i in range(num_qubit_pairs):
+                I_st[i].buffer(len(dfs)).buffer(len(dcs)).average().save(f"I{i + 1}")
+                Q_st[i].buffer(len(dfs)).buffer(len(dcs)).average().save(f"Q{i + 1}")
+
+
+# %% {Simulate}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or not node.parameters.simulate)
+def simulate_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Connect to the QOP and simulate the QUA program"""
+    # Connect to the QOP
+    qmm = node.machine.connect()
+    # Get the config from the machine
+    config = node.machine.generate_config()
+    # Simulate the QUA program, generate the waveform report and plot the simulated samples
+    samples, fig, wf_report = simulate_and_plot(qmm, config, node.namespace["qua_program"], node.parameters)
+    # Store the figure, waveform report and simulated samples
+    node.results["simulation"] = {"figure": fig, "wf_report": wf_report, "samples": samples}
+
+
+# %% {Execute}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or node.parameters.simulate)
+def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Connect to the QOP, execute the QUA program and fetch the raw data,
+    storing it in a xarray dataset called "ds_raw"."""
+    # Connect to the QOP
+    qmm = node.machine.connect()
+    # Get the config from the machine
+    config = node.machine.generate_config()
+    # Execute the QUA program only if the quantum machine is available (this is to avoid interrupting running jobs).
+    with qm_session(qmm, config, timeout=node.parameters.timeout) as qm:
+        # The job is stored in the node namespace to be reused in the fetching_data run_action
+        node.namespace["job"] = job = qm.execute(node.namespace["qua_program"])
+        # Display the progress bar
+        data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
+        for dataset in data_fetcher:
+            progress_counter(
+                data_fetcher.get("n", 0),
+                node.parameters.num_shots,
+                start_time=data_fetcher.t_start,
+            )
+        # Display the execution report to expose possible runtime errors
+        node.log(job.execution_report())
+    # Rename qubit_pair dimension to qubit for compatibility with analysis functions
+    if "qubit_pair" in dataset.dims:
+        qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
+        measured_qubit_names = [q.name for q in node.namespace["measured_qubits"]]
+        dataset = dataset.rename({"qubit_pair": "qubit"})
+        dataset = dataset.assign_coords(qubit=qubit_pair_names)
+        dataset = dataset.assign_coords(measured_qubit_name=("qubit", measured_qubit_names))
+    # Register the raw dataset
+    node.results["ds_raw"] = dataset
+
+
+# %% {Load_historical_data}
+@node.run_action(skip_if=node.parameters.load_data_id is None)
+def load_data(node: QualibrationNode[Parameters, Quam]):
+    """Load a previously acquired dataset."""
+    load_data_id = node.parameters.load_data_id
+    # Load the specified dataset
+    node.load_from_id(node.parameters.load_data_id)
+    node.parameters.load_data_id = load_data_id
+
+    # Get the active qubit pairs from the loaded node parameters
+    node.namespace["qubit_pairs"] = qubit_pairs = get_qubit_pairs(node)
+
+    # Extract measured qubits based on measure_qubit parameter
+    measured_qubits = []
+    for qp in qubit_pairs:
+        if node.parameters.measure_qubit == "control":
+            measured_qubits.append(qp.qubit_control)
+        else:
+            measured_qubits.append(qp.qubit_target)
+    node.namespace["measured_qubits"] = measured_qubits
+    node.namespace["qubits"] = measured_qubits
+
+    # Rename qubit_pair dimension to qubit, keeping the qubit-pair names as
+    # the coordinate (they are unique even when two pairs share a measured qubit).
+    if "qubit_pair" in node.results["ds_raw"].dims:
+        qubit_pair_names = [qp.name for qp in qubit_pairs]
+        measured_qubit_names = [q.name for q in measured_qubits]
+        node.results["ds_raw"] = node.results["ds_raw"].rename({"qubit_pair": "qubit"})
+        node.results["ds_raw"] = node.results["ds_raw"].assign_coords(qubit=qubit_pair_names)
+        node.results["ds_raw"] = node.results["ds_raw"].assign_coords(
+            measured_qubit_name=("qubit", measured_qubit_names)
+        )
+
+
+# %% {Analyse_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def analyse_data(node: QualibrationNode[Parameters, Quam]):
+    """Analyse the raw data and store the fitted data in xarray dataset "ds_fit"
+    and the fitted results in the "fit_results" dictionary."""
+    # Ensure qubits namespace is set for utility functions
+    if "qubits" not in node.namespace:
+        node.namespace["qubits"] = node.namespace["measured_qubits"]
+
+    node.results["ds_raw"] = process_raw_dataset(node.results["ds_raw"], node)
+    node.results["ds_fit"], fit_results = fit_raw_data(node.results["ds_raw"], node)
+    node.results["fit_results"] = {k: asdict(v) for k, v in fit_results.items()}
+
+    # Log the relevant information extracted from the data analysis
+    log_fitted_results(node.results["fit_results"], log_callable=node.log)
+    # fit_results is keyed by the qubit coordinate, which is the qubit-pair name.
+    qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
+    node.outcomes = {
+        qp_name: node.results["fit_results"].get(qp_name, {}).get("success", False)
+        for qp_name in qubit_pair_names
+    }
+    # Convert boolean outcomes to "successful"/"failed" strings
+    node.outcomes = {k: ("successful" if v else "failed") for k, v in node.outcomes.items()}
+
+
+# %% {Plot_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def plot_data(node: QualibrationNode[Parameters, Quam]):
+    """Plot the raw and fitted data, laid out by coupler chip position using QubitPairGrid."""
+    # Ensure qubits namespace is set for plotting function
+    if "qubits" not in node.namespace:
+        node.namespace["qubits"] = node.namespace["measured_qubits"]
+
+    fig_raw_fit = plot_raw_data_with_fit(
+        node.results["ds_raw"],
+        node.namespace["qubit_pairs"],
+        node.namespace["measured_qubits"],
+        node.results["ds_fit"],
+    )
+    plt.show()
+    # Store the generated figures
+    node.results["figures"] = {
+        "amplitude": fig_raw_fit,
+    }
+
+
+# %% {Update_state}
+@node.run_action(skip_if=node.parameters.simulate)
+def update_state(node: QualibrationNode[Parameters, Quam]):
+    """Update the relevant parameters if the qubit data analysis was successful."""
+    with node.record_state_updates():
+        for qp in node.namespace["qubit_pairs"]:
+            if node.outcomes[qp.name] == "failed":
+                continue
+
+            # fit_results is keyed by the coupler (qubit-pair) name, not the measured qubit name.
+            # measured_qubit = qp.qubit_control if node.parameters.measure_qubit == "control" else qp.qubit_target
+            # fit_results = node.results["fit_results"][qp.name]
+            # Update manually the state according to the data
+
+
+# %% {Save_results}
+@node.run_action()
+def save_results(node: QualibrationNode[Parameters, Quam]):
+    """Save the node results and state."""
+    node.save()

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
@@ -117,7 +117,7 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
 
     # The QUA program stored in the node namespace to be transfer to the simulation and execution run_actions
     with program() as node.namespace["qua_program"]:
-        I, I_st, Q, Q_st, n, n_st = node.machine.declare_qua_variables()
+        I, I_st, Q, Q_st, n, n_st = node.machine.declare_qua_variables(num_qubit_pairs)
         dc = declare(fixed)  # QUA variable for the coupler flux bias
         df = declare(int)  # QUA variable for the readout frequency detuning
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
@@ -298,8 +298,7 @@ def update_state(node: QualibrationNode[Parameters, Quam]):
             if node.outcomes[qp.name] == "failed":
                 continue
 
-            # fit_results is keyed by the coupler (qubit-pair) name, not the measured qubit name.
-            # measured_qubit = qp.qubit_control if node.parameters.measure_qubit == "control" else qp.qubit_target
+            # Access the measured qubit-pair if needed:
             # fit_results = node.results["fit_results"][qp.name]
             # Update manually the state according to the data
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
@@ -22,6 +22,7 @@ from qualibration_libs.data import XarrayDataFetcher
 from qualibration_libs.parameters import get_qubit_pairs
 from qualibration_libs.runtime import simulate_and_plot
 from quam_config import Quam
+
 # %% {Node initialisation}
 description = """
         RESONATOR SPECTROSCOPY VERSUS COUPLER FLUX
@@ -32,10 +33,15 @@ coupler flux biases and corresponding readout frequency.
 
 This information can then be used to adjust the readout frequency for different coupler flux points.
 
+Multiplexing behaviour:
+    - multiplexed=False (default): each coupler is swept individually while all other couplers are held at
+      their idle flux point. Resonators are measured one at a time.
+    - multiplexed=True: all couplers are swept to the same DC value simultaneously and all resonators
+      are measured at the same time. 
+
 Prerequisites:
     - Having calibrated the resonator frequency (nodes 02a, 02b and/or 02c).
     - Having specified the desired flux point (qubit.z.flux_point).
-
 
 State update:
     - update coupler flux biases
@@ -62,7 +68,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
 
 # Instantiate the QUAM class from the state file
 node.machine = Quam.load()
-
 
 # %% {Create_QUA_program}
 @node.run_action(skip_if=node.parameters.load_data_id is not None)
@@ -128,17 +133,17 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
                     # Apply coupler flux bias via DC offset for EACH qubit pair's coupler
                     for ii, qp in multiplexed_qubit_pairs.items():
                         qp.coupler.set_dc_offset(dc)
-                    # Wait for coupler to settle
-                    qp.coupler.wait(settle_time)
+                        # Wait for coupler to settle
+                        qp.coupler.wait(settle_time)
+                    # align all the couplers
+                    align()
                     # Measure all qubits in the batch
-                    for ii, qp in multiplexed_qubit_pairs.items():
-                        if node.parameters.measure_qubit == "control":
-                            measured_qubit = qp.qubit_control
-                        else:
-                            measured_qubit = qp.qubit_target
-                        rr = measured_qubit.resonator
-                        measured_qubit.align()
-                        with for_(*from_array(df, dfs)):
+                    with for_(*from_array(df, dfs)):
+                        for ii, qp in multiplexed_qubit_pairs.items():
+                            measured_qubit = (
+                                qp.qubit_control if node.parameters.measure_qubit == "control" else qp.qubit_target
+                            )
+                            rr = measured_qubit.resonator
                             # Update the resonator frequency
                             rr.update_frequency(df + rr.intermediate_frequency)
                             # Readout the resonator
@@ -148,11 +153,7 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
                             # Save data
                             save(I[ii], I_st[ii])
                             save(Q[ii], Q_st[ii])
-
-            # Measure sequentially if not multiplexed
-            if not node.parameters.multiplexed:
-                align()
-
+                        align()
         with stream_processing():
             n_st.save("n")
             for i in range(num_qubit_pairs):

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
@@ -69,6 +69,7 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
 # Instantiate the QUAM class from the state file
 node.machine = Quam.load()
 
+
 # %% {Create_QUA_program}
 @node.run_action(skip_if=node.parameters.load_data_id is not None)
 def create_qua_program(node: QualibrationNode[Parameters, Quam]):
@@ -261,8 +262,7 @@ def analyse_data(node: QualibrationNode[Parameters, Quam]):
     # fit_results is keyed by the qubit coordinate, which is the qubit-pair name.
     qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
     node.outcomes = {
-        qp_name: node.results["fit_results"].get(qp_name, {}).get("success", False)
-        for qp_name in qubit_pair_names
+        qp_name: node.results["fit_results"].get(qp_name, {}).get("success", False) for qp_name in qubit_pair_names
     }
     # Convert boolean outcomes to "successful"/"failed" strings
     node.outcomes = {k: ("successful" if v else "failed") for k, v in node.outcomes.items()}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
@@ -33,12 +33,6 @@ coupler flux biases and corresponding readout frequency.
 
 This information can then be used to adjust the readout frequency for different coupler flux points.
 
-Multiplexing behaviour:
-    - multiplexed=False (default): each coupler is swept individually while all other couplers are held at
-      their idle flux point. Resonators are measured one at a time.
-    - multiplexed=True: all couplers are swept to the same DC value simultaneously and all resonators
-      are measured at the same time. 
-
 Prerequisites:
     - Having calibrated the resonator frequency (nodes 02a, 02b and/or 02c).
     - Having specified the desired flux point (qubit.z.flux_point).


### PR DESCRIPTION
Summary:

1. Adds 02d_resonator_spectroscopy_vs_coupler_flux.py, a new calibration node that measures resonator frequency as a function of coupler flux bias for all qubit pairs.
2. Adds supporting utilities under calibration_utils/resonator_spectroscopy_vs_coupler_flux/ (analysis, plotting, parameters) and calibration_utils/pair_grid.py for topology-aware coupler subplot layout.

Why:

Resonator frequency shifts with coupler flux, so calibrating this dependence is a prerequisite for operating qubits at different coupler flux points.

Implementation notes:

Plotting uses a custom QubitPairGrid that positions coupler subplots on a doubled grid derived from control/target qubit grid_location, giving a topology-aware chip layout view. This object should move to qualibration_libs eventualy  
