### PR TITLE
Qubit frequency vs coupler flux calibration

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/qubit_spectroscopy_vs_coupler/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/qubit_spectroscopy_vs_coupler/__init__.py
@@ -1,0 +1,13 @@
+"""Qubit spectroscopy vs coupler flux calibration utilities."""
+
+from .parameters import Parameters
+from .analysis import process_raw_dataset, fit_raw_data, log_fitted_results
+from .plotting import plot_raw_data_with_fit
+
+__all__ = [
+    "Parameters",
+    "process_raw_dataset",
+    "fit_raw_data",
+    "log_fitted_results",
+    "plot_raw_data_with_fit",
+]

--- a/qualibration_graphs/superconducting/calibration_utils/qubit_spectroscopy_vs_coupler/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/qubit_spectroscopy_vs_coupler/analysis.py
@@ -1,0 +1,522 @@
+# pylint: disable=too-many-positional-arguments, too-many-arguments
+"""Analysis utilities for qubit spectroscopy vs coupler flux calibration."""
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import numpy as np
+import xarray as xr
+from qualibrate import QualibrationNode
+from qualibration_libs.analysis import peaks_dips
+from qualibration_libs.data import add_amplitude_and_phase
+from scipy import optimize, signal
+
+
+@dataclass
+class FitParameters:
+    """Stores the relevant node-specific fitted parameters used to update the state at the end of the node."""
+
+    success: bool
+    avoided_crossing_flux_biases: list[float]
+    """List of flux bias values where avoided crossings occur (V)."""
+    num_crossings: int
+    """Number of avoided crossings found."""
+    hyperbolic_fit_params: list[dict] | None = None
+    """
+    List of parameters for fitted avoided crossing models, one per crossing.
+    Each dict contains: 'w_r' (resonator frequency), 'w_q0' (qubit frequency at phi0),
+    'alpha' (qubit frequency slope), 'phi0' (crossing position), 'g' (coupling strength),
+    'flux_range' (fit window), 'branch_assignments' (branch assignments for each data point)
+    """
+
+
+# Define avoided crossing model (2x2 eigenvalues, with linear bare tunable mode)
+def avoided_crossing(phi, w_r, w_q0, alpha, phi0, g, branch):
+    """
+    Avoided crossing model with both branches.
+    branch = +1 for upper eigenvalue, -1 for lower eigenvalue
+    """
+    w1 = w_r
+    w2 = w_q0 + alpha * (phi - phi0)
+    avg = 0.5 * (w1 + w2)
+    det = 0.5 * (w1 - w2)
+    split = np.sqrt(det**2 + g**2)
+    return avg + branch * split
+
+
+def log_fitted_results(fit_results: Dict, log_callable=None):
+    """
+    Logs the node-specific fitted results for all qubits from the fit results
+
+    Parameters:
+    -----------
+    fit_results : dict
+        Dictionary containing the fitted results for all qubits.
+    log_callable : callable, optional
+        Callable for logging the fitted results. If None, a default logger is used.
+
+    """
+    if log_callable is None:
+        log_callable = logging.getLogger(__name__).info
+    for q in fit_results.keys():
+        s_qubit = f"Results for qubit {q}: "
+        num_crossings = fit_results[q]["num_crossings"]
+        s_crossings = f"Found {num_crossings} avoided crossing(s) | "
+        if num_crossings > 0:
+            crossings_str = ", ".join([f"{fc * 1e3:.1f} mV" for fc in fit_results[q]["avoided_crossing_flux_biases"]])
+            s_crossings += f"at: {crossings_str}"
+
+            # Log hyperbolic fit information
+            hyperbolic_fits = fit_results[q].get("hyperbolic_fit_params")
+            if hyperbolic_fits is not None:
+                num_fits = len(hyperbolic_fits)
+                s_crossings += f" | {num_fits}/{num_crossings} hyperbolic fit(s) successful"
+            else:
+                s_crossings += " | No hyperbolic fits"
+        else:
+            s_crossings += "none found"
+        if fit_results[q]["success"]:
+            s_qubit += " SUCCESS!\n"
+        else:
+            s_qubit += " FAIL!\n"
+        log_callable(s_qubit + s_crossings)
+
+
+def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
+    """
+    Process the raw dataset by converting I/Q quadratures to V and adding RF frequency coordinates.
+    """
+
+    # Inline IQ-to-V conversion: the library convert_IQ_to_V builds a
+    # readout_lengths array keyed by q.name, which can have duplicates when
+    # multiple pairs share the same measured qubit.  We build it with the
+    # dataset's own (unique) pair-name coordinate instead.
+    qubit_coord_names = list(ds.qubit.values)
+    readout_lengths = xr.DataArray(
+        [q.resonator.operations["readout"].length for q in node.namespace["qubits"]],
+        coords=[("qubit", qubit_coord_names)],
+    )
+    # Convert I and Q from demodulation units to Volts (same formula as
+    # convert_IQ_to_V with single_demod=False).
+    ds = ds.assign({key: ds[key] * 2**12 / readout_lengths for key in ("I", "Q")})
+    # Add the amplitude and phase to the raw dataset
+    ds = add_amplitude_and_phase(ds, "detuning", subtract_slope_flag=True)
+    # Add the RF frequency as a coordinate of the raw dataset
+    full_freq = np.array([ds.detuning + q.xy.RF_frequency for q in node.namespace["qubits"]])
+    ds = ds.assign_coords(full_freq=(["qubit", "detuning"], full_freq))
+    ds.full_freq.attrs = {"long_name": "RF frequency", "units": "Hz"}
+    # Add the current axis of each qubit to the dataset coordinates for plotting
+    current = ds.flux_bias / node.parameters.input_line_impedance_in_ohm
+    ds = ds.assign_coords({"current": (["flux_bias"], current.data)})
+    ds.current.attrs["long_name"] = "Current"
+    ds.current.attrs["units"] = "A"
+    # Add attenuated current to dataset
+    attenuation_factor = 10 ** (-node.parameters.line_attenuation_in_db / 20)
+    attenuated_current = ds.current * attenuation_factor
+    ds = ds.assign_coords({"attenuated_current": (["flux_bias"], attenuated_current.values)})
+    ds.attenuated_current.attrs["long_name"] = "Attenuated Current"
+    ds.attenuated_current.attrs["units"] = "A"
+    return ds
+
+
+def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, dict[str, FitParameters]]:
+    """
+    Find all avoided crossings for each qubit.
+
+    The method:
+    1. Finds the peak frequency for each flux bias point
+    2. Identifies all avoided crossings (discontinuities) in the frequency vs flux curve
+
+    Parameters:
+    -----------
+    ds : xr.Dataset
+        Dataset containing the raw data with dimensions (qubit, detuning, flux_bias).
+    node : QualibrationNode
+        The calibration node containing parameters.
+
+    Returns:
+    --------
+    Tuple[xr.Dataset, dict[str, FitParameters]]
+        Dataset containing the fit results and dictionary of fit parameters per qubit.
+    """
+    ds_fit = ds.copy()
+
+    # Find peak frequency for each flux bias point
+    peak_freq = peaks_dips(ds.I, dim="detuning", prominence_factor=5)
+    peak_freq_vs_flux = peak_freq.position  # Shape: (qubit, flux_bias)
+
+    # Store the peak frequency curve (detuning at peak) and absolute frequency for each qubit
+    ds_fit["peak_frequency"] = peak_freq_vs_flux
+    # Use pair names from the dataset coordinate (guaranteed unique) instead of
+    # measured qubit names (which may have duplicates across pairs).
+    qubit_coord_names = list(ds.qubit.values)
+    rf_freqs = xr.DataArray(
+        [q.xy.RF_frequency for q in node.namespace["qubits"]],
+        coords={"qubit": qubit_coord_names},
+    )
+    ds_fit["abs_peak_frequency"] = peak_freq_vs_flux + rf_freqs
+    ds_fit["abs_peak_frequency"].attrs = {"long_name": "Absolute peak frequency", "units": "Hz"}
+
+    # Extract the relevant fitted parameters
+    fit_dataset, fit_results = _extract_relevant_fit_parameters(ds_fit, node, peak_freq_vs_flux)
+    return fit_dataset, fit_results
+
+
+def _extract_relevant_fit_parameters(  # pylint: disable=too-many-branches,too-many-statements
+    fit: xr.Dataset, node: QualibrationNode, peak_freq_vs_flux: xr.DataArray
+):
+    """
+    Extract relevant fit parameters by identifying all avoided crossings.
+
+    Parameters:
+    -----------
+    fit : xr.Dataset
+        Dataset containing the processed data.
+    node : QualibrationNode
+        The calibration node.
+    peak_freq_vs_flux : xr.DataArray
+        Peak frequency vs flux bias, shape (qubit, flux_bias).
+
+    Returns:
+    --------
+    Tuple[xr.Dataset, dict[str, FitParameters]]
+        Updated fit dataset and dictionary of fit parameters.
+    """
+    fit_results = {}
+
+    # Iterate using unique pair names from the dataset coordinate alongside the
+    # measured qubit objects.  pair_name is used for all .sel() / dict-key
+    # operations (guaranteed unique), while q.name is only used for logging.
+    qubit_pair_names = list(fit.qubit.values)
+    for qubit_idx, (pair_name, q) in enumerate(zip(qubit_pair_names, node.namespace["qubits"])):
+        q_name = q.name
+        try:
+            # Get peak frequency vs flux for this qubit pair (unique selection)
+            peak_freq_1d = peak_freq_vs_flux.sel(qubit=pair_name)
+
+            # Remove NaN values
+            valid_mask = ~np.isnan(peak_freq_1d)
+            flux_bias_valid = peak_freq_1d.flux_bias[valid_mask]
+            peak_freq_valid = peak_freq_1d[valid_mask]
+
+            if len(peak_freq_valid) < 5:
+                # Not enough data points
+                fit_results[pair_name] = FitParameters(
+                    success=False,
+                    avoided_crossing_flux_biases=[],
+                    num_crossings=0,
+                )
+                continue
+
+            # Calculate derivative to find discontinuities (avoided crossings)
+            # Use a smoothed derivative to reduce noise
+            flux_bias_array = flux_bias_valid.data
+            peak_freq_array = peak_freq_valid.data
+
+            # Smooth the data slightly to reduce noise
+            if len(peak_freq_array) > 5:
+                window_size = min(5, len(peak_freq_array) // 3)
+                if not window_size % 2:
+                    window_size += 1
+                peak_freq_smooth = signal.savgol_filter(peak_freq_array, window_size, 2)
+            else:
+                peak_freq_smooth = peak_freq_array
+
+            # Store smoothed peak frequency for plotting
+            # Initialize smoothed_peak_frequency if not exists
+            if "smoothed_peak_frequency" not in fit.data_vars:
+                flux_bias_all = fit.flux_bias.data
+                smoothed_init = np.full((len(qubit_pair_names), len(flux_bias_all)), np.nan)
+                fit["smoothed_peak_frequency"] = (
+                    ["qubit", "flux_bias"],
+                    smoothed_init,
+                    {"long_name": "Smoothed peak frequency", "units": "Hz"},
+                )
+            # Store smoothed data for this qubit (use enumerate index directly
+            # instead of .index(q_name) which only finds the first duplicate)
+            for i, flux_val in enumerate(flux_bias_array):
+                flux_idx = np.argmin(np.abs(fit.flux_bias.data - flux_val))
+                fit["smoothed_peak_frequency"][qubit_idx, flux_idx] = peak_freq_smooth[i]
+
+            # Calculate derivative
+            dfreq_dflux = np.gradient(peak_freq_smooth, flux_bias_array)
+
+            # Find large changes in derivative (avoided crossings)
+            # Use a threshold based on the standard deviation of the derivative
+            threshold = 3 * np.std(dfreq_dflux)
+
+            # Find clusters of large derivatives (avoided crossings)
+            crossing_indices = []
+            if np.any(np.abs(dfreq_dflux) > threshold):
+                # Find start and end of each crossing region
+                large_deriv_mask = np.abs(dfreq_dflux) > threshold
+                diff_mask = np.diff(large_deriv_mask.astype(int))
+                starts = np.where(diff_mask == 1)[0]
+                ends = np.where(diff_mask == -1)[0]
+
+                # Handle edge cases
+                if len(starts) > len(ends):
+                    ends = np.append(ends, len(large_deriv_mask) - 1)
+                if len(ends) > len(starts):
+                    starts = np.insert(starts, 0, 0)
+
+                # Find the center of each crossing region
+                for start, end in zip(starts, ends):
+                    crossing_region = np.arange(start, end + 1)
+                    if len(crossing_region) > 0:
+                        # Find the point with maximum derivative magnitude in this region
+                        max_idx = crossing_region[np.argmax(np.abs(dfreq_dflux[crossing_region]))]
+                        crossing_indices.append(max_idx)
+
+            # If no crossings found via clustering, try peak finding
+            if not crossing_indices:
+                min_distance = max(1, len(dfreq_dflux) // 20)  # Minimum distance between peaks
+                peak_indices, _ = signal.find_peaks(np.abs(dfreq_dflux), height=threshold, distance=min_distance)
+                crossing_indices = sorted(peak_indices.tolist())
+
+            # Get flux bias values at crossings
+            crossing_flux_biases = [float(flux_bias_array[idx]) for idx in crossing_indices]
+            crossing_flux_biases = sorted(crossing_flux_biases)  # Sort by flux bias value
+
+            # Fit hyperbolic function locally around each crossing
+            # Hyperbolic form: f(φ) = f₀ + √((Δf/2)² + (g·(φ-φ₀))²)
+            hyperbolic_fit_params = []
+
+            if len(crossing_flux_biases) > 0:
+                # Automatically calculate window size based on data characteristics
+                # Calculate typical flux spacing
+                if len(flux_bias_array) > 1:
+                    flux_step = np.mean(np.diff(flux_bias_array))
+                    flux_range_total = np.max(flux_bias_array) - np.min(flux_bias_array)
+                else:
+                    flux_step = 0.001  # Fallback
+                    flux_range_total = 0.1  # Fallback
+
+                # Target window: use ~30-40 data points, but adapt to data density
+                target_points = 35
+                base_window_volts = target_points * abs(flux_step)
+
+                # Ensure minimum and maximum window sizes relative to scanning range
+                # At least 5% of range or 15 points
+                min_window_volts = max(0.05 * flux_range_total, 15 * abs(flux_step))
+                max_window_volts = 0.5 * flux_range_total  # At most 50% of range
+                base_window_volts = np.clip(base_window_volts, min_window_volts, max_window_volts)
+
+                def model(xdata, w_r, w_q0, alpha, phi0, g):
+                    """Model function for curve_fit"""
+                    phi, br = xdata
+                    return avoided_crossing(phi, w_r, w_q0, alpha, phi0, g, br)
+
+                # Fit around each crossing
+                for i, crossing_flux in enumerate(crossing_flux_biases):
+                    try:
+                        # Calculate adaptive window size for this crossing
+                        # Consider distance to neighboring crossings
+                        window_volts = base_window_volts
+
+                        # If there are neighboring crossings, reduce window to avoid overlap
+                        if len(crossing_flux_biases) > 1:
+                            # Find distances to nearest neighbors
+                            distances = []
+                            for other_crossing in crossing_flux_biases:
+                                if other_crossing != crossing_flux:
+                                    distances.append(abs(other_crossing - crossing_flux))
+
+                            if distances:
+                                min_distance = min(distances)
+                                # Use at most 60% of distance to nearest crossing, but not less than minimum
+                                adaptive_window = min(0.6 * min_distance, base_window_volts)
+                                window_volts = max(adaptive_window, min_window_volts)
+
+                        # Find indices within the window around this crossing
+                        window_mask = np.abs(flux_bias_array - crossing_flux) <= window_volts
+
+                        # Extract data within window
+                        flux_window = flux_bias_array[window_mask]
+                        freq_window = peak_freq_smooth[window_mask]
+
+                        # Ensure we have enough points for fitting
+                        if len(flux_window) < 10:
+                            logging.warning(
+                                f"Insufficient data points ({len(flux_window)}) for avoided crossing fit "
+                                f"around crossing at {crossing_flux * 1e3:.1f} mV for {pair_name} ({q_name}). Skipping."
+                            )
+                            continue
+
+                        # Initial guesses (heuristics)
+                        left = flux_window < crossing_flux
+                        right = flux_window > crossing_flux
+
+                        w_r0 = np.median(freq_window[left]) if np.any(left) else np.median(freq_window)
+                        w_q00 = np.median(freq_window[right]) if np.any(right) else np.median(freq_window)
+
+                        # Slope guess from right side (rough linear fit)
+                        if np.sum(right) >= 5:
+                            alpha0, _ = np.polyfit(flux_window[right], freq_window[right], 1)
+                        elif np.sum(left) >= 5:
+                            alpha0, _ = np.polyfit(flux_window[left], freq_window[left], 1)
+                        else:
+                            alpha0, _ = np.polyfit(flux_window, freq_window, 1)
+
+                        # Crossing guess at the identified crossing position
+                        phi00 = float(crossing_flux)
+
+                        # Coupling guess from overall scale (kept >= 1 MHz)
+                        g0 = max(1e6, 0.25 * (np.percentile(freq_window, 95) - np.percentile(freq_window, 5)))
+
+                        p = np.array([w_r0, w_q00, alpha0, phi00, g0], dtype=float)
+
+                        def fit_with_branches(flux_, freq_, branch_, p0):
+                            """Fit model with given branch assignments"""
+                            popt, _ = optimize.curve_fit(model, (flux_, branch_), freq_, p0=p0, maxfev=50000)
+                            return popt
+
+                        # EM-style loop: assign branch using current params, then refit
+                        branch = np.ones_like(freq_window, dtype=float)
+                        for iteration in range(30):
+                            upper = avoided_crossing(flux_window, *p, branch=+1.0)
+                            lower = avoided_crossing(flux_window, *p, branch=-1.0)
+
+                            new_branch = np.where(
+                                np.abs(freq_window - upper) <= np.abs(freq_window - lower), +1.0, -1.0
+                            )
+
+                            p_new = fit_with_branches(flux_window, freq_window, new_branch, p)
+
+                            # Stop if stable
+                            if np.all(new_branch == branch) and np.allclose(p_new, p, rtol=1e-5, atol=1e-3):
+                                p = p_new
+                                branch = new_branch
+                                break
+
+                            p = p_new
+                            branch = new_branch
+
+                        # Optional robust cleanup: drop large-residual outliers once, refit
+                        upper = avoided_crossing(flux_window, *p, branch=+1.0)
+                        lower = avoided_crossing(flux_window, *p, branch=-1.0)
+                        pred = np.where(branch > 0, upper, lower)
+                        resid = freq_window - pred
+
+                        mad = np.median(np.abs(resid - np.median(resid))) + 1e-12
+                        sigma = 1.4826 * mad
+                        keep = np.abs(resid) < 4.5 * sigma  # ~4.5-sigma rule
+
+                        if np.sum(keep) >= 10:  # Ensure enough points after outlier removal
+                            p_final = fit_with_branches(flux_window[keep], freq_window[keep], branch[keep], p)
+                            # Recompute branch assignments with final parameters
+                            upper_final = avoided_crossing(flux_window[keep], *p_final, branch=+1.0)
+                            lower_final = avoided_crossing(flux_window[keep], *p_final, branch=-1.0)
+                            branch_final = np.where(
+                                np.abs(freq_window[keep] - upper_final) <= np.abs(freq_window[keep] - lower_final),
+                                +1.0,
+                                -1.0,
+                            )
+                        else:
+                            p_final = p
+                            branch_final = branch[keep] if np.any(keep) else branch
+
+                        w_r, w_q0, alpha, phi0_fit, g = p_final
+
+                        # Store fit parameters
+                        fit_params = {
+                            "w_r": float(w_r),  # Resonator frequency (Hz)
+                            "w_q0": float(w_q0),  # Qubit frequency at phi0 (Hz)
+                            "alpha": float(alpha),  # Qubit frequency slope (Hz/V)
+                            "phi0": float(phi0_fit),  # Crossing flux position (V)
+                            "g": float(g),  # Coupling strength (Hz)
+                            "flux_range": [
+                                float(np.min(flux_window)),
+                                float(np.max(flux_window)),
+                            ],  # Fit window range
+                            "branch_assignments": (
+                                branch_final.tolist() if hasattr(branch_final, "tolist") else branch_final
+                            ),
+                        }
+                        hyperbolic_fit_params.append(fit_params)
+
+                    except Exception as e:
+                        logging.warning(
+                            f"Failed to fit hyperbolic function around crossing at "
+                            f"{crossing_flux * 1e3:.1f} mV for {pair_name} ({q_name}): {e}"
+                        )
+                        # Continue with other crossings
+                        continue
+
+            # Set to None if no fits were successful
+            if not hyperbolic_fit_params:
+                hyperbolic_fit_params = None
+
+            # Assess success: found at least one crossing
+            success = len(crossing_flux_biases) > 0
+
+            fit_results[pair_name] = FitParameters(
+                success=success,
+                avoided_crossing_flux_biases=crossing_flux_biases,
+                num_crossings=len(crossing_flux_biases),
+                hyperbolic_fit_params=hyperbolic_fit_params,
+            )
+
+        except Exception as e:
+            logging.warning(f"Error fitting {pair_name} ({q_name}): {e}")
+            fit_results[pair_name] = FitParameters(
+                success=False,
+                avoided_crossing_flux_biases=[],
+                num_crossings=0,
+                hyperbolic_fit_params=None,
+            )
+
+    # Add fit results to dataset for easy access in plotting
+    # Use pair names (the dataset's qubit coordinate values) as keys
+    success_array = xr.DataArray(
+        [fit_results[pn].success for pn in qubit_pair_names],
+        coords={"qubit": qubit_pair_names},
+    )
+    num_crossings_array = xr.DataArray(
+        [fit_results[pn].num_crossings for pn in qubit_pair_names],
+        coords={"qubit": qubit_pair_names},
+    )
+
+    fit = fit.assign_coords(
+        success=("qubit", success_array.data),
+        num_crossings=("qubit", num_crossings_array.data),
+    )
+
+    # Store crossing positions as a JSON string for netCDF serialization
+    # Convert dict to JSON string since netCDF can't serialize nested dicts
+    # Ensure all values are native Python types (not numpy) for JSON serialization
+    crossing_dict = {pn: [float(x) for x in fit_results[pn].avoided_crossing_flux_biases] for pn in qubit_pair_names}
+    fit.attrs["avoided_crossing_flux_biases"] = json.dumps(crossing_dict)
+
+    # Store hyperbolic fit parameters as JSON string
+    hyperbolic_fits_dict = {}
+    for pn in qubit_pair_names:
+        if fit_results[pn].hyperbolic_fit_params is not None:
+            # Convert each fit dict to ensure all values are native Python types
+            hyperbolic_fits_dict[pn] = []
+            for fp in fit_results[pn].hyperbolic_fit_params:
+                fit_dict = {
+                    "w_r": float(fp["w_r"]),
+                    "w_q0": float(fp["w_q0"]),
+                    "alpha": float(fp["alpha"]),
+                    "phi0": float(fp["phi0"]),
+                    "g": float(fp["g"]),
+                    "flux_range": [float(fp["flux_range"][0]), float(fp["flux_range"][1])],
+                }
+                # Store branch assignments if available (may be large, so optional)
+                if "branch_assignments" in fp:
+                    fit_dict["branch_assignments"] = fp["branch_assignments"]
+                hyperbolic_fits_dict[pn].append(fit_dict)
+        else:
+            hyperbolic_fits_dict[pn] = []
+    fit.attrs["hyperbolic_fit_params"] = json.dumps(hyperbolic_fits_dict)
+
+    # Ensure smoothed_peak_frequency has proper coordinates
+    if "smoothed_peak_frequency" in fit.data_vars:
+        fit["smoothed_peak_frequency"] = fit["smoothed_peak_frequency"].assign_coords(
+            qubit=qubit_pair_names, flux_bias=fit.flux_bias
+        )
+
+    return fit, fit_results

--- a/qualibration_graphs/superconducting/calibration_utils/qubit_spectroscopy_vs_coupler/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/qubit_spectroscopy_vs_coupler/parameters.py
@@ -1,0 +1,51 @@
+"""Parameter definitions for qubit spectroscopy vs coupler flux calibration."""
+
+from typing import ClassVar, Literal, Optional
+
+from qualibrate import NodeParameters
+from qualibrate.core.parameters import RunnableParameters
+from qualibration_libs.parameters import CommonNodeParameters, QubitPairExperimentNodeParameters
+
+
+class NodeSpecificParameters(RunnableParameters):
+    """Node-specific parameters for qubit spectroscopy vs coupler flux calibration."""
+
+    num_shots: int = 50
+    """Number of averages to perform. Default is 50."""
+    operation: str = "saturation"
+    """Operation to perform. Default is "saturation"."""
+    operation_amplitude_factor: float = 0.1
+    """Amplitude factor for the operation. Default is 0.1."""
+    operation_len_in_ns: Optional[int] = None
+    """Length of the operation in ns. Default is the predefined pulse length."""
+    frequency_span_in_mhz: float = 100.0
+    """Frequency span in MHz. Default is 100 MHz."""
+    frequency_step_in_mhz: float = 0.5
+    """Frequency step in MHz. Default is 0.5 MHz."""
+    min_flux_in_v: float = -0.025
+    """Minimum flux bias in volts. Default is -0.025 V."""
+    max_flux_in_v: float = 0.025
+    """Maximum flux bias in volts. Default is 0.025 V."""
+    num_flux_points: int = 11
+    """Number of flux points. Default is 11."""
+    input_line_impedance_in_ohm: Optional[int] = 50
+    """Input line impedance in ohms. Default is 50 Ohm."""
+    line_attenuation_in_db: Optional[int] = 0
+    """Line attenuation in dB. Default is 0 dB."""
+    measure_qubit: Literal["control", "target"] = "target"
+    """Which qubit to measure: 'control' or 'target'. Default is 'target'."""
+    settle_time_in_ns: int = 20000
+    """Settle time in ns. Default is 5000 ns."""
+    buffer_time_in_ns: int = 100
+    """Buffer time before readout in ns. Default is 100 ns."""
+
+
+class Parameters(
+    NodeParameters,
+    CommonNodeParameters,
+    NodeSpecificParameters,
+    QubitPairExperimentNodeParameters,
+):
+    """Combined parameters for qubit spectroscopy vs coupler flux calibration."""
+
+    targets_name: ClassVar[str] = "qubit_pairs"

--- a/qualibration_graphs/superconducting/calibration_utils/qubit_spectroscopy_vs_coupler/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/qubit_spectroscopy_vs_coupler/parameters.py
@@ -34,7 +34,7 @@ class NodeSpecificParameters(RunnableParameters):
     """Line attenuation in dB. Default is 0 dB."""
     measure_qubit: Literal["control", "target"] = "target"
     """Which qubit to measure: 'control' or 'target'. Default is 'target'."""
-    settle_time_in_ns: int = 20000
+    settle_time_in_ns: int = 5000
     """Settle time in ns. Default is 5000 ns."""
     buffer_time_in_ns: int = 100
     """Buffer time before readout in ns. Default is 100 ns."""

--- a/qualibration_graphs/superconducting/calibration_utils/qubit_spectroscopy_vs_coupler/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/qubit_spectroscopy_vs_coupler/plotting.py
@@ -1,0 +1,436 @@
+# pylint: disable=too-many-positional-arguments
+"""Plotting utilities for qubit spectroscopy vs coupler flux calibration."""
+
+import json
+from typing import List
+
+import numpy as np
+import xarray as xr
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from qualang_tools.units import unit
+from qualibration_libs.plotting import grid_iter
+from calibration_utils.pair_grid import QubitPairGrid, grid_pair_names
+from .analysis import avoided_crossing
+
+u = unit(coerce_to_integer=True)
+
+
+def plot_raw_data_with_fit(ds: xr.Dataset, qubit_pairs, fits: xr.Dataset):
+    """
+    Plots the raw data with avoided crossings marked with red crosses.
+
+    The subplot layout is computed automatically from the qubit-pair
+    grid locations using :class:`~calibration_utils.pair_grid.QubitPairGrid`.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The dataset containing the quadrature data.
+    qubit_pairs : list
+        A list of qubit pair objects (must expose ``.qubit_control`` /
+        ``.qubit_target`` with ``.grid_location`` and ``.name``).
+    fits : xr.Dataset
+        The dataset containing the fit parameters (should include peak_frequency).
+
+    Returns
+    -------
+    Figure
+        The matplotlib figure object containing the plots.
+    """
+    g_names, qp_names = grid_pair_names(qubit_pairs)
+    grid = QubitPairGrid(g_names, qp_names)
+    for ax, qubit in grid_iter(grid):
+        plot_individual_raw_data_with_fit(ax, ds, qubit, fits)
+
+    grid.fig.suptitle("Qubit spectroscopy vs coupler flux")
+    grid.fig.tight_layout()
+    return grid.fig
+
+
+def plot_individual_raw_data_with_fit(  # pylint: disable=too-many-branches,too-many-statements,too-many-nested-blocks
+    ax: Axes, ds: xr.Dataset, qubit: dict[str, str], fit: xr.Dataset = None
+):
+    """
+    Plots individual qubit data on a given axis with avoided crossings marked with red crosses.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The axis on which to plot the data.
+    ds : xr.Dataset
+        The dataset containing the quadrature data.
+    qubit : dict[str, str]
+        mapping to the qubit to plot.
+    fit : xr.Dataset, optional
+        The dataset containing the fit parameters including peak_frequency and fit results (default is None).
+
+    Notes
+    -----
+    - If the fit dataset is provided, the peak frequency curve is plotted along with red crosses
+      marking the positions of avoided crossings.
+    """
+    qubit_name = qubit["qubit"]  # pair name (unique coordinate value)
+    # Resolve human-readable measured qubit name for display
+    if "measured_qubit_name" in ds.coords:
+        measured_qubit_name = str(ds.measured_qubit_name.sel(qubit=qubit_name).values)
+        display_name = f"Measured qubit: {measured_qubit_name}\nCoupler: {qubit_name}"
+    else:
+        display_name = qubit_name
+
+    # Plot the 2D spectroscopy data
+    ds_plot = ds.assign_coords(freq_GHz=ds.full_freq / 1e9).loc[qubit]
+    im = ds_plot.I.plot(ax=ax, add_colorbar=True, x="flux_bias", y="freq_GHz", robust=True, cmap="viridis")
+
+    # Plot peak frequency curve if available
+    if fit is not None and "peak_frequency" in fit.data_vars:
+        try:
+            # Select the peak frequency for this specific qubit
+            # Try different methods to access the qubit dimension
+            peak_freq_da = fit.peak_frequency
+            if "qubit" in peak_freq_da.dims:
+                # Find the index of this qubit in the dimension
+                if "qubit" in peak_freq_da.coords:
+                    # Has coordinate, can use sel
+                    peak_freq = peak_freq_da.sel(qubit=qubit_name)
+                else:
+                    # No coordinate, find by matching dimension values
+                    qubit_dim = peak_freq_da.dims[peak_freq_da.dims.index("qubit")]
+                    qubit_values = peak_freq_da[qubit_dim].values
+                    if isinstance(qubit_values[0], str):
+                        qubit_idx = np.where(qubit_values == qubit_name)[0]
+                    else:
+                        # Try to match by name attribute or convert to string
+                        qubit_idx = np.where([str(q) == qubit_name for q in qubit_values])[0]
+
+                    if len(qubit_idx) > 0:
+                        peak_freq = peak_freq_da.isel(qubit=qubit_idx[0])
+                    else:
+                        raise KeyError(f"Qubit {qubit_name} not found in peak_frequency")
+            else:
+                raise KeyError("qubit dimension not found in peak_frequency")
+
+            # Remove NaN values for plotting
+            valid_mask = ~np.isnan(peak_freq)
+            if np.any(valid_mask):
+                peak_freq_valid = peak_freq[valid_mask]
+                flux_bias_vals = peak_freq_valid.flux_bias
+
+                # Get the RF frequency for this qubit (from the dataset or use a reference)
+                # peak_freq is the detuning, so we need to add the RF frequency
+                # Get RF frequency from the dataset's full_freq coordinate
+                rf_freq = ds_plot.full_freq.mean(dim=["detuning"]).values
+                if np.isnan(rf_freq) or not rf_freq:
+                    # Fallback: use the first flux bias point's mean full_freq
+                    rf_freq = float(ds_plot.full_freq.isel(flux_bias=0).mean(dim="detuning").values)
+
+                # Calculate full frequency: detuning + RF_frequency
+                peak_freq_full = peak_freq_valid + rf_freq
+                peak_freq_GHz = peak_freq_full / 1e9
+
+                # Plot peak frequency as red scatter points
+                ax.scatter(
+                    flux_bias_vals,
+                    peak_freq_GHz,
+                    c="red",
+                    s=20,
+                    marker="o",
+                    alpha=0.7,
+                    label="Peak frequency",
+                    zorder=5,
+                )
+        except (KeyError, ValueError, IndexError):
+            # If selection fails, skip plotting peak frequency
+            pass
+
+    # Mark avoided crossings with red crosses if fit results are available
+    if fit is not None:
+        try:
+            # Try to get success status - handle both coordinate and attribute access
+            if "success" in fit.coords:
+                success = bool(fit.success.sel(qubit=qubit_name).values)
+            elif "success" in fit.data_vars:
+                success = bool(fit.success.sel(qubit=qubit_name).values)
+            else:
+                success = False
+
+            if success and "avoided_crossing_flux_biases" in fit.attrs:
+                # Parse JSON string back to dict (stored as JSON for netCDF serialization)
+                crossing_dict_str = fit.attrs["avoided_crossing_flux_biases"]
+                if isinstance(crossing_dict_str, str):
+                    crossing_dict = json.loads(crossing_dict_str)
+                else:
+                    # Backward compatibility: if it's already a dict (in-memory)
+                    crossing_dict = crossing_dict_str
+                crossing_flux_biases = crossing_dict.get(qubit_name, [])
+
+                # Get RF frequency for conversion (used for both hyperbolic fit and crosses)
+                rf_freq = ds_plot.full_freq.mean(dim=["detuning"]).values
+                if np.isnan(rf_freq) or not rf_freq:
+                    rf_freq = float(ds_plot.full_freq.isel(flux_bias=0).mean(dim="detuning").values)
+
+                # Plot the smoothed peak frequency fit used in the analysis
+                if "smoothed_peak_frequency" in fit.data_vars:
+                    try:
+                        # Get smoothed peak frequency for this qubit
+                        smoothed_peak_freq_da = fit.smoothed_peak_frequency
+                        if "qubit" in smoothed_peak_freq_da.dims:
+                            if "qubit" in smoothed_peak_freq_da.coords:
+                                smoothed_peak_freq = smoothed_peak_freq_da.sel(qubit=qubit_name)
+                            else:
+                                qubit_dim = smoothed_peak_freq_da.dims[smoothed_peak_freq_da.dims.index("qubit")]
+                                qubit_values = smoothed_peak_freq_da[qubit_dim].values
+                                if isinstance(qubit_values[0], str):
+                                    qubit_idx = np.where(qubit_values == qubit_name)[0]
+                                else:
+                                    qubit_idx = np.where([str(q) == qubit_name for q in qubit_values])[0]
+                                if len(qubit_idx) > 0:
+                                    smoothed_peak_freq = smoothed_peak_freq_da.isel(qubit=qubit_idx[0])
+                                else:
+                                    raise KeyError(f"Qubit {qubit_name} not found")
+                        else:
+                            raise KeyError("qubit dimension not found")
+
+                        # Remove NaN values
+                        valid_mask = ~np.isnan(smoothed_peak_freq)
+                        if np.any(valid_mask):
+                            smoothed_peak_freq_valid = smoothed_peak_freq[valid_mask]
+                            flux_bias_vals_smooth = smoothed_peak_freq_valid.flux_bias
+
+                            # Add RF frequency to get full frequency, then convert to GHz
+                            smoothed_freq_full_Hz = smoothed_peak_freq_valid + rf_freq
+                            smoothed_freq_GHz = smoothed_freq_full_Hz / 1e9
+
+                            # Plot the smoothed fit curve
+                            ax.plot(
+                                flux_bias_vals_smooth,
+                                smoothed_freq_GHz,
+                                "r-",
+                                linewidth=2,
+                                alpha=0.8,
+                                label="Smoothed fit",
+                                zorder=7,
+                            )
+
+                            # Mark avoided crossings with red crosses using the smoothed fit
+                            for i, crossing_flux in enumerate(crossing_flux_biases):
+                                # Find the frequency at this flux bias by interpolating on smoothed data
+                                crossing_freq_GHz = np.interp(
+                                    crossing_flux, flux_bias_vals_smooth.data, smoothed_freq_GHz.data
+                                )
+
+                                # Plot red cross
+                                ax.plot(
+                                    crossing_flux,
+                                    crossing_freq_GHz,
+                                    "b+",
+                                    markersize=15,
+                                    markeredgewidth=3,
+                                    label="Avoided crossing" if not i else "",
+                                    zorder=10,
+                                )
+
+                            # Plot hyperbolic fits if available
+                            if "hyperbolic_fit_params" in fit.attrs:
+                                try:
+                                    hyperbolic_fits_str = fit.attrs["hyperbolic_fit_params"]
+                                    if isinstance(hyperbolic_fits_str, str):
+                                        hyperbolic_fits_dict = json.loads(hyperbolic_fits_str)
+                                    else:
+                                        hyperbolic_fits_dict = hyperbolic_fits_str
+
+                                    hyperbolic_fits = hyperbolic_fits_dict.get(qubit_name, [])
+
+                                    # Plot fit for each crossing
+                                    for i, fit_params in enumerate(hyperbolic_fits):
+                                        try:
+                                            flux_range = fit_params.get("flux_range", None)
+                                            if flux_range is None:
+                                                # Fallback: use window around crossing
+                                                crossing_flux = crossing_flux_biases[i]
+                                                flux_range = [
+                                                    crossing_flux - 0.01,
+                                                    crossing_flux + 0.01,
+                                                ]
+
+                                            # Generate flux points for fit curve
+                                            flux_fit = np.linspace(flux_range[0], flux_range[1], 200)
+
+                                            # Evaluate both branches of the avoided crossing
+                                            upper_fit_Hz = avoided_crossing(
+                                                flux_fit,
+                                                fit_params["w_r"],
+                                                fit_params["w_q0"],
+                                                fit_params["alpha"],
+                                                fit_params["phi0"],
+                                                fit_params["g"],
+                                                branch=+1.0,
+                                            )
+                                            lower_fit_Hz = avoided_crossing(
+                                                flux_fit,
+                                                fit_params["w_r"],
+                                                fit_params["w_q0"],
+                                                fit_params["alpha"],
+                                                fit_params["phi0"],
+                                                fit_params["g"],
+                                                branch=-1.0,
+                                            )
+
+                                            # Convert to full frequency and GHz
+                                            upper_fit_full_Hz = upper_fit_Hz + rf_freq
+                                            lower_fit_full_Hz = lower_fit_Hz + rf_freq
+                                            upper_fit_GHz = upper_fit_full_Hz / 1e9
+                                            lower_fit_GHz = lower_fit_full_Hz / 1e9
+
+                                            # Plot both branches of the fit curve
+                                            ax.plot(
+                                                flux_fit,
+                                                upper_fit_GHz,
+                                                color="violet",
+                                                linestyle="-",
+                                                linewidth=3,
+                                                alpha=0.8,
+                                                label=f"Avoided crossing fit #{i + 1} (upper)" if not i else "",
+                                                zorder=8,
+                                            )
+                                            ax.plot(
+                                                flux_fit,
+                                                lower_fit_GHz,
+                                                color="violet",
+                                                linestyle="-",
+                                                linewidth=3,
+                                                alpha=0.8,
+                                                label=f"Avoided crossing fit #{i + 1} (lower)" if not i else "",
+                                                zorder=8,
+                                            )
+                                        except (KeyError, ValueError, TypeError) as e:
+                                            # Skip this fit if there's an error
+                                            continue
+
+                                except (KeyError, json.JSONDecodeError, AttributeError):
+                                    # If fit parameters not available, skip plotting fits
+                                    pass
+                    except (KeyError, ValueError, IndexError):
+                        # If smoothed data selection fails, mark crossings at middle of y-axis
+                        y_mid = np.mean(ax.get_ylim())
+                        for crossing_flux in crossing_flux_biases:
+                            ax.plot(
+                                crossing_flux,
+                                y_mid,
+                                "r+",
+                                markersize=15,
+                                markeredgewidth=3,
+                                label="Avoided crossing" if crossing_flux == crossing_flux_biases[0] else "",
+                                zorder=10,
+                            )
+
+                # If smoothed fit is not available, fallback to marking crossings at middle of y-axis
+                if "smoothed_peak_frequency" not in fit.data_vars:
+                    # Get RF frequency for conversion (needed for hyperbolic fits)
+                    rf_freq_fallback = ds_plot.full_freq.mean(dim=["detuning"]).values
+                    if np.isnan(rf_freq_fallback) or not rf_freq_fallback:
+                        rf_freq_fallback = float(ds_plot.full_freq.isel(flux_bias=0).mean(dim="detuning").values)
+
+                    y_mid = np.mean(ax.get_ylim())
+                    for i, crossing_flux in enumerate(crossing_flux_biases):
+                        ax.plot(
+                            crossing_flux,
+                            y_mid,
+                            "r+",
+                            markersize=15,
+                            markeredgewidth=3,
+                            label="Avoided crossing" if not i else "",
+                            zorder=10,
+                        )
+
+                    # Still try to plot hyperbolic fits if available
+                    if "hyperbolic_fit_params" in fit.attrs:
+                        try:
+                            hyperbolic_fits_str = fit.attrs["hyperbolic_fit_params"]
+                            if isinstance(hyperbolic_fits_str, str):
+                                hyperbolic_fits_dict = json.loads(hyperbolic_fits_str)
+                            else:
+                                hyperbolic_fits_dict = hyperbolic_fits_str
+
+                            hyperbolic_fits = hyperbolic_fits_dict.get(qubit_name, [])
+
+                            # Plot fit for each crossing
+                            for i, fit_params in enumerate(hyperbolic_fits):
+                                try:
+                                    flux_range = fit_params.get("flux_range", None)
+                                    if flux_range is None:
+                                        # Fallback: use window around crossing
+                                        crossing_flux = crossing_flux_biases[i]
+                                        flux_range = [
+                                            crossing_flux - 0.01,
+                                            crossing_flux + 0.01,
+                                        ]
+
+                                    # Generate flux points for fit curve
+                                    flux_fit = np.linspace(flux_range[0], flux_range[1], 200)
+
+                                    # Evaluate both branches of the avoided crossing
+                                    upper_fit_Hz = avoided_crossing(
+                                        flux_fit,
+                                        fit_params["w_r"],
+                                        fit_params["w_q0"],
+                                        fit_params["alpha"],
+                                        fit_params["phi0"],
+                                        fit_params["g"],
+                                        branch=+1.0,
+                                    )
+                                    lower_fit_Hz = avoided_crossing(
+                                        flux_fit,
+                                        fit_params["w_r"],
+                                        fit_params["w_q0"],
+                                        fit_params["alpha"],
+                                        fit_params["phi0"],
+                                        fit_params["g"],
+                                        branch=-1.0,
+                                    )
+
+                                    # Convert to full frequency and GHz
+                                    upper_fit_full_Hz = upper_fit_Hz + rf_freq_fallback
+                                    lower_fit_full_Hz = lower_fit_Hz + rf_freq_fallback
+                                    upper_fit_GHz = upper_fit_full_Hz / 1e9
+                                    lower_fit_GHz = lower_fit_full_Hz / 1e9
+
+                                    # Plot both branches of the fit curve
+                                    ax.plot(
+                                        flux_fit,
+                                        upper_fit_GHz,
+                                        color="pink",
+                                        linestyle="-",
+                                        linewidth=3,
+                                        alpha=0.8,
+                                        label=f"Avoided crossing fit #{i + 1} (upper)" if not i else "",
+                                        zorder=8,
+                                    )
+                                    ax.plot(
+                                        flux_fit,
+                                        lower_fit_GHz,
+                                        color="pink",
+                                        linestyle="-",
+                                        linewidth=3,
+                                        alpha=0.8,
+                                        label=f"Avoided crossing fit #{i + 1} (lower)" if not i else "",
+                                        zorder=8,
+                                    )
+                                except (KeyError, ValueError, TypeError) as e:
+                                    # Skip this fit if there's an error
+                                    continue
+
+                        except (KeyError, json.JSONDecodeError, AttributeError):
+                            # If fit parameters not available, skip plotting fits
+                            pass
+        except (KeyError, AttributeError, ValueError):
+            # Fit results not available, skip marking
+            pass
+
+    ax.set_title(display_name)
+    ax.set_xlabel("Coupler flux (V)")
+    ax.set_ylabel("Frequency (GHz)")
+    if ax.get_legend() is not None:
+        ax.legend(loc="best", fontsize=8)
+
+    return ax

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03c_qubit_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03c_qubit_spectroscopy_vs_coupler_flux.py
@@ -1,0 +1,343 @@
+# pylint: disable=duplicate-code
+"""Qubit spectroscopy vs coupler flux calibration."""
+
+# %% {Imports}
+from dataclasses import asdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from calibration_utils.qubit_spectroscopy_vs_coupler import (
+    Parameters,
+    fit_raw_data,
+    log_fitted_results,
+    plot_raw_data_with_fit,
+    process_raw_dataset,
+)
+from qm.qua import *
+from qualang_tools.loops import from_array
+from qualang_tools.multi_user import qm_session
+from qualang_tools.results import progress_counter
+from qualang_tools.units import unit
+from qualibrate import QualibrationNode
+from qualibration_libs.data import XarrayDataFetcher
+from qualibration_libs.parameters import get_qubit_pairs
+from qualibration_libs.runtime import simulate_and_plot
+from quam_config import Quam
+
+
+# %% {Description}
+description = """
+        QUBIT SPECTROSCOPY VERSUS COUPLER FLUX
+This sequence involves doing a qubit spectroscopy for several coupler flux biases in order to exhibit the qubit frequency
+versus coupler flux response.
+
+Prerequisites:
+    - Having calibrated the mixer or the Octave (nodes 01a or 01b).
+    - Having calibrated the readout parameters (nodes 02a, 02b and/or 02c).
+    - Having calibrated the qubit frequency (node 03a_qubit_spectroscopy.py).
+    - Having specified the desired flux point (qubit.z.flux_point).
+
+State update:
+    - Records the snapshot index in qubit extras under the key "{coupler_name}_dispersion_load_id"
+      for traceability. Avoided crossing positions are logged but not automatically applied to state.
+"""
+
+
+node = QualibrationNode[Parameters, Quam](
+    name="03c_qubit_spectroscopy_vs_coupler_flux",
+    description=description,
+    parameters=Parameters(),
+)
+
+
+# Any parameters that should change for debugging purposes only should go in here
+# These parameters are ignored when run through the GUI or as part of a graph
+@node.run_action(skip_if=node.modes.external)
+def custom_param(node: QualibrationNode[Parameters, Quam]):
+    """Allow the user to locally set the node parameters."""
+    # You can get type hinting in your IDE by typing node.parameters.
+    # node.parameters.qubit_pairs = ["coupler_q1_q2"]
+    pass
+
+
+# Instantiate the QUAM class from the state file
+node.machine = Quam.load()
+
+
+# %% {Create_QUA_program}
+@node.run_action(skip_if=node.parameters.load_data_id is not None)
+def create_qua_program(
+    node: QualibrationNode[Parameters, Quam]
+):  # pylint: disable=too-many-branches,too-many-statements
+    """Create the sweep axes and generate the QUA program from the pulse sequence and the node parameters."""
+    # Class containing tools to help handle units and conversions.
+    u = unit(coerce_to_integer=True)
+    # Get the active qubit pairs from the node and organize them by batches
+    node.namespace["qubit_pairs"] = qubit_pairs = get_qubit_pairs(node)
+    num_qubit_pairs = len(qubit_pairs)
+
+    # Extract the measured qubits based on measure_qubit parameter
+    measured_qubits = []
+    for qp in qubit_pairs:
+        if node.parameters.measure_qubit == "control":
+            measured_qubits.append(qp.qubit_control)
+        else:
+            measured_qubits.append(qp.qubit_target)
+    node.namespace["measured_qubits"] = measured_qubits
+    # Also set in qubits for compatibility with utility functions
+    node.namespace["qubits"] = measured_qubits
+
+    operation = node.parameters.operation  # The qubit operation to play
+    n_avg = node.parameters.num_shots
+    # Adjust the pulse duration and amplitude to drive the qubit into a mixed state - can be None
+    operation_len = node.parameters.operation_len_in_ns
+    # pre-factor to the value defined in the config - restricted to [-2; 2)
+    operation_amp = node.parameters.operation_amplitude_factor
+    # Qubit detuning sweep with respect to their resonance frequencies
+    span = node.parameters.frequency_span_in_mhz * u.MHz
+    step = node.parameters.frequency_step_in_mhz * u.MHz
+    dfs = np.arange(-span / 2, +span / 2, step)
+    # Flux bias sweep in V
+    min_flux = node.parameters.min_flux_in_v * u.V
+    max_flux = node.parameters.max_flux_in_v * u.V
+    num = node.parameters.num_flux_points
+    dcs = np.linspace(min_flux, max_flux, num)
+    # Buffer time for flux to wait (in unit of clock cycle)
+    settle_t = node.parameters.settle_time_in_ns // 4
+    buffer_t = node.parameters.buffer_time_in_ns // 4
+
+    # Register the sweep axes to be added to the dataset when fetching data
+    node.namespace["sweep_axes"] = {
+        "qubit_pair": xr.DataArray(qubit_pairs.get_names()),
+        "detuning": xr.DataArray(dfs, attrs={"long_name": "qubit frequency", "units": "Hz"}),
+        "flux_bias": xr.DataArray(dcs, attrs={"long_name": "flux bias", "units": "V"}),
+    }
+
+    with program() as node.namespace["qua_program"]:
+        I, I_st, Q, Q_st, n, n_st = node.machine.declare_qua_variables(num_IQ_pairs=num_qubit_pairs)
+        df = declare(int)  # QUA variable for the qubit frequency
+        dc = declare(fixed)  # QUA variable for the flux dc level
+
+        for multiplexed_qubit_pairs in qubit_pairs.batch():
+            # Initialize the QPU in terms of flux points (flux tunable transmons and/or tunable couplers)
+            for qp in multiplexed_qubit_pairs.values():
+                node.machine.initialize_qpu(target=qp.qubit_control)
+                node.machine.initialize_qpu(target=qp.qubit_target)
+            align()
+
+            # Pre-compute which qubit to drive/measure for each pair in this batch
+            measured_qubits_map = {
+                ii: qp.qubit_control if node.parameters.measure_qubit == "control" else qp.qubit_target
+                for ii, qp in multiplexed_qubit_pairs.items()
+            }
+
+            with for_(n, 0, n < n_avg, n + 1):
+                save(n, n_st)
+                with for_(*from_array(df, dfs)):
+                    with for_(*from_array(dc, dcs)):
+                        for ii, _ in multiplexed_qubit_pairs.items():
+                            measured_qubit = measured_qubits_map[ii]
+                            # Update the qubit frequency
+                            measured_qubit.xy.update_frequency(df + measured_qubit.xy.intermediate_frequency)
+                            # Wait for the qubits to decay to the ground state
+                            measured_qubit.reset_qubit_thermal()
+                            # Compute operation duration
+                            duration = (
+                                operation_len * u.ns
+                                if operation_len is not None
+                                else measured_qubit.xy.operations[operation].length * u.ns
+                            ) // 4
+                        align()
+
+                        # Qubit manipulation
+                        for ii, qp in multiplexed_qubit_pairs.items():
+                            measured_qubit = measured_qubits_map[ii]
+                            # Bring the qubit to the desired point during the saturation pulse
+                            qp.coupler.play(
+                                "const",
+                                amplitude_scale=dc / qp.coupler.operations["const"].amplitude,
+                                duration=duration + settle_t + buffer_t,
+                            )
+                            measured_qubit.xy.wait(settle_t)
+                            # Apply saturation pulse to the measured qubit
+                            measured_qubit.xy.play(
+                                operation,
+                                amplitude_scale=operation_amp,
+                                duration=duration,
+                            )
+                        align()
+
+                        # Qubit readout - only measure the selected qubit
+                        for ii, _ in multiplexed_qubit_pairs.items():
+                            measured_qubit = measured_qubits_map[ii]
+                            measured_qubit.resonator.wait(50)
+                            measured_qubit.resonator.measure("readout", qua_vars=(I[ii], Q[ii]))
+                            # save data
+                            save(I[ii], I_st[ii])
+                            save(Q[ii], Q_st[ii])
+                        align()
+
+        with stream_processing():
+            n_st.save("n")
+            for i in range(num_qubit_pairs):
+                I_st[i].buffer(len(dcs)).buffer(len(dfs)).average().save(f"I{i + 1}")
+                Q_st[i].buffer(len(dcs)).buffer(len(dfs)).average().save(f"Q{i + 1}")
+
+
+# %% {Simulate}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or not node.parameters.simulate)
+def simulate_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Connect to the QOP and simulate the QUA program"""
+    # Connect to the QOP
+    qmm = node.machine.connect()
+    # Get the config from the machine
+    config = node.machine.generate_config()
+    # Simulate the QUA program, generate the waveform report and plot the simulated samples
+    samples, fig, wf_report = simulate_and_plot(qmm, config, node.namespace["qua_program"], node.parameters)
+    # Store the figure, waveform report and simulated samples
+    node.results["simulation"] = {"figure": fig, "wf_report": wf_report, "samples": samples}
+
+
+# %% {Execute}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or node.parameters.simulate)
+def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """
+    Connect to the QOP, execute the QUA program and fetch the raw data
+    and store it in a xarray dataset called "ds_raw".
+    """
+    # Connect to the QOP
+    qmm = node.machine.connect()
+    # Get the config from the machine
+    config = node.machine.generate_config()
+    # Execute the QUA program only if the quantum machine is available (this is to avoid interrupting running jobs).
+    with qm_session(qmm, config, timeout=node.parameters.timeout) as qm:
+        # The job is stored in the node namespace to be reused in the fetching_data run_action
+        node.namespace["job"] = job = qm.execute(node.namespace["qua_program"])
+        # Display the progress bar
+        data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
+        for dataset in data_fetcher:
+            progress_counter(
+                data_fetcher.get("n", 0),
+                node.parameters.num_shots,
+                start_time=data_fetcher.t_start,
+            )
+        # Display the execution report to expose possible runtime errors
+        node.log(job.execution_report())
+    # Register the raw dataset
+    # Rename qubit_pair dimension to qubit for compatibility with analysis functions
+    # Use unique pair names as coordinate values to avoid duplicates when multiple
+    # pairs share the same measured qubit (e.g. q3 in q0-3, q3-4, q3-6).
+    if "qubit_pair" in dataset.dims:
+        qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
+        measured_qubit_names = [q.name for q in node.namespace["measured_qubits"]]
+        dataset = dataset.rename({"qubit_pair": "qubit"})
+        dataset = dataset.assign_coords(qubit=qubit_pair_names)
+        dataset = dataset.assign_coords(measured_qubit_name=("qubit", measured_qubit_names))
+    node.results["ds_raw"] = dataset
+
+
+# %% {Load_historical_data}
+@node.run_action(skip_if=node.parameters.load_data_id is None)
+def load_data(node: QualibrationNode[Parameters, Quam]):
+    """Load a previously acquired dataset."""
+    load_data_id = node.parameters.load_data_id
+    # Load the specified dataset
+    node.load_from_id(node.parameters.load_data_id)
+    node.parameters.load_data_id = load_data_id
+    # Get the active qubit pairs from the loaded node parameters
+    node.namespace["qubit_pairs"] = get_qubit_pairs(node)
+    # Extract measured qubits
+    measured_qubits = []
+    for qp in node.namespace["qubit_pairs"]:
+        if node.parameters.measure_qubit == "control":
+            measured_qubits.append(qp.qubit_control)
+        else:
+            measured_qubits.append(qp.qubit_target)
+    node.namespace["measured_qubits"] = measured_qubits
+    node.namespace["qubits"] = measured_qubits
+    # Rename qubit_pair dimension to qubit for compatibility with analysis functions
+    # Use unique pair names as coordinate values (see execute_qua_program for rationale)
+    if "qubit_pair" in node.results["ds_raw"].dims:
+        qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
+        measured_qubit_names = [q.name for q in measured_qubits]
+        node.results["ds_raw"] = node.results["ds_raw"].rename({"qubit_pair": "qubit"})
+        node.results["ds_raw"] = node.results["ds_raw"].assign_coords(qubit=qubit_pair_names)
+        node.results["ds_raw"] = node.results["ds_raw"].assign_coords(
+            measured_qubit_name=("qubit", measured_qubit_names)
+        )
+
+
+# %% {Analyse_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def analyse_data(node: QualibrationNode[Parameters, Quam]):
+    """
+    Analyse the raw data and store the fitted data in another xarray dataset "ds_fit"
+    and the fitted results in the "fit_results" dictionary.
+    """
+    # Ensure qubits namespace is set for utility functions
+    if "qubits" not in node.namespace:
+        node.namespace["qubits"] = node.namespace["measured_qubits"]
+
+    node.results["ds_raw"] = process_raw_dataset(node.results["ds_raw"], node)
+    node.results["ds_fit"], fit_results = fit_raw_data(node.results["ds_raw"], node)
+    node.results["fit_results"] = {k: asdict(v) for k, v in fit_results.items()}
+
+    # Log the relevant information extracted from the data analysis
+    log_fitted_results(node.results["fit_results"], log_callable=node.log)
+    # Map outcomes to qubit_pair names for state update
+    # fit_results is now keyed by pair name (unique), not measured qubit name
+    qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
+    node.outcomes = {
+        qp_name: node.results["fit_results"].get(qp_name, {}).get("success", False)
+        for qp_name in qubit_pair_names
+    }
+    # Convert boolean outcomes to "successful"/"failed" strings
+    node.outcomes = {k: ("successful" if v else "failed") for k, v in node.outcomes.items()}
+
+
+# %% {Plot_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def plot_data(node: QualibrationNode[Parameters, Quam]):
+    """Plot the raw and fitted data in specific figures whose shape is given by qubit.grid_location."""
+    # Ensure qubits namespace is set for utility functions
+    if "qubits" not in node.namespace:
+        node.namespace["qubits"] = node.namespace["measured_qubits"]
+
+    fig_raw_fit = plot_raw_data_with_fit(
+        node.results["ds_raw"], node.namespace["qubit_pairs"], node.results["ds_fit"],
+    )
+    plt.show()
+    # Store the generated figures
+    node.results["figures"] = {
+        "amplitude": fig_raw_fit,
+    }
+
+
+# %% {Update_state}
+@node.run_action(skip_if=node.parameters.simulate)
+def update_state(node: QualibrationNode[Parameters, Quam]):
+    """Update the relevant parameters if the qubit data analysis was successful."""
+    with node.record_state_updates():
+        for qp in node.namespace["qubit_pairs"]:
+            measured_qubit_name = (
+                qp.qubit_control.name if node.parameters.measure_qubit == "control" else qp.qubit_target.name
+            )
+            node.machine.qubits[measured_qubit_name].extras[f"{qp.coupler.name}_dispersion_load_id"] = node.snapshot_idx
+            if node.outcomes[qp.name] == "failed":
+                continue
+            # fit_results = node.results["fit_results"][measured_qubit_name]
+            # Store avoided crossing positions for reference
+            # The avoided crossings are recorded but not automatically used to update state
+            # This allows the user to manually inspect and decide how to use them
+            # Example: could store in qubit metadata or coupler configuration
+
+
+# %% {Save_results}
+@node.run_action()
+def save_results(node: QualibrationNode[Parameters, Quam]):
+    """Save the calibration results."""
+    node.save()
+
+
+# %%

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03c_qubit_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03c_qubit_spectroscopy_vs_coupler_flux.py
@@ -25,7 +25,6 @@ from qualibration_libs.parameters import get_qubit_pairs
 from qualibration_libs.runtime import simulate_and_plot
 from quam_config import Quam
 
-
 # %% {Description}
 description = """
         QUBIT SPECTROSCOPY VERSUS COUPLER FLUX
@@ -68,7 +67,7 @@ node.machine = Quam.load()
 # %% {Create_QUA_program}
 @node.run_action(skip_if=node.parameters.load_data_id is not None)
 def create_qua_program(
-    node: QualibrationNode[Parameters, Quam]
+    node: QualibrationNode[Parameters, Quam],
 ):  # pylint: disable=too-many-branches,too-many-statements
     """Create the sweep axes and generate the QUA program from the pulse sequence and the node parameters."""
     # Class containing tools to help handle units and conversions.
@@ -289,8 +288,7 @@ def analyse_data(node: QualibrationNode[Parameters, Quam]):
     # fit_results is now keyed by pair name (unique), not measured qubit name
     qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
     node.outcomes = {
-        qp_name: node.results["fit_results"].get(qp_name, {}).get("success", False)
-        for qp_name in qubit_pair_names
+        qp_name: node.results["fit_results"].get(qp_name, {}).get("success", False) for qp_name in qubit_pair_names
     }
     # Convert boolean outcomes to "successful"/"failed" strings
     node.outcomes = {k: ("successful" if v else "failed") for k, v in node.outcomes.items()}
@@ -305,7 +303,9 @@ def plot_data(node: QualibrationNode[Parameters, Quam]):
         node.namespace["qubits"] = node.namespace["measured_qubits"]
 
     fig_raw_fit = plot_raw_data_with_fit(
-        node.results["ds_raw"], node.namespace["qubit_pairs"], node.results["ds_fit"],
+        node.results["ds_raw"],
+        node.namespace["qubit_pairs"],
+        node.results["ds_fit"],
     )
     plt.show()
     # Store the generated figures

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03c_qubit_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03c_qubit_spectroscopy_vs_coupler_flux.py
@@ -56,7 +56,6 @@ node = QualibrationNode[Parameters, Quam](
 def custom_param(node: QualibrationNode[Parameters, Quam]):
     """Allow the user to locally set the node parameters."""
     # You can get type hinting in your IDE by typing node.parameters.
-    # node.parameters.qubit_pairs = ["coupler_q1_q2"]
     pass
 
 
@@ -130,12 +129,14 @@ def create_qua_program(
                 ii: qp.qubit_control if node.parameters.measure_qubit == "control" else qp.qubit_target
                 for ii, qp in multiplexed_qubit_pairs.items()
             }
+            # Pre-compute the operation durations for each qubit pair
             operation_durations = {
                 ii: (
                     operation_len * u.ns
                     if operation_len is not None
                     else measured_qubits_map[ii].xy.operations[operation].length * u.ns
-                ) // 4
+                )
+                // 4
                 for ii in multiplexed_qubit_pairs
             }
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03c_qubit_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03c_qubit_spectroscopy_vs_coupler_flux.py
@@ -130,6 +130,14 @@ def create_qua_program(
                 ii: qp.qubit_control if node.parameters.measure_qubit == "control" else qp.qubit_target
                 for ii, qp in multiplexed_qubit_pairs.items()
             }
+            operation_durations = {
+                ii: (
+                    operation_len * u.ns
+                    if operation_len is not None
+                    else measured_qubits_map[ii].xy.operations[operation].length * u.ns
+                ) // 4
+                for ii in multiplexed_qubit_pairs
+            }
 
             with for_(n, 0, n < n_avg, n + 1):
                 save(n, n_st)
@@ -141,12 +149,6 @@ def create_qua_program(
                             measured_qubit.xy.update_frequency(df + measured_qubit.xy.intermediate_frequency)
                             # Wait for the qubits to decay to the ground state
                             measured_qubit.reset_qubit_thermal()
-                            # Compute operation duration
-                            duration = (
-                                operation_len * u.ns
-                                if operation_len is not None
-                                else measured_qubit.xy.operations[operation].length * u.ns
-                            ) // 4
                         align()
 
                         # Qubit manipulation
@@ -156,14 +158,14 @@ def create_qua_program(
                             qp.coupler.play(
                                 "const",
                                 amplitude_scale=dc / qp.coupler.operations["const"].amplitude,
-                                duration=duration + settle_t + buffer_t,
+                                duration=operation_durations[ii] + settle_t + buffer_t,
                             )
                             measured_qubit.xy.wait(settle_t)
                             # Apply saturation pulse to the measured qubit
                             measured_qubit.xy.play(
                                 operation,
                                 amplitude_scale=operation_amp,
-                                duration=duration,
+                                duration=operation_durations[ii],
                             )
                         align()
 


### PR DESCRIPTION
Summary:

1. Adds 03c_qubit_spectroscopy_vs_coupler_flux.py, a new calibration node that sweeps qubit saturation spectroscopy over coupler flux bias for all qubit pairs, mapping out qubit frequency vs coupler flux and detecting avoided crossings.

2. Adds supporting utilities under calibration_utils/qubit_spectroscopy_vs_coupler/ (analysis, plotting, parameters).

Why:

Qubit frequency shifts with coupler flux due to dispersive coupling between the qubit and coupler modes. Measuring this dependence and locating avoided crossings is necessary to characterise idle and interaction points of the coupler, and to understand how much the qubit frequency is pulled at different coupler operating points.

Implementation notes:

1. Avoided crossing detection uses a derivative-based approach on the smoothed peak frequency curve, followed by a local hyperbolic fit with EM-style branch assignment to extract the crossing flux position, bare frequencies, and coupling strength g.
2. Plotting uses QubitPairGrid (from calibration_utils/pair_grid.py) to position coupler subplots in a topology-aware chip layout view — same approach as 02d (PR #515). This object should eventually move to qualibration_libs. 