### PR TITLE
Decoupling flux calibration via zero of residual ZZ coupling using JAZZ sequence 

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/__init__.py
@@ -2,7 +2,7 @@
 
 from .analysis import FitResults, damped_cosine, fit_raw_data, log_fitted_results, process_raw_dataset
 from .parameters import Parameters
-from .plotting import plot_oscillation_data, plot_raw_data_with_fit, plot_decay_rate_data
+from .plotting import plot_decay_rate_data, plot_effective_coupling, plot_fit_data, plot_raw_data
 
 __all__ = [
     "Parameters",
@@ -11,7 +11,8 @@ __all__ = [
     "log_fitted_results",
     "FitResults",
     "damped_cosine",
-    "plot_raw_data_with_fit",
-    "plot_oscillation_data",
+    "plot_effective_coupling",
     "plot_decay_rate_data",
+    "plot_raw_data",
+    "plot_fit_data",
 ]

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/__init__.py
@@ -1,0 +1,17 @@
+"""Utility functions and parameters for the JAZZ_ZZ calibration node."""
+
+from .analysis import FitResults, damped_cosine, fit_raw_data, log_fitted_results, process_raw_dataset
+from .parameters import Parameters
+from .plotting import plot_oscillation_data, plot_raw_data_with_fit, plot_decay_rate_data
+
+__all__ = [
+    "Parameters",
+    "process_raw_dataset",
+    "fit_raw_data",
+    "log_fitted_results",
+    "FitResults",
+    "damped_cosine",
+    "plot_raw_data_with_fit",
+    "plot_oscillation_data",
+    "plot_decay_rate_data",
+]

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/analysis.py
@@ -121,10 +121,10 @@ def fit_jazz_zz_routine(da, node):  # pylint: disable=too-many-statements
     xr.DataArray
         Data array with added fit results
     """
-    if hasattr(da, "state_target"):
-        data = "state_target"
+    if hasattr(da, "state_measured"):
+        data = "state_measured"
     else:
-        data = "I_target"
+        data = "I_measured"
 
     # Extract the data matrix with time along axis 0, amplitude along axis 1
     signal_da = da[data].squeeze()

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/analysis.py
@@ -208,7 +208,7 @@ def fit_jazz_zz_routine(da, node):  # pylint: disable=too-many-statements
 
     # Fit a damped cosine to the oscillation vs t_single for each coupler amplitude.
     # Extracted frequency ωm = ζ + ωb  →  stored as jeff_raw  (see module docstring).
-    jeff_raw = []   # ωm = ζ + ωb [MHz]
+    jeff_raw = []  # ωm = ζ + ωb [MHz]
     gamma_raw = []  # γ [1/µs]
     fit_mask = []
     fitted_matrix = np.full(data_matrix.shape, np.nan)
@@ -225,7 +225,7 @@ def fit_jazz_zz_routine(da, node):  # pylint: disable=too-many-statements
                 # bounds=([-np.inf, -np.inf, -np.inf, -np.pi, -np.inf], [np.inf, np.inf, np.inf, np.pi, np.inf]),
                 maxfev=5000,
             )
-            freq_mhz = popt[2]   # ωm [MHz] = ζ + ωb  (stored as jeff_raw)
+            freq_mhz = popt[2]  # ωm [MHz] = ζ + ωb  (stored as jeff_raw)
             gamma_mhz = popt[1]  # γ [1/µs]
             jeff_raw.append(freq_mhz)
             gamma_raw.append(gamma_mhz)

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/analysis.py
@@ -1,4 +1,71 @@
-"""Analysis functions for JAZZ_ZZ calibration: fitting and extracting effective ZZ coupling."""
+"""Analysis functions for JAZZ_ZZ calibration: fitting and extracting residual ZZ coupling.
+
+Reference: arXiv:2402.18926 — Li et al., "Realization of High-Fidelity CZ Gate based on a
+Double-Transmon Coupler", Sec. III.1.
+
+JAZZ pulse sequence (as implemented in 19_zz_off_jazz.py)
+---------------------------------------------------------
+The ZZ Hamiltonian is H_ZZ = (ζ/4) σz¹σz², so the phase rate seen by Q1's superposition
+depends on Q2's state:
+    Q2 = |0⟩  →  phase rate = −ζ/2  (σz eigenvalue = +1 for |0⟩)
+    Q2 = |1⟩  →  phase rate = +ζ/2  (σz eigenvalue = −1 for |1⟩)
+ZZ is ALWAYS active; only its sign changes with Q2's state. The purpose of the echo
+is NOT to switch ZZ on — it is to cancel single-qubit phase offsets while keeping
+both ZZ contributions accumulating in the same direction.
+
+Step 1 — x90 on Q1 (measured qubit):
+    Q1 is prepared in superposition |+⟩ = (|0⟩ + |1⟩) / √2.
+    Q2 is in |0⟩ after reset.
+
+Step 2 — First coupler pulse for duration t_single:
+    Q2 is in |0⟩. ZZ is active with rate −ζ/2.
+    Phase accumulated on Q1:  φ₁ = −(ζ/2) · t_single.
+
+Step 3 — x180 echo on both Q1 and Q2:
+    Xπ on Q1: inverts the sign of the already-accumulated phase (φ₁ → +ζ/2 · t_single).
+    Xπ on Q2: flips Q2 from |0⟩ → |1⟩, switching the ZZ rate from −ζ/2 to +ζ/2.
+    Combined effect: single-qubit phase offsets (bare qubit frequencies etc.) cancel,
+    while the ZZ phase from step 2 and step 5 accumulate additively.
+
+Step 4 — Frame rotation on Q1 by ωb · t_single  (artificial detuning):
+    An intentional phase ωb · t_single is added to Q1's rotating frame, where
+    ωb = artificial_detuning_in_mhz [MHz].
+    This shifts the oscillation away from DC so the fitting is more reliable.
+    Necessary because ζ near the idle point is tiny (~kHz), giving a very slow
+    oscillation that is hard to resolve within the qubit coherence time.
+
+Step 5 — Second coupler pulse for duration t_single:
+    Q2 is now in |1⟩. ZZ is active with rate +ζ/2.
+    Phase accumulated on Q1:  φ₂ = +(ζ/2) · t_single.
+
+Step 6 — x90 on Q1 → measure:
+    Population oscillates as  P = (1 − cos φ) / 2.
+
+Phase and frequency summary
+---------------------------
+Both intervals contribute ZZ phase in the same direction after the echo:
+    φ_ZZ = (ζ/2)·t_single  +  (ζ/2)·t_single  =  ζ · t_single
+
+Total phase including artificial detuning:
+    φ = ζ · t_single + ωb · t_single = (ζ + ωb) · t_single
+
+Fitting  cos(2π · ωm · t_single)  to the signal gives:
+    ωm = ζ + ωb                          ← stored as ``jeff_raw`` [MHz]
+
+True residual ZZ coupling:
+    ζ = ωm − ωb = jeff_raw − artificial_detuning
+
+The optimal coupler amplitude is where |ζ| is minimised (ζ → 0),
+i.e. where  jeff_raw ≈ artificial_detuning.
+
+Variable reference
+------------------
+``jeff_raw``   = ωm = ζ + ωb  [MHz]  (measured oscillation frequency, NOT ζ itself)
+``jeff_smooth``                        (Savitzky–Golay smoothed version of jeff_raw)
+``gamma_raw``  = γ  [1/µs]    (decay rate of the damped cosine envelope)
+``tau_raw``    = τ = 1/γ [µs] (decay time constant)
+residual       = |ζ| = |jeff_raw − artificial_detuning|  [MHz]
+"""
 
 import logging
 from dataclasses import dataclass
@@ -22,7 +89,14 @@ class FitResults:
 
 
 def damped_cosine(t, A, gamma, f, phi, C):  # pylint: disable=too-many-arguments,too-many-positional-arguments
-    """Damped cosine fitting function for JAZZ_ZZ oscillations."""
+    """Damped cosine fitting function for JAZZ_ZZ oscillations.
+
+    Args:
+        t     : t_single [µs]  — single coupler pulse duration (sweep axis)
+        f     : ωm [MHz]       — total oscillation frequency; ωm = ζ + ωb  (stored as jeff_raw)
+        gamma : γ [1/µs]       — decay rate of the oscillation envelope
+        A, phi, C              — amplitude, phase offset, vertical offset
+    """
     return A * np.exp(-gamma * t) * np.cos(2 * np.pi * f * t + phi) + C
 
 
@@ -130,11 +204,12 @@ def fit_jazz_zz_routine(da, node):  # pylint: disable=too-many-statements
     signal_da = da[data].squeeze()
     data_matrix = signal_da.transpose("time", "amp").values  # shape = (n_time, n_amp)
     flux_bias = da.amp.data  # amplitude values
-    time_us = da.time_us.data  # time in µs
+    time_us = da.time_us.data  # t_single [µs]: single coupler pulse duration (sweep axis)
 
-    # Extract J_eff and gamma (decay rate) from each flux slice
-    jeff_raw = []
-    gamma_raw = []
+    # Fit a damped cosine to the oscillation vs t_single for each coupler amplitude.
+    # Extracted frequency ωm = ζ + ωb  →  stored as jeff_raw  (see module docstring).
+    jeff_raw = []   # ωm = ζ + ωb [MHz]
+    gamma_raw = []  # γ [1/µs]
     fit_mask = []
     fitted_matrix = np.full(data_matrix.shape, np.nan)
 
@@ -150,8 +225,8 @@ def fit_jazz_zz_routine(da, node):  # pylint: disable=too-many-statements
                 # bounds=([-np.inf, -np.inf, -np.inf, -np.pi, -np.inf], [np.inf, np.inf, np.inf, np.pi, np.inf]),
                 maxfev=5000,
             )
-            freq_mhz = popt[2]
-            gamma_mhz = popt[1]  # decay rate
+            freq_mhz = popt[2]   # ωm [MHz] = ζ + ωb  (stored as jeff_raw)
+            gamma_mhz = popt[1]  # γ [1/µs]
             jeff_raw.append(freq_mhz)
             gamma_raw.append(gamma_mhz)
             fit_mask.append(True)
@@ -188,7 +263,7 @@ def fit_jazz_zz_routine(da, node):  # pylint: disable=too-many-statements
         gamma_smooth = gamma_raw.copy()
         tau_smooth = tau_raw.copy()
 
-    # Find optimal amplitude (closest to artificial_detuning_in_mhz to minimize coupling)
+    # Find the coupler amplitude where |ζ| = |ωm − ωb| is minimised (ζ → 0).
     valid_indices = np.where(fit_mask)[0]
     if len(valid_indices) > 0:
         coupling_deviation = np.abs(jeff_smooth[fit_mask] - node.parameters.artificial_detuning_in_mhz)
@@ -278,9 +353,15 @@ def _extract_relevant_parameters(
         ds_fit.fitted_state.attrs = {"long_name": "fitted oscillation", "units": "a.u."}
     ds_fit["artificial_detuning"] = node.parameters.artificial_detuning_in_mhz
     if "jeff_raw" in ds_fit.data_vars:
-        ds_fit.jeff_raw.attrs = {"long_name": "raw extracted effective coupling", "units": "MHz"}
+        ds_fit.jeff_raw.attrs = {
+            "long_name": "measured oscillation frequency",
+            "units": "MHz",
+        }
     if "jeff_smooth" in ds_fit.data_vars:
-        ds_fit.jeff_smooth.attrs = {"long_name": "smoothed effective coupling", "units": "MHz"}
+        ds_fit.jeff_smooth.attrs = {
+            "long_name": "smoothed oscillation frequency",
+            "units": "MHz",
+        }
     if "gamma_raw" in ds_fit.data_vars:
         ds_fit.gamma_raw.attrs = {"long_name": "raw extracted decay rate", "units": "MHz"}
     if "gamma_smooth" in ds_fit.data_vars:

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/analysis.py
@@ -7,7 +7,6 @@ from typing import Dict, Tuple
 import numpy as np
 import xarray as xr
 from qualibrate import QualibrationNode
-from qualibration_libs.analysis import fit_oscillation, oscillation
 from scipy.optimize import curve_fit
 from scipy.signal import savgol_filter
 
@@ -127,8 +126,9 @@ def fit_jazz_zz_routine(da, node):  # pylint: disable=too-many-statements
     else:
         data = "I_target"
 
-    # Extract the data matrix (time vs amplitude)
-    data_matrix = da[data].data[0].T  # shape = (n_time, n_amp)
+    # Extract the data matrix with time along axis 0, amplitude along axis 1
+    signal_da = da[data].squeeze()
+    data_matrix = signal_da.transpose("time", "amp").values  # shape = (n_time, n_amp)
     flux_bias = da.amp.data  # amplitude values
     time_us = da.time_us.data  # time in µs
 
@@ -136,6 +136,7 @@ def fit_jazz_zz_routine(da, node):  # pylint: disable=too-many-statements
     jeff_raw = []
     gamma_raw = []
     fit_mask = []
+    fitted_matrix = np.full(data_matrix.shape, np.nan)
 
     for i in range(data_matrix.shape[1]):
         ydata = data_matrix[:, i] - np.mean(data_matrix[:, i])
@@ -154,6 +155,7 @@ def fit_jazz_zz_routine(da, node):  # pylint: disable=too-many-statements
             jeff_raw.append(freq_mhz)
             gamma_raw.append(gamma_mhz)
             fit_mask.append(True)
+            fitted_matrix[:, i] = damped_cosine(time_us, *popt)
         except RuntimeError:
             jeff_raw.append(0.0)
             gamma_raw.append(0.0)
@@ -210,8 +212,16 @@ def fit_jazz_zz_routine(da, node):  # pylint: disable=too-many-statements
         max_decay_time_amplitude = np.nan
         success = False
 
+    # Match fitted_state dim order to the measured signal (typically amp, time)
+    fitted_state = xr.DataArray(
+        fitted_matrix,
+        dims=("time", "amp"),
+        coords={"time": da.time, "amp": da.amp},
+    ).transpose(*signal_da.dims)
+
     # Add results to data array
     da = da.assign(
+        fitted_state=fitted_state,
         jeff_raw=("amp", jeff_raw),
         jeff_smooth=("amp", jeff_smooth),
         gamma_raw=("amp", gamma_raw),
@@ -264,6 +274,9 @@ def _extract_relevant_parameters(
             "long_name": "amplitude at maximum decay time",
             "units": "a.u.",
         }
+    if "fitted_state" in ds_fit.data_vars:
+        ds_fit.fitted_state.attrs = {"long_name": "fitted oscillation", "units": "a.u."}
+    ds_fit["artificial_detuning"] = node.parameters.artificial_detuning_in_mhz
     if "jeff_raw" in ds_fit.data_vars:
         ds_fit.jeff_raw.attrs = {"long_name": "raw extracted effective coupling", "units": "MHz"}
     if "jeff_smooth" in ds_fit.data_vars:

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/analysis.py
@@ -1,0 +1,295 @@
+"""Analysis functions for JAZZ_ZZ calibration: fitting and extracting effective ZZ coupling."""
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import numpy as np
+import xarray as xr
+from qualibrate import QualibrationNode
+from qualibration_libs.analysis import fit_oscillation, oscillation
+from scipy.optimize import curve_fit
+from scipy.signal import savgol_filter
+
+
+@dataclass
+class FitResults:
+    """Stores the relevant JAZZ_ZZ experiment fit parameters for a single qubit pair"""
+
+    optimal_amplitude: float
+    max_decay_time: float  # maximum decay time constant (1/gamma) in µs
+    max_decay_time_amplitude: float  # amplitude where max decay time occurs
+    success: bool
+
+
+def damped_cosine(t, A, gamma, f, phi, C):  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    """Damped cosine fitting function for JAZZ_ZZ oscillations."""
+    return A * np.exp(-gamma * t) * np.cos(2 * np.pi * f * t + phi) + C
+
+
+def log_fitted_results(fit_results: Dict[str, FitResults], log_callable=None):
+    """
+    Logs the JAZZ_ZZ fitted results for all qubit pairs.
+
+    Parameters:
+    -----------
+    fit_results : Dict[str, FitResults]
+        Dictionary containing FitResults for each qubit pair.
+    log_callable : callable, optional
+        Logger for logging the fitted results. If None, a default logger is used.
+    """
+    if log_callable is None:
+        log_callable = logging.getLogger(__name__).info
+
+    for qp_name, fit_result in fit_results.items():
+        s_qubit = f"Results for qubit pair {qp_name}: "
+        s_amp = f"\tOptimal JAZZ_ZZ amplitude for minimum coupling: {fit_result.optimal_amplitude:.6f} a.u."
+        s_tau = (
+            f"\tMaximum decay time constant: {fit_result.max_decay_time:.6f} µs "
+            f"at amplitude {fit_result.max_decay_time_amplitude:.6f} a.u."
+        )
+
+        if fit_result.success:
+            s_qubit += "SUCCESS!\n"
+        else:
+            s_qubit += "FAIL!\n"
+
+        log_message = s_qubit + s_amp + "\n" + s_tau
+
+        log_callable(log_message)
+
+
+def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
+    """
+    Process the raw dataset for JAZZ_ZZ analysis.
+
+    Parameters:
+    -----------
+    ds : xr.Dataset
+        Raw dataset from the experiment
+    node : QualibrationNode
+        The calibration node containing qubit pairs information
+
+    Returns:
+    --------
+    xr.Dataset
+        Processed dataset with additional coordinates
+    """
+    # Convert time from ns to µs for fitting
+    time_us = ds.time.data * 1e-3
+    ds = ds.assign_coords(time_us=("time", time_us))
+
+    return ds
+
+
+def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, Dict[str, FitResults]]:
+    """
+    Fit the JAZZ_ZZ data by extracting effective coupling J_eff from oscillations.
+
+    Parameters:
+    -----------
+    ds : xr.Dataset
+        Dataset containing the processed data.
+    node : QualibrationNode
+        The calibration node containing parameters and qubit pairs.
+
+    Returns:
+    --------
+    Tuple[xr.Dataset, Dict[str, FitResults]]
+        Dataset with fit results and dictionary of fit results for each qubit pair.
+    """
+    ds_fit = ds.groupby("qubit_pair").apply(lambda da: fit_jazz_zz_routine(da, node))
+
+    # Extract the relevant fitted parameters
+    ds_fit, fit_results = _extract_relevant_parameters(ds_fit, node)
+
+    return ds_fit, fit_results
+
+
+def fit_jazz_zz_routine(da, node):  # pylint: disable=too-many-statements
+    """
+    Extract effective coupling J_eff from JAZZ_ZZ oscillations for each amplitude.
+
+    Parameters:
+    -----------
+    da : xr.DataArray
+        Data array containing the oscillation data
+    node : QualibrationNode
+        The calibration node containing parameters
+
+    Returns:
+    --------
+    xr.DataArray
+        Data array with added fit results
+    """
+    if hasattr(da, "state_target"):
+        data = "state_target"
+    else:
+        data = "I_target"
+
+    # Extract the data matrix (time vs amplitude)
+    data_matrix = da[data].data[0].T  # shape = (n_time, n_amp)
+    flux_bias = da.amp.data  # amplitude values
+    time_us = da.time_us.data  # time in µs
+
+    # Extract J_eff and gamma (decay rate) from each flux slice
+    jeff_raw = []
+    gamma_raw = []
+    fit_mask = []
+
+    for i in range(data_matrix.shape[1]):
+        ydata = data_matrix[:, i] - np.mean(data_matrix[:, i])
+
+        try:
+            popt, _ = curve_fit(
+                damped_cosine,
+                time_us,
+                ydata,
+                p0=[0.3, 1.0, 5.0, 0.0, 0.0],
+                # bounds=([-np.inf, -np.inf, -np.inf, -np.pi, -np.inf], [np.inf, np.inf, np.inf, np.pi, np.inf]),
+                maxfev=5000,
+            )
+            freq_mhz = popt[2]
+            gamma_mhz = popt[1]  # decay rate
+            jeff_raw.append(freq_mhz)
+            gamma_raw.append(gamma_mhz)
+            fit_mask.append(True)
+        except RuntimeError:
+            jeff_raw.append(0.0)
+            gamma_raw.append(0.0)
+            fit_mask.append(False)
+
+    jeff_raw = np.array(jeff_raw)
+    gamma_raw = np.array(gamma_raw)
+    fit_mask = np.array(fit_mask)
+
+    # Calculate decay time constants (τ = 1/γ) in microseconds
+    # Convert gamma from MHz to 1/µs: τ = 1/γ [µs] = 1/(γ [MHz])
+    tau_raw = np.zeros_like(gamma_raw)
+    tau_raw[fit_mask & (gamma_raw > 0)] = 1.0 / gamma_raw[fit_mask & (gamma_raw > 0)]
+
+    # Smooth only the valid (nonzero) portion if there are enough valid points
+    if np.sum(fit_mask) >= 5:  # Need at least 5 points for window_length=5
+        jeff_smooth = np.zeros_like(jeff_raw)
+        gamma_smooth = np.zeros_like(gamma_raw)
+        tau_smooth = np.zeros_like(tau_raw)
+        jeff_smooth[fit_mask] = savgol_filter(jeff_raw[fit_mask], window_length=5, polyorder=3)
+        gamma_smooth[fit_mask] = savgol_filter(gamma_raw[fit_mask], window_length=5, polyorder=3)
+        # For tau, only smooth valid positive values
+        valid_tau_mask = fit_mask & (tau_raw > 0)
+        if np.sum(valid_tau_mask) >= 5:
+            tau_smooth[valid_tau_mask] = savgol_filter(tau_raw[valid_tau_mask], window_length=5, polyorder=3)
+        else:
+            tau_smooth = tau_raw.copy()
+    else:
+        jeff_smooth = jeff_raw.copy()
+        gamma_smooth = gamma_raw.copy()
+        tau_smooth = tau_raw.copy()
+
+    # Find optimal amplitude (closest to artificial_detuning_in_mhz to minimize coupling)
+    valid_indices = np.where(fit_mask)[0]
+    if len(valid_indices) > 0:
+        coupling_deviation = np.abs(jeff_smooth[fit_mask] - node.parameters.artificial_detuning_in_mhz)
+        min_coupling_idx = valid_indices[np.argmin(coupling_deviation)]
+        optimal_amplitude = flux_bias[min_coupling_idx]
+
+        # Find maximum decay time constant
+        valid_tau_indices = np.where(fit_mask & (tau_smooth > 0))[0]
+        if len(valid_tau_indices) > 0:
+            max_tau_idx = valid_tau_indices[np.argmax(tau_smooth[valid_tau_indices])]
+            max_decay_time = tau_smooth[max_tau_idx]
+            max_decay_time_amplitude = flux_bias[max_tau_idx]
+        else:
+            max_decay_time = np.nan
+            max_decay_time_amplitude = np.nan
+
+        success = True
+    else:
+        optimal_amplitude = np.nan
+        max_decay_time = np.nan
+        max_decay_time_amplitude = np.nan
+        success = False
+
+    # Add results to data array
+    da = da.assign(
+        jeff_raw=("amp", jeff_raw),
+        jeff_smooth=("amp", jeff_smooth),
+        gamma_raw=("amp", gamma_raw),
+        gamma_smooth=("amp", gamma_smooth),
+        tau_raw=("amp", tau_raw),
+        tau_smooth=("amp", tau_smooth),
+        fit_mask=("amp", fit_mask),
+        optimal_amplitude=optimal_amplitude,
+        max_decay_time=max_decay_time,
+        max_decay_time_amplitude=max_decay_time_amplitude,
+        success=success,
+    )
+
+    return da
+
+
+def _extract_relevant_parameters(
+    ds_fit: xr.Dataset, node: QualibrationNode
+) -> Tuple[xr.Dataset, Dict[str, FitResults]]:
+    """
+    Extract relevant fit parameters and create FitResults for each qubit pair.
+
+    Parameters:
+    -----------
+    ds_fit : xr.Dataset
+        Dataset containing the fit results from fit_jazz_zz_routine.
+    node : QualibrationNode
+        The calibration node containing parameters and qubit pairs.
+
+    Returns:
+    --------
+    Tuple[xr.Dataset, Dict[str, FitResults]]
+        Dataset with additional metadata and dictionary of FitResults for each qubit pair.
+    """
+    qubit_pairs = node.namespace["qubit_pairs"]
+
+    # Add metadata attributes to the dataset
+    if "optimal_amplitude" in ds_fit.data_vars:
+        ds_fit.optimal_amplitude.attrs = {
+            "long_name": "optimal JAZZ_ZZ amplitude for minimum coupling",
+            "units": "a.u.",
+        }
+    if "max_decay_time" in ds_fit.data_vars:
+        ds_fit.max_decay_time.attrs = {
+            "long_name": "maximum decay time constant",
+            "units": "µs",
+        }
+    if "max_decay_time_amplitude" in ds_fit.data_vars:
+        ds_fit.max_decay_time_amplitude.attrs = {
+            "long_name": "amplitude at maximum decay time",
+            "units": "a.u.",
+        }
+    if "jeff_raw" in ds_fit.data_vars:
+        ds_fit.jeff_raw.attrs = {"long_name": "raw extracted effective coupling", "units": "MHz"}
+    if "jeff_smooth" in ds_fit.data_vars:
+        ds_fit.jeff_smooth.attrs = {"long_name": "smoothed effective coupling", "units": "MHz"}
+    if "gamma_raw" in ds_fit.data_vars:
+        ds_fit.gamma_raw.attrs = {"long_name": "raw extracted decay rate", "units": "MHz"}
+    if "gamma_smooth" in ds_fit.data_vars:
+        ds_fit.gamma_smooth.attrs = {"long_name": "smoothed decay rate", "units": "MHz"}
+    if "tau_raw" in ds_fit.data_vars:
+        ds_fit.tau_raw.attrs = {"long_name": "raw decay time constant", "units": "µs"}
+    if "tau_smooth" in ds_fit.data_vars:
+        ds_fit.tau_smooth.attrs = {"long_name": "smoothed decay time constant", "units": "µs"}
+    if "fit_mask" in ds_fit.data_vars:
+        ds_fit.fit_mask.attrs = {"long_name": "successful fit mask", "units": "bool"}
+
+    # Create FitResults for each qubit pair
+    fit_results = {}
+    for qp in qubit_pairs:
+        qp_name = qp.name
+        qp_data = ds_fit.sel(qubit_pair=qp_name)
+
+        fit_results[qp_name] = FitResults(
+            optimal_amplitude=float(qp_data.optimal_amplitude.values),
+            max_decay_time=float(qp_data.max_decay_time.values),
+            max_decay_time_amplitude=float(qp_data.max_decay_time_amplitude.values),
+            success=bool(qp_data.success.values),
+        )
+
+    return ds_fit, fit_results

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/parameters.py
@@ -1,0 +1,43 @@
+"""Parameters for JAZZ_ZZ calibration node."""
+
+from typing import ClassVar, Literal
+
+from qualibrate import NodeParameters
+from qualibrate.core.parameters import RunnableParameters
+from qualibration_libs.parameters import CommonNodeParameters, QubitPairExperimentNodeParameters
+
+
+class NodeSpecificParameters(RunnableParameters):
+    """Parameters specific to JAZZ_ZZ calibration."""
+
+    num_shots: int = 100
+    """Number of shots to perform. Default is 100."""
+    amp_min: float = -0.1
+    """Minimum amplitude for the coupler scan. Default is -0.1."""
+    amp_max: float = 0.1
+    """Maximum amplitude for the coupler scan. Default is 0.1."""
+    amp_step: float = 0.001
+    """Step size for amplitude scanning. Default is 0.001."""
+    time_min_in_ns: float = 16
+    """Minimum free-evolution time in nanoseconds. Default is 16."""
+    time_max_in_ns: float = 1000
+    """Maximum free-evolution time in nanoseconds. Default is 1000."""
+    time_step_in_ns: float = 16
+    """Step size for the free-evolution time sweep in nanoseconds. Default is 16."""
+    artificial_detuning_in_mhz: float = 1.0
+    """Artificial detuning applied during the Ramsey-like sequence in MHz. Default is 1.0."""
+    use_state_discrimination: bool = True
+    """Whether to use state discrimination for readout. Default is True."""
+    measure_qubit: Literal["control", "target"] = "target"
+    """Which qubit in the pair to measure: 'control' or 'target'. Default is 'target'."""
+
+
+class Parameters(
+    NodeParameters,
+    CommonNodeParameters,
+    NodeSpecificParameters,
+    QubitPairExperimentNodeParameters,
+):
+    """Combined parameters for JAZZ_ZZ calibration node."""
+
+    targets_name: ClassVar[str] = "qubit_pairs"

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
@@ -1,69 +1,62 @@
 """Plotting functions for JAZZ_ZZ calibration results."""
 
-from typing import Dict
-
-import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
-from calibration_utils.JAZZ_ZZ.analysis import FitResults
-from qualibration_libs.core import BatchableList
+from matplotlib.figure import Figure
+from qualibration_libs.plotting import grid_iter
+
+from calibration_utils.pair_grid import QubitPairGrid, grid_pair_names
+
+_FIG_TITLE_PREFIX = "ZZ coupling off - JAZZ"
 
 
-def plot_raw_data_with_fit(
-    fit_results: xr.Dataset,
-    qubit_pairs: BatchableList,
-    node=None,
-) -> plt.Figure:
+def _subplot_title(ds: xr.Dataset, qp_name: str) -> str:
+    if "measured_qubit_name" in ds.coords:
+        measured_name = str(ds.measured_qubit_name.sel(qubit_pair=qp_name).values)
+        return f"{qp_name}\nMeasured: {measured_name}"
+    return qp_name
+
+
+def _pairs_with_successful_fits(ds_fit: xr.Dataset, qubit_pairs) -> list:
+    return [qp for qp in qubit_pairs if bool(ds_fit.sel(qubit_pair=qp.name).success.values)]
+
+
+def plot_effective_coupling(ds_fit: xr.Dataset, qubit_pairs) -> Figure | None:
+    """Effective coupling $|J_{eff}|$ vs coupler flux for each pair.
+
+    The subplot layout is computed automatically from the qubit-pair
+    grid locations using :class:`~calibration_utils.pair_grid.QubitPairGrid`.
+    Pairs where all per-amplitude fits failed are skipped. Returns ``None`` if
+    there is nothing to plot.
+
+    Parameters
+    ----------
+    ds_fit : xr.Dataset
+        Fitted dataset containing ``jeff_raw``, ``jeff_smooth``, ``fit_mask``,
+        ``optimal_amplitude``, ``measured_qubit_name``, and ``artificial_detuning``.
+    qubit_pairs : list
+        Qubit pair objects (must expose ``.qubit_control`` / ``.qubit_target``
+        with ``.grid_location`` and ``.name``).
+
+    Returns
+    -------
+    Figure or None
     """
-    Plot the JAZZ_ZZ data showing effective coupling J_eff vs flux bias with optimal point.
+    valid_pairs = _pairs_with_successful_fits(ds_fit, qubit_pairs)
+    if not valid_pairs:
+        return None
 
-    Parameters:
-    -----------
-    fit_results : xr.Dataset
-        Fit results for each qubit pair containing jeff_raw, jeff_smooth, fit_mask, optimal_amplitude
-    qubit_pairs : BatchableList
-        List of qubit pairs
-    node : QualibrationNode, optional
-        Node containing parameters like artificial_detuning_in_mhz
-
-    Returns:
-    --------
-    plt.Figure
-        The generated figure
-    """
-    n_pairs = len(qubit_pairs)
-    cols = min(4, n_pairs)  # Max 4 columns
-    rows = (n_pairs + cols - 1) // cols  # Ceiling division
-
-    fig, axes = plt.subplots(rows, cols, figsize=(8 * cols, 5 * rows), squeeze=False)
-    axes = axes.flatten()
-
-    for i, qp in enumerate(qubit_pairs):
-        ax = axes[i]
-        qp_name = qp.name
-        fit_result = fit_results.sel(qubit_pair=qp_name)
-
-        # Get flux bias values and coupling data
+    artificial_detuning = float(ds_fit.artificial_detuning)
+    g_names, qp_names = grid_pair_names(valid_pairs)
+    grid = QubitPairGrid(g_names, qp_names)
+    for ax, qubit in grid_iter(grid):
+        qp_name = qubit["qubit"]
+        fit_result = ds_fit.sel(qubit_pair=qp_name)
         flux_bias = fit_result.amp.values
         jeff_raw = fit_result.jeff_raw.values
         jeff_smooth = fit_result.jeff_smooth.values
         fit_mask = fit_result.fit_mask.values.astype(bool)
 
-        # Get artificial detuning from parameters
-        artificial_detuning = node.parameters.artificial_detuning_in_mhz if node else 1.0
-
-        # Plot flat traces (failed fits) - Blue
-        plt.sca(ax)
-        # ax.plot(
-        #     flux_bias[~fit_mask],
-        #     jeff_raw[~fit_mask] - artificial_detuning,
-        #     "o",
-        #     color="blue",
-        #     alpha=0.5,
-        #     label="Flat signal (J = 0)",
-        # )
-
-        # Plot valid fits - Gold
         ax.plot(
             flux_bias[fit_mask],
             np.abs(jeff_raw[fit_mask] - artificial_detuning),
@@ -72,19 +65,14 @@ def plot_raw_data_with_fit(
             alpha=0.6,
             label="Extracted $J_{eff}$",
         )
-
-        # Plot smoothed fit - Orange
-        if np.any(fit_mask):
-            ax.plot(
-                flux_bias[fit_mask],
-                np.abs(jeff_smooth[fit_mask] - artificial_detuning),
-                "-",
-                color="orange",
-                linewidth=2,
-                label="Smoothed $J_{eff}$",
-            )
-
-        # Mark optimal amplitude (minimum coupling)
+        ax.plot(
+            flux_bias[fit_mask],
+            np.abs(jeff_smooth[fit_mask] - artificial_detuning),
+            "-",
+            color="orange",
+            linewidth=2,
+            label="Smoothed $J_{eff}$",
+        )
         if not np.isnan(fit_result.optimal_amplitude.values):
             ax.axvline(
                 x=fit_result.optimal_amplitude.values,
@@ -94,147 +82,72 @@ def plot_raw_data_with_fit(
                 label="Optimal amplitude",
             )
 
-        ax.set_xlabel("Flux Bias (arb. units)")
-        ax.set_ylabel("Effective Coupling $|J_{eff}|$ (MHz)")
-        ax.set_title(f"JAZZ_ZZ Coupling vs Flux Bias - {qp_name}")
+        ax.set_title(_subplot_title(ds_fit, qp_name))
+        ax.set_xlabel("Coupler flux (V)")
+        ax.set_ylabel(r"Effective coupling $|J_{eff}|$ (MHz)")
         ax.grid(True)
-        ax.legend()
+        ax.legend(fontsize="small")
 
-    # Hide unused axes
-    for i in range(n_pairs, len(axes)):
-        axes[i].axis("off")
-
-    fig.suptitle("JAZZ_ZZ Effective Coupling Extraction")
-    fig.tight_layout()
-
-    return fig
+    grid.fig.suptitle(f"{_FIG_TITLE_PREFIX} — $J_{{eff}}$ vs coupler flux")
+    grid.fig.tight_layout()
+    return grid.fig
 
 
-def plot_oscillation_data(
-    ds_raw: xr.Dataset,
-    qubit_pairs: BatchableList,
-    amp_indices: list = None,
-) -> plt.Figure:
+def plot_decay_rate_data(ds_fit: xr.Dataset, qubit_pairs) -> Figure | None:
+    """Decay time constant τ vs coupler flux for each pair.
+
+    The subplot layout is computed automatically from the qubit-pair
+    grid locations using :class:`~calibration_utils.pair_grid.QubitPairGrid`.
+    Pairs with no valid decay-time extraction are skipped. Returns ``None`` if
+    there is nothing to plot.
+
+    Parameters
+    ----------
+    ds_fit : xr.Dataset
+        Fitted dataset containing ``tau_raw``, ``tau_smooth``, ``fit_mask``,
+        ``max_decay_time``, ``max_decay_time_amplitude``, and ``measured_qubit_name``.
+    qubit_pairs : list
+        Qubit pair objects (must expose ``.qubit_control`` / ``.qubit_target``
+        with ``.grid_location`` and ``.name``).
+
+    Returns
+    -------
+    Figure or None
     """
-    Plot raw oscillation data for selected amplitudes to show the time evolution.
+    valid_pairs = [
+        qp for qp in qubit_pairs if np.any(ds_fit.sel(qubit_pair=qp.name).tau_raw.values > 0)
+    ]
+    if not valid_pairs:
+        return None
 
-    Parameters:
-    -----------
-    ds_raw : xr.Dataset
-        Raw dataset containing state_target oscillations
-    qubit_pairs : BatchableList
-        List of qubit pairs
-    amp_indices : list, optional
-        List of amplitude indices to plot. If None, plots a few representative ones.
-
-    Returns:
-    --------
-    plt.Figure
-        The generated figure showing oscillation traces
-    """
-    n_pairs = len(qubit_pairs)
-    cols = min(4, n_pairs)
-    rows = (n_pairs + cols - 1) // cols
-
-    fig, axes = plt.subplots(rows, cols, figsize=(8 * cols, 5 * rows), squeeze=False)
-    axes = axes.flatten()
-
-    for i, qp in enumerate(qubit_pairs):
-        ax = axes[i]
-        qp_name = qp.name
-        qp_data = ds_raw.sel(qubit_pair=qp_name)
-
-        qp_data.state_target.plot(ax=ax, x="amp")
-
-        ax.set_xlabel("Time (µs)")
-        ax.set_ylabel("State Target")
-        ax.set_title(f"JAZZ_ZZ Oscillations - {qp_name}")
-
-    # Hide unused axes
-    for i in range(n_pairs, len(axes)):
-        axes[i].axis("off")
-
-    fig.suptitle("JAZZ_ZZ Raw Oscillation Data")
-    fig.tight_layout()
-
-    return fig
-
-
-def plot_decay_rate_data(
-    fit_results: xr.Dataset,
-    qubit_pairs: BatchableList,
-    node=None,
-) -> plt.Figure:
-    """
-    Plot the decay time constant (τ = 1/γ) vs coupler amplitude for JAZZ_ZZ data.
-
-    Parameters:
-    -----------
-    fit_results : xr.Dataset
-        Fit results for each qubit pair containing tau_raw, tau_smooth, fit_mask, max_decay_time
-    qubit_pairs : BatchableList
-        List of qubit pairs
-    node : QualibrationNode, optional
-        Node containing parameters
-
-    Returns:
-    --------
-    plt.Figure
-        The generated figure showing decay time constant vs coupler amplitude
-    """
-    n_pairs = len(qubit_pairs)
-    cols = min(4, n_pairs)  # Max 4 columns
-    rows = (n_pairs + cols - 1) // cols  # Ceiling division
-
-    fig, axes = plt.subplots(rows, cols, figsize=(8 * cols, 5 * rows), squeeze=False)
-    axes = axes.flatten()
-
-    for i, qp in enumerate(qubit_pairs):
-        ax = axes[i]
-        qp_name = qp.name
-        fit_result = fit_results.sel(qubit_pair=qp_name)
-
-        # Get flux bias values and decay time data
+    g_names, qp_names = grid_pair_names(valid_pairs)
+    grid = QubitPairGrid(g_names, qp_names)
+    for ax, qubit in grid_iter(grid):
+        qp_name = qubit["qubit"]
+        fit_result = ds_fit.sel(qubit_pair=qp_name)
         flux_bias = fit_result.amp.values
         tau_raw = fit_result.tau_raw.values
         tau_smooth = fit_result.tau_smooth.values
         fit_mask = fit_result.fit_mask.values.astype(bool)
-
-        # Plot flat traces (failed fits) - Blue
-        plt.sca(ax)
-        # ax.plot(
-        #     flux_bias[~fit_mask],
-        #     tau_raw[~fit_mask],
-        #     "o",
-        #     color="blue",
-        #     alpha=0.5,
-        #     label="Failed fits (τ = 0)",
-        # )
-
-        # Plot valid fits - Gold
         valid_tau_mask = fit_mask & (tau_raw > 0)
-        if np.any(valid_tau_mask):
-            ax.plot(
-                flux_bias[valid_tau_mask],
-                tau_raw[valid_tau_mask],
-                "o",
-                color="gold",
-                alpha=0.6,
-                label="Extracted decay time",
-            )
 
-        # Plot smoothed fit - Orange
-        if np.any(valid_tau_mask):
-            ax.plot(
-                flux_bias[valid_tau_mask],
-                tau_smooth[valid_tau_mask],
-                "-",
-                color="orange",
-                linewidth=2,
-                label="Smoothed decay time",
-            )
+        ax.plot(
+            flux_bias[valid_tau_mask],
+            tau_raw[valid_tau_mask],
+            "o",
+            color="gold",
+            alpha=0.6,
+            label="Extracted decay time",
+        )
+        ax.plot(
+            flux_bias[valid_tau_mask],
+            tau_smooth[valid_tau_mask],
+            "-",
+            color="orange",
+            linewidth=2,
+            label="Smoothed decay time",
+        )
 
-        # Mark maximum decay time
         if not np.isnan(fit_result.max_decay_time.values):
             max_tau = fit_result.max_decay_time.values
             max_tau_amp = fit_result.max_decay_time_amplitude.values
@@ -245,8 +158,6 @@ def plot_decay_rate_data(
                 linewidth=2,
                 label=f"Max τ amplitude (τ={max_tau:.3f} µs)",
             )
-
-            # Mark the maximum decay time point
             ax.plot(
                 max_tau_amp,
                 max_tau,
@@ -255,7 +166,6 @@ def plot_decay_rate_data(
                 label="Maximum decay time",
             )
 
-        # Also mark optimal amplitude for reference
         if not np.isnan(fit_result.optimal_amplitude.values):
             ax.axvline(
                 x=fit_result.optimal_amplitude.values,
@@ -266,16 +176,80 @@ def plot_decay_rate_data(
                 label="Optimal coupling amplitude",
             )
 
-        ax.set_xlabel("Coupler Amplitude (arb. units)")
-        ax.set_ylabel("Decay Time Constant τ (µs)")
-        ax.set_title(f"JAZZ_ZZ Decay Time vs Coupler Amplitude - {qp_name}")
+        ax.set_title(_subplot_title(ds_fit, qp_name))
+        ax.set_xlabel("Coupler flux (V)")
+        ax.set_ylabel("Decay time constant τ (µs)")
         ax.grid(True)
-        ax.legend()
+        ax.legend(fontsize="small")
 
-    # Hide unused axes
-    for i in range(n_pairs, len(axes)):
-        axes[i].axis("off")
+    grid.fig.suptitle(f"{_FIG_TITLE_PREFIX} — decay vs coupler flux")
+    grid.fig.tight_layout()
+    return grid.fig
 
-    fig.suptitle("JAZZ_ZZ Decay Time Constant Analysis")
 
-    return fig
+def plot_raw_data(ds: xr.Dataset, qubit_pairs) -> Figure:
+    """2D heatmap of measured signal vs (coupler flux, time) for each pair.
+
+    The subplot layout is computed automatically from the qubit-pair
+    grid locations using :class:`~calibration_utils.pair_grid.QubitPairGrid`.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Raw dataset containing ``state_target`` or ``I_target``, and
+        ``measured_qubit_name``.
+    qubit_pairs : list
+        Qubit pair objects (must expose ``.qubit_control`` / ``.qubit_target``
+        with ``.grid_location`` and ``.name``).
+
+    Returns
+    -------
+    Figure
+    """
+    data_var = "state_target" if "state_target" in ds.data_vars else "I_target"
+    g_names, qp_names = grid_pair_names(qubit_pairs)
+    grid = QubitPairGrid(g_names, qp_names)
+    for ax, qubit in grid_iter(grid):
+        qp_name = qubit["qubit"]
+        ds[data_var].sel(qubit_pair=qp_name).squeeze().plot(ax=ax, x="amp", y="time")
+        ax.set_xlabel("Coupler flux (V)")
+        ax.set_ylabel("Time (ns)")
+        ax.set_title(_subplot_title(ds, qp_name))
+    grid.fig.suptitle(f"{_FIG_TITLE_PREFIX} — raw data")
+    grid.fig.tight_layout()
+    return grid.fig
+
+
+def plot_fit_data(ds_fit: xr.Dataset, qubit_pairs) -> Figure | None:
+    """2D heatmap of the fitted oscillation for each pair.
+
+    Skips pairs where all fits failed (all ``fitted_state`` values are NaN)
+    and returns ``None`` if there is nothing to plot.
+
+    Parameters
+    ----------
+    ds_fit : xr.Dataset
+        Fitted dataset containing ``fitted_state`` and ``measured_qubit_name``.
+    qubit_pairs : list
+        Qubit pair objects (must expose ``.qubit_control`` / ``.qubit_target``
+        with ``.grid_location`` and ``.name``).
+
+    Returns
+    -------
+    Figure or None
+    """
+    valid_pairs = _pairs_with_successful_fits(ds_fit, qubit_pairs)
+    if not valid_pairs:
+        return None
+
+    g_names, qp_names = grid_pair_names(valid_pairs)
+    grid = QubitPairGrid(g_names, qp_names)
+    for ax, qubit in grid_iter(grid):
+        qp_name = qubit["qubit"]
+        ds_fit.fitted_state.sel(qubit_pair=qp_name).squeeze().plot(ax=ax, x="amp", y="time")
+        ax.set_xlabel("Coupler flux (V)")
+        ax.set_ylabel("Time (ns)")
+        ax.set_title(_subplot_title(ds_fit, qp_name))
+    grid.fig.suptitle(f"{_FIG_TITLE_PREFIX} — fit")
+    grid.fig.tight_layout()
+    return grid.fig

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
@@ -22,7 +22,14 @@ def _pairs_with_successful_fits(ds_fit: xr.Dataset, qubit_pairs) -> list:
 
 
 def plot_effective_coupling(ds_fit: xr.Dataset, qubit_pairs, log_y: bool = False) -> Figure | None:
-    """Residual coupling $|J_{eff} - \\delta|$ vs coupler flux for each pair.
+    """Residual ZZ coupling |ζ| vs coupler flux for each pair.
+
+    Following arXiv:2402.18926 (Li et al., Sec. III.1):
+      - ``jeff_raw`` stores ωm_code = ζ + ωb_eff, the total oscillation frequency
+        measured vs t_single (one coupler pulse duration).
+      - The true ZZ coupling is ζ = jeff_raw − artificial_detuning.
+      - The plotted quantity is |ζ| = |jeff_raw − artificial_detuning|.
+      - The optimal amplitude is the coupler bias where |ζ| is minimised (ζ ≈ 0).
 
     The subplot layout is computed automatically from the qubit-pair
     grid locations using :class:`~calibration_utils.pair_grid.QubitPairGrid`.
@@ -60,6 +67,7 @@ def plot_effective_coupling(ds_fit: xr.Dataset, qubit_pairs, log_y: bool = False
         jeff_smooth = fit_result.jeff_smooth.values
         fit_mask = fit_result.fit_mask.values.astype(bool)
 
+        # |ζ| = |ωm_code − ωb_eff| = |jeff_raw − artificial_detuning|
         residual_raw = np.abs(jeff_raw[fit_mask] - artificial_detuning)
         residual_smooth = np.abs(jeff_smooth[fit_mask] - artificial_detuning)
         flux_plot = flux_bias[fit_mask]
@@ -115,11 +123,11 @@ def plot_effective_coupling(ds_fit: xr.Dataset, qubit_pairs, log_y: bool = False
 
         ax.set_title(_subplot_title(ds_fit, qp_name))
         ax.set_xlabel("Coupler flux (V)")
-        ax.set_ylabel(r"Residual $|J_{eff} - \delta|$ (MHz)")
+        ax.set_ylabel(r"Residual ZZ coupling $|\zeta|$ (MHz)")
         ax.grid(True, which="both" if log_y else "major")
         ax.legend(fontsize="small")
 
-    grid.fig.suptitle(f"{_FIG_TITLE_PREFIX} — residual coupling vs coupler flux")
+    grid.fig.suptitle(f"{_FIG_TITLE_PREFIX} — residual ZZ coupling |ζ| vs coupler flux")
     grid.fig.tight_layout()
     return grid.fig
 

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
@@ -7,7 +7,7 @@ from qualibration_libs.plotting import grid_iter
 
 from calibration_utils.pair_grid import QubitPairGrid, grid_pair_names
 
-_FIG_TITLE_PREFIX = "ZZ coupling off - JAZZ"
+_FIG_TITLE_PREFIX = "ZZ coupling off (JAZZ)"
 
 
 def _subplot_title(ds: xr.Dataset, qp_name: str) -> str:
@@ -21,8 +21,8 @@ def _pairs_with_successful_fits(ds_fit: xr.Dataset, qubit_pairs) -> list:
     return [qp for qp in qubit_pairs if bool(ds_fit.sel(qubit_pair=qp.name).success.values)]
 
 
-def plot_effective_coupling(ds_fit: xr.Dataset, qubit_pairs) -> Figure | None:
-    """Effective coupling $|J_{eff}|$ vs coupler flux for each pair.
+def plot_effective_coupling(ds_fit: xr.Dataset, qubit_pairs, log_y: bool = False) -> Figure | None:
+    """Residual coupling $|J_{eff} - \\delta|$ vs coupler flux for each pair.
 
     The subplot layout is computed automatically from the qubit-pair
     grid locations using :class:`~calibration_utils.pair_grid.QubitPairGrid`.
@@ -37,6 +37,9 @@ def plot_effective_coupling(ds_fit: xr.Dataset, qubit_pairs) -> Figure | None:
     qubit_pairs : list
         Qubit pair objects (must expose ``.qubit_control`` / ``.qubit_target``
         with ``.grid_location`` and ``.name``).
+    log_y : bool
+        If ``True``, use a logarithmic y-axis (only points with positive residual
+        coupling are shown).
 
     Returns
     -------
@@ -57,22 +60,50 @@ def plot_effective_coupling(ds_fit: xr.Dataset, qubit_pairs) -> Figure | None:
         jeff_smooth = fit_result.jeff_smooth.values
         fit_mask = fit_result.fit_mask.values.astype(bool)
 
-        ax.plot(
-            flux_bias[fit_mask],
-            np.abs(jeff_raw[fit_mask] - artificial_detuning),
-            "o",
-            color="gold",
-            alpha=0.6,
-            label="Extracted $J_{eff}$",
-        )
-        ax.plot(
-            flux_bias[fit_mask],
-            np.abs(jeff_smooth[fit_mask] - artificial_detuning),
-            "-",
-            color="orange",
-            linewidth=2,
-            label="Smoothed $J_{eff}$",
-        )
+        residual_raw = np.abs(jeff_raw[fit_mask] - artificial_detuning)
+        residual_smooth = np.abs(jeff_smooth[fit_mask] - artificial_detuning)
+        flux_plot = flux_bias[fit_mask]
+
+        if log_y:
+            positive = residual_raw > 0
+            if np.any(positive):
+                ax.plot(
+                    flux_plot[positive],
+                    residual_raw[positive],
+                    "o",
+                    color="gold",
+                    alpha=0.6,
+                    label="Extracted residual",
+                )
+            positive_smooth = residual_smooth > 0
+            if np.any(positive_smooth):
+                ax.plot(
+                    flux_plot[positive_smooth],
+                    residual_smooth[positive_smooth],
+                    "-",
+                    color="orange",
+                    linewidth=2,
+                    label="Smoothed residual",
+                )
+            ax.set_yscale("log")
+        else:
+            ax.plot(
+                flux_plot,
+                residual_raw,
+                "o",
+                color="gold",
+                alpha=0.6,
+                label="Extracted residual",
+            )
+            ax.plot(
+                flux_plot,
+                residual_smooth,
+                "-",
+                color="orange",
+                linewidth=2,
+                label="Smoothed residual",
+            )
+
         if not np.isnan(fit_result.optimal_amplitude.values):
             ax.axvline(
                 x=fit_result.optimal_amplitude.values,
@@ -84,16 +115,16 @@ def plot_effective_coupling(ds_fit: xr.Dataset, qubit_pairs) -> Figure | None:
 
         ax.set_title(_subplot_title(ds_fit, qp_name))
         ax.set_xlabel("Coupler flux (V)")
-        ax.set_ylabel(r"Effective coupling $|J_{eff}|$ (MHz)")
-        ax.grid(True)
+        ax.set_ylabel(r"Residual $|J_{eff} - \delta|$ (MHz)")
+        ax.grid(True, which="both" if log_y else "major")
         ax.legend(fontsize="small")
 
-    grid.fig.suptitle(f"{_FIG_TITLE_PREFIX} — $J_{{eff}}$ vs coupler flux")
+    grid.fig.suptitle(f"{_FIG_TITLE_PREFIX} — residual coupling vs coupler flux")
     grid.fig.tight_layout()
     return grid.fig
 
 
-def plot_decay_rate_data(ds_fit: xr.Dataset, qubit_pairs) -> Figure | None:
+def plot_decay_rate_data(ds_fit: xr.Dataset, qubit_pairs, log_y: bool = False) -> Figure | None:
     """Decay time constant τ vs coupler flux for each pair.
 
     The subplot layout is computed automatically from the qubit-pair
@@ -109,6 +140,8 @@ def plot_decay_rate_data(ds_fit: xr.Dataset, qubit_pairs) -> Figure | None:
     qubit_pairs : list
         Qubit pair objects (must expose ``.qubit_control`` / ``.qubit_target``
         with ``.grid_location`` and ``.name``).
+    log_y : bool
+        If ``True``, use a logarithmic y-axis (only τ > 0 are shown).
 
     Returns
     -------
@@ -130,41 +163,67 @@ def plot_decay_rate_data(ds_fit: xr.Dataset, qubit_pairs) -> Figure | None:
         tau_smooth = fit_result.tau_smooth.values
         fit_mask = fit_result.fit_mask.values.astype(bool)
         valid_tau_mask = fit_mask & (tau_raw > 0)
+        flux_plot = flux_bias[valid_tau_mask]
+        tau_raw_plot = tau_raw[valid_tau_mask]
+        tau_smooth_plot = tau_smooth[valid_tau_mask]
 
-        ax.plot(
-            flux_bias[valid_tau_mask],
-            tau_raw[valid_tau_mask],
-            "o",
-            color="gold",
-            alpha=0.6,
-            label="Extracted decay time",
-        )
-        ax.plot(
-            flux_bias[valid_tau_mask],
-            tau_smooth[valid_tau_mask],
-            "-",
-            color="orange",
-            linewidth=2,
-            label="Smoothed decay time",
-        )
+        if log_y:
+            smooth_mask = tau_smooth_plot > 0
+            if np.any(valid_tau_mask):
+                ax.plot(
+                    flux_plot,
+                    tau_raw_plot,
+                    "o",
+                    color="gold",
+                    alpha=0.6,
+                    label="Extracted decay time",
+                )
+            if np.any(smooth_mask):
+                ax.plot(
+                    flux_plot[smooth_mask],
+                    tau_smooth_plot[smooth_mask],
+                    "-",
+                    color="orange",
+                    linewidth=2,
+                    label="Smoothed decay time",
+                )
+            ax.set_yscale("log")
+        else:
+            ax.plot(
+                flux_plot,
+                tau_raw_plot,
+                "o",
+                color="gold",
+                alpha=0.6,
+                label="Extracted decay time",
+            )
+            ax.plot(
+                flux_plot,
+                tau_smooth_plot,
+                "-",
+                color="orange",
+                linewidth=2,
+                label="Smoothed decay time",
+            )
 
         if not np.isnan(fit_result.max_decay_time.values):
             max_tau = fit_result.max_decay_time.values
             max_tau_amp = fit_result.max_decay_time_amplitude.values
-            ax.axvline(
-                x=max_tau_amp,
-                color="red",
-                linestyle="--",
-                linewidth=2,
-                label=f"Max τ amplitude (τ={max_tau:.3f} µs)",
-            )
-            ax.plot(
-                max_tau_amp,
-                max_tau,
-                "ro",
-                markersize=8,
-                label="Maximum decay time",
-            )
+            if not log_y or max_tau > 0:
+                ax.axvline(
+                    x=max_tau_amp,
+                    color="red",
+                    linestyle="--",
+                    linewidth=2,
+                    label=f"Max τ amplitude (τ={max_tau:.3f} µs)",
+                )
+                ax.plot(
+                    max_tau_amp,
+                    max_tau,
+                    "ro",
+                    markersize=8,
+                    label="Maximum decay time",
+                )
 
         if not np.isnan(fit_result.optimal_amplitude.values):
             ax.axvline(
@@ -179,7 +238,7 @@ def plot_decay_rate_data(ds_fit: xr.Dataset, qubit_pairs) -> Figure | None:
         ax.set_title(_subplot_title(ds_fit, qp_name))
         ax.set_xlabel("Coupler flux (V)")
         ax.set_ylabel("Decay time constant τ (µs)")
-        ax.grid(True)
+        ax.grid(True, which="both" if log_y else "major")
         ax.legend(fontsize="small")
 
     grid.fig.suptitle(f"{_FIG_TITLE_PREFIX} — decay vs coupler flux")

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
@@ -196,7 +196,7 @@ def plot_raw_data(ds: xr.Dataset, qubit_pairs) -> Figure:
     Parameters
     ----------
     ds : xr.Dataset
-        Raw dataset containing ``state_target`` or ``I_target``, and
+        Raw dataset containing ``state_measured`` or ``I_measured``, and
         ``measured_qubit_name``.
     qubit_pairs : list
         Qubit pair objects (must expose ``.qubit_control`` / ``.qubit_target``
@@ -206,7 +206,7 @@ def plot_raw_data(ds: xr.Dataset, qubit_pairs) -> Figure:
     -------
     Figure
     """
-    data_var = "state_target" if "state_target" in ds.data_vars else "I_target"
+    data_var = "state_measured" if "state_measured" in ds.data_vars else "I_measured"
     g_names, qp_names = grid_pair_names(qubit_pairs)
     grid = QubitPairGrid(g_names, qp_names)
     for ax, qubit in grid_iter(grid):

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
@@ -1,0 +1,281 @@
+"""Plotting functions for JAZZ_ZZ calibration results."""
+
+from typing import Dict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from calibration_utils.JAZZ_ZZ.analysis import FitResults
+from qualibration_libs.core import BatchableList
+
+
+def plot_raw_data_with_fit(
+    fit_results: xr.Dataset,
+    qubit_pairs: BatchableList,
+    node=None,
+) -> plt.Figure:
+    """
+    Plot the JAZZ_ZZ data showing effective coupling J_eff vs flux bias with optimal point.
+
+    Parameters:
+    -----------
+    fit_results : xr.Dataset
+        Fit results for each qubit pair containing jeff_raw, jeff_smooth, fit_mask, optimal_amplitude
+    qubit_pairs : BatchableList
+        List of qubit pairs
+    node : QualibrationNode, optional
+        Node containing parameters like artificial_detuning_in_mhz
+
+    Returns:
+    --------
+    plt.Figure
+        The generated figure
+    """
+    n_pairs = len(qubit_pairs)
+    cols = min(4, n_pairs)  # Max 4 columns
+    rows = (n_pairs + cols - 1) // cols  # Ceiling division
+
+    fig, axes = plt.subplots(rows, cols, figsize=(8 * cols, 5 * rows), squeeze=False)
+    axes = axes.flatten()
+
+    for i, qp in enumerate(qubit_pairs):
+        ax = axes[i]
+        qp_name = qp.name
+        fit_result = fit_results.sel(qubit_pair=qp_name)
+
+        # Get flux bias values and coupling data
+        flux_bias = fit_result.amp.values
+        jeff_raw = fit_result.jeff_raw.values
+        jeff_smooth = fit_result.jeff_smooth.values
+        fit_mask = fit_result.fit_mask.values.astype(bool)
+
+        # Get artificial detuning from parameters
+        artificial_detuning = node.parameters.artificial_detuning_in_mhz if node else 1.0
+
+        # Plot flat traces (failed fits) - Blue
+        plt.sca(ax)
+        # ax.plot(
+        #     flux_bias[~fit_mask],
+        #     jeff_raw[~fit_mask] - artificial_detuning,
+        #     "o",
+        #     color="blue",
+        #     alpha=0.5,
+        #     label="Flat signal (J = 0)",
+        # )
+
+        # Plot valid fits - Gold
+        ax.plot(
+            flux_bias[fit_mask],
+            np.abs(jeff_raw[fit_mask] - artificial_detuning),
+            "o",
+            color="gold",
+            alpha=0.6,
+            label="Extracted $J_{eff}$",
+        )
+
+        # Plot smoothed fit - Orange
+        if np.any(fit_mask):
+            ax.plot(
+                flux_bias[fit_mask],
+                np.abs(jeff_smooth[fit_mask] - artificial_detuning),
+                "-",
+                color="orange",
+                linewidth=2,
+                label="Smoothed $J_{eff}$",
+            )
+
+        # Mark optimal amplitude (minimum coupling)
+        if not np.isnan(fit_result.optimal_amplitude.values):
+            ax.axvline(
+                x=fit_result.optimal_amplitude.values,
+                color="red",
+                linestyle="--",
+                linewidth=2,
+                label="Optimal amplitude",
+            )
+
+        ax.set_xlabel("Flux Bias (arb. units)")
+        ax.set_ylabel("Effective Coupling $|J_{eff}|$ (MHz)")
+        ax.set_title(f"JAZZ_ZZ Coupling vs Flux Bias - {qp_name}")
+        ax.grid(True)
+        ax.legend()
+
+    # Hide unused axes
+    for i in range(n_pairs, len(axes)):
+        axes[i].axis("off")
+
+    fig.suptitle("JAZZ_ZZ Effective Coupling Extraction")
+    fig.tight_layout()
+
+    return fig
+
+
+def plot_oscillation_data(
+    ds_raw: xr.Dataset,
+    qubit_pairs: BatchableList,
+    amp_indices: list = None,
+) -> plt.Figure:
+    """
+    Plot raw oscillation data for selected amplitudes to show the time evolution.
+
+    Parameters:
+    -----------
+    ds_raw : xr.Dataset
+        Raw dataset containing state_target oscillations
+    qubit_pairs : BatchableList
+        List of qubit pairs
+    amp_indices : list, optional
+        List of amplitude indices to plot. If None, plots a few representative ones.
+
+    Returns:
+    --------
+    plt.Figure
+        The generated figure showing oscillation traces
+    """
+    n_pairs = len(qubit_pairs)
+    cols = min(4, n_pairs)
+    rows = (n_pairs + cols - 1) // cols
+
+    fig, axes = plt.subplots(rows, cols, figsize=(8 * cols, 5 * rows), squeeze=False)
+    axes = axes.flatten()
+
+    for i, qp in enumerate(qubit_pairs):
+        ax = axes[i]
+        qp_name = qp.name
+        qp_data = ds_raw.sel(qubit_pair=qp_name)
+
+        qp_data.state_target.plot(ax=ax, x="amp")
+
+        ax.set_xlabel("Time (µs)")
+        ax.set_ylabel("State Target")
+        ax.set_title(f"JAZZ_ZZ Oscillations - {qp_name}")
+
+    # Hide unused axes
+    for i in range(n_pairs, len(axes)):
+        axes[i].axis("off")
+
+    fig.suptitle("JAZZ_ZZ Raw Oscillation Data")
+    fig.tight_layout()
+
+    return fig
+
+
+def plot_decay_rate_data(
+    fit_results: xr.Dataset,
+    qubit_pairs: BatchableList,
+    node=None,
+) -> plt.Figure:
+    """
+    Plot the decay time constant (τ = 1/γ) vs coupler amplitude for JAZZ_ZZ data.
+
+    Parameters:
+    -----------
+    fit_results : xr.Dataset
+        Fit results for each qubit pair containing tau_raw, tau_smooth, fit_mask, max_decay_time
+    qubit_pairs : BatchableList
+        List of qubit pairs
+    node : QualibrationNode, optional
+        Node containing parameters
+
+    Returns:
+    --------
+    plt.Figure
+        The generated figure showing decay time constant vs coupler amplitude
+    """
+    n_pairs = len(qubit_pairs)
+    cols = min(4, n_pairs)  # Max 4 columns
+    rows = (n_pairs + cols - 1) // cols  # Ceiling division
+
+    fig, axes = plt.subplots(rows, cols, figsize=(8 * cols, 5 * rows), squeeze=False)
+    axes = axes.flatten()
+
+    for i, qp in enumerate(qubit_pairs):
+        ax = axes[i]
+        qp_name = qp.name
+        fit_result = fit_results.sel(qubit_pair=qp_name)
+
+        # Get flux bias values and decay time data
+        flux_bias = fit_result.amp.values
+        tau_raw = fit_result.tau_raw.values
+        tau_smooth = fit_result.tau_smooth.values
+        fit_mask = fit_result.fit_mask.values.astype(bool)
+
+        # Plot flat traces (failed fits) - Blue
+        plt.sca(ax)
+        # ax.plot(
+        #     flux_bias[~fit_mask],
+        #     tau_raw[~fit_mask],
+        #     "o",
+        #     color="blue",
+        #     alpha=0.5,
+        #     label="Failed fits (τ = 0)",
+        # )
+
+        # Plot valid fits - Gold
+        valid_tau_mask = fit_mask & (tau_raw > 0)
+        if np.any(valid_tau_mask):
+            ax.plot(
+                flux_bias[valid_tau_mask],
+                tau_raw[valid_tau_mask],
+                "o",
+                color="gold",
+                alpha=0.6,
+                label="Extracted decay time",
+            )
+
+        # Plot smoothed fit - Orange
+        if np.any(valid_tau_mask):
+            ax.plot(
+                flux_bias[valid_tau_mask],
+                tau_smooth[valid_tau_mask],
+                "-",
+                color="orange",
+                linewidth=2,
+                label="Smoothed decay time",
+            )
+
+        # Mark maximum decay time
+        if not np.isnan(fit_result.max_decay_time.values):
+            max_tau = fit_result.max_decay_time.values
+            max_tau_amp = fit_result.max_decay_time_amplitude.values
+            ax.axvline(
+                x=max_tau_amp,
+                color="red",
+                linestyle="--",
+                linewidth=2,
+                label=f"Max τ amplitude (τ={max_tau:.3f} µs)",
+            )
+
+            # Mark the maximum decay time point
+            ax.plot(
+                max_tau_amp,
+                max_tau,
+                "ro",
+                markersize=8,
+                label="Maximum decay time",
+            )
+
+        # Also mark optimal amplitude for reference
+        if not np.isnan(fit_result.optimal_amplitude.values):
+            ax.axvline(
+                x=fit_result.optimal_amplitude.values,
+                color="green",
+                linestyle=":",
+                linewidth=1,
+                alpha=0.7,
+                label="Optimal coupling amplitude",
+            )
+
+        ax.set_xlabel("Coupler Amplitude (arb. units)")
+        ax.set_ylabel("Decay Time Constant τ (µs)")
+        ax.set_title(f"JAZZ_ZZ Decay Time vs Coupler Amplitude - {qp_name}")
+        ax.grid(True)
+        ax.legend()
+
+    # Hide unused axes
+    for i in range(n_pairs, len(axes)):
+        axes[i].axis("off")
+
+    fig.suptitle("JAZZ_ZZ Decay Time Constant Analysis")
+
+    return fig

--- a/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/JAZZ_ZZ/plotting.py
@@ -147,9 +147,7 @@ def plot_decay_rate_data(ds_fit: xr.Dataset, qubit_pairs, log_y: bool = False) -
     -------
     Figure or None
     """
-    valid_pairs = [
-        qp for qp in qubit_pairs if np.any(ds_fit.sel(qubit_pair=qp.name).tau_raw.values > 0)
-    ]
+    valid_pairs = [qp for qp in qubit_pairs if np.any(ds_fit.sel(qubit_pair=qp.name).tau_raw.values > 0)]
     if not valid_pairs:
         return None
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
@@ -1,28 +1,24 @@
 # %% {Imports}
 from dataclasses import asdict
 
-import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from calibration_utils.JAZZ_ZZ import (
-    FitResults,
     Parameters,
     fit_raw_data,
     log_fitted_results,
     plot_decay_rate_data,
-    plot_oscillation_data,
-    plot_raw_data_with_fit,
+    plot_effective_coupling,
+    plot_fit_data,
+    plot_raw_data,
     process_raw_dataset,
 )
-from qm import SimulationConfig
 from qm.qua import *
-from qualang_tools.bakery import baking
 from qualang_tools.loops import from_array
 from qualang_tools.multi_user import qm_session
-from qualang_tools.results import fetching_tool, progress_counter
+from qualang_tools.results import progress_counter
 from qualang_tools.units import unit
 from qualibrate import QualibrationNode
-from qualibration_libs.core import tracked_updates
 from qualibration_libs.data import XarrayDataFetcher
 from qualibration_libs.parameters import get_qubit_pairs
 from qualibration_libs.runtime import simulate_and_plot
@@ -62,11 +58,10 @@ State update:
 
 # Be sure to include [Parameters, Quam] so the node has proper type hinting
 node = QualibrationNode[Parameters, Quam](
-    name="24_zz_off_jazz",  # Name should be unique
+    name="19_zz_off_jazz",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
-    parameters=Parameters(),  # Node parameters defined under calibration_utils/cz_conditional_phase/parameters.py
+    parameters=Parameters(),  # Node parameters defined under calibration_utils/JAZZ_ZZ/parameters.py
 )
-# instrument_calibration_node(node)
 
 
 # Any parameters that should change for debugging purposes only should go in here
@@ -75,14 +70,18 @@ node = QualibrationNode[Parameters, Quam](
 def custom_param(node: QualibrationNode[Parameters, Quam]):
     """Allow the user to locally set the node parameters."""
     # You can get type hinting in your IDE by typing node.parameters.
-    # node.parameters.qubit_pairs = ["q1-q2"]
+    node.parameters.qubit_pairs = None
+    node.parameters.measure_qubit = "control"
+    node.parameters.amp_step = 0.01
+    node.parameters.num_shots = 10
+
     # node.parameters.qubit_pairs = ["qC4-C5"]
     # node.parameters.time_min_in_ns = 16
     # node.parameters.time_max_in_ns = 500
     # node.parameters.time_step_in_ns = 4
     # node.parameters.artificial_detuning_in_mhz = 10
-    # node.parameters.amp_min = -0.04
-    # node.parameters.amp_max = 0.04
+    node.parameters.amp_min = -0.1
+    node.parameters.amp_max = 0.1
     # node.parameters.amp_step = 0.001
     # node.parameters.num_shots = 200
     # node.parameters.use_state_discrimination = True
@@ -105,20 +104,25 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):  # pylint: dis
     # Get the active qubit pairs from the node and organize them by batches
     node.namespace["qubit_pairs"] = qubit_pairs = get_qubit_pairs(node)
     num_qubit_pairs = len(qubit_pairs)
+    measured_qubits = []
+    for qp in qubit_pairs:
+        if node.parameters.measure_qubit == "control":
+            measured_qubits.append(qp.qubit_control)
+        else:
+            measured_qubits.append(qp.qubit_target)
+    node.namespace["measured_qubits"] = measured_qubits
 
     # Extract the sweep parameters and axes from the node parameters
     n_avg = node.parameters.num_shots
     amplitudes = np.arange(node.parameters.amp_min, node.parameters.amp_max, node.parameters.amp_step)
-    durations = (
-        np.arange(node.parameters.time_min_in_ns, node.parameters.time_max_in_ns, node.parameters.time_step_in_ns) // 4
-    )
+    durations = np.arange(node.parameters.time_min_in_ns, node.parameters.time_max_in_ns, node.parameters.time_step_in_ns) // 4
     detuning = node.parameters.artificial_detuning_in_mhz * u.MHz
 
     # Register the sweep axes to be added to the dataset when fetching data
     node.namespace["sweep_axes"] = {
         "qubit_pair": xr.DataArray(qubit_pairs.get_names()),
         "amp": xr.DataArray(amplitudes, attrs={"long_name": "coupler amplitude", "units": "V"}),
-        "time": xr.DataArray(durations * 4, attrs={"long_name": "coupler amplitude", "units": "ns"}),
+        "time": xr.DataArray(durations * 4, attrs={"long_name": "interaction time", "units": "ns"}),
     }
 
     # The QUA program stored in the node namespace to be transfer to the simulation and execution run_actions
@@ -151,33 +155,38 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):  # pylint: dis
                             # Reset the frames of both qubits
                             reset_frame(qp.qubit_target.xy.name)
                             reset_frame(qp.qubit_control.xy.name)
+                            qp.align()
+                            # setting the protagonist and antagonist qubits
                             if node.parameters.measure_qubit == "control":
                                 protagonist_qubit = qp.qubit_control
                                 antagonist_qubit = qp.qubit_target
                             else:
                                 protagonist_qubit = qp.qubit_target
                                 antagonist_qubit = qp.qubit_control
-                            protagonist_qubit.xy.play("x90")
                             qp.align()
-                            qp.coupler.wait(10)
-                            # play the CZ gate
+                            # play the x90 gate on the protagonist qubit
+                            protagonist_qubit.xy.play("x90")
+                            qp.coupler.wait(protagonist_qubit.xy.operations["x90"].length//4)
+                            antagonist_qubit.wait(protagonist_qubit.xy.operations["x90"].length//4)
+                            # play the coupler pulse
                             qp.coupler.play(
                                 "const", amplitude_scale=amp / qp.coupler.operations["const"].amplitude, duration=t
                             )
-                            qp.align()
+                            protagonist_qubit.xy.wait(t)
+                            antagonist_qubit.xy.wait(t)
                             # Echo pulse
                             protagonist_qubit.xy.play("x180")
                             antagonist_qubit.xy.play("x180")
-                            qp.align()
+                            qp.coupler.wait(protagonist_qubit.xy.operations["x180"].length//4)
                             # rotate the frame
                             protagonist_qubit.xy.frame_rotation_2pi(virtual_detuning_phase)
-                            qp.coupler.wait(10)
-                            # play the CZ gate
+                            # play the coupler pulse
                             qp.coupler.play(
                                 "const", amplitude_scale=amp / qp.coupler.operations["const"].amplitude, duration=t
                             )
-                            qp.align()
-                            # Tomographic rotation on the target qubit
+                            protagonist_qubit.xy.wait(t)
+                            antagonist_qubit.xy.wait(t)
+                            # Tomographic rotation on the protagonist qubit
                             protagonist_qubit.xy.play("x90")
                             qp.align()
 
@@ -185,14 +194,12 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):  # pylint: dis
                                 # measure both qubits
                                 protagonist_qubit.readout_state(state_t[ii])
                                 save(state_t[ii], state_t_st[ii])
-
-                        else:
-                            protagonist_qubit.resonator.measure("readout", qua_vars=(I_t[ii], Q_t[ii]))
-                            save(I_t[ii], I_t_st[ii])
-                            save(Q_t[ii], Q_t_st[ii])
+                            else:
+                                protagonist_qubit.resonator.measure("readout", qua_vars=(I_t[ii], Q_t[ii]))
+                                save(I_t[ii], I_t_st[ii])
+                                save(Q_t[ii], Q_t_st[ii])
 
             align()
-
         with stream_processing():
             n_st.save("n")
             for i in range(num_qubit_pairs):
@@ -212,7 +219,7 @@ def simulate_qua_program(node: QualibrationNode[Parameters, Quam]):
     # Get the config from the machine
     config = node.machine.generate_config()
     # Simulate the QUA program, generate the waveform report and plot the simulated samples
-    samples, fig, wf_report = simulate_and_plot(qmm, config, node.namespace["qua_program"], node.parameters)
+    _, fig, wf_report = simulate_and_plot(qmm, config, node.namespace["qua_program"], node.parameters)
     # Store the figure, waveform report and simulated samples
     node.results["simulation"] = {"figure": fig, "wf_report": wf_report.to_dict()}
 
@@ -239,6 +246,8 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
             )
         # Display the execution report to expose possible runtime errors
         node.log(job.execution_report())
+    measured_qubit_names = [q.name for q in node.namespace["measured_qubits"]]
+    dataset = dataset.assign_coords(measured_qubit_name=("qubit_pair", measured_qubit_names))
     # Register the raw dataset
     node.results["ds_raw"] = dataset
 
@@ -253,6 +262,18 @@ def load_data(node: QualibrationNode[Parameters, Quam]):
     node.parameters.load_data_id = load_data_id
     # Get the active qubit pairs from the loaded node parameters
     node.namespace["qubit_pairs"] = get_qubit_pairs(node)
+    measured_qubits = []
+    for qp in node.namespace["qubit_pairs"]:
+        if node.parameters.measure_qubit == "control":
+            measured_qubits.append(qp.qubit_control)
+        else:
+            measured_qubits.append(qp.qubit_target)
+    node.namespace["measured_qubits"] = measured_qubits
+    if "measured_qubit_name" not in node.results["ds_raw"].coords:
+        measured_qubit_names = [q.name for q in measured_qubits]
+        node.results["ds_raw"] = node.results["ds_raw"].assign_coords(
+            measured_qubit_name=("qubit_pair", measured_qubit_names)
+        )
 
 
 # %% {Analyse_data}
@@ -278,21 +299,21 @@ def analyse_data(node: QualibrationNode[Parameters, Quam]):
 # %% {Plot_data}
 @node.run_action(skip_if=node.parameters.simulate)
 def plot_data(node: QualibrationNode[Parameters, Quam]):
-    """Plot the JAZZ_ZZ coupling analysis, decay time constant analysis, and oscillation traces."""
+    """Plot J_eff, decay time, raw oscillations, and fitted oscillations."""
     qubit_pairs = node.namespace["qubit_pairs"]
+    ds_fit = node.results["ds_fit"]
 
-    # Plot coupling vs flux bias
-    fig_coupling = plot_raw_data_with_fit(node.results["ds_fit"], qubit_pairs, node)
+    fig_jeff = plot_effective_coupling(ds_fit, qubit_pairs)
+    fig_decay = plot_decay_rate_data(ds_fit, qubit_pairs)
+    fig_raw = plot_raw_data(node.results["ds_raw"], qubit_pairs)
+    fig_fit = plot_fit_data(ds_fit, qubit_pairs)
 
-    # Plot decay time constant vs coupler amplitude
-    fig_decay_time = plot_decay_rate_data(node.results["ds_fit"], qubit_pairs, node)
-
-    # Plot oscillation traces for verification
-    fig_oscillations = plot_oscillation_data(node.results["ds_raw"], qubit_pairs)
-
-    node.results["coupling_figure"] = fig_coupling
-    node.results["decay_time_figure"] = fig_decay_time
-    node.results["oscillation_figure"] = fig_oscillations
+    node.results["figures"] = {
+        "jeff_vs_amp": fig_jeff,
+        "decay_time": fig_decay,
+        "raw_data": fig_raw,
+        **({"fit_data": fig_fit} if fig_fit is not None else {}),
+    }
 
 
 # %% {Update_state}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
@@ -70,23 +70,6 @@ node = QualibrationNode[Parameters, Quam](
 def custom_param(node: QualibrationNode[Parameters, Quam]):
     """Allow the user to locally set the node parameters."""
     # You can get type hinting in your IDE by typing node.parameters.
-    node.parameters.qubit_pairs = None
-    node.parameters.measure_qubit = "control"
-    node.parameters.amp_step = 0.01
-    node.parameters.num_shots = 10
-
-    # node.parameters.qubit_pairs = ["qC4-C5"]
-    # node.parameters.time_min_in_ns = 16
-    # node.parameters.time_max_in_ns = 500
-    # node.parameters.time_step_in_ns = 4
-    # node.parameters.artificial_detuning_in_mhz = 10
-    node.parameters.amp_min = -0.1
-    node.parameters.amp_max = 0.1
-    # node.parameters.amp_step = 0.001
-    # node.parameters.num_shots = 200
-    # node.parameters.use_state_discrimination = True
-    # node.parameters.reset_type = "active"
-    # node.parameters.measure_qubit = "target"
     pass
 
 
@@ -308,14 +291,14 @@ def plot_data(node: QualibrationNode[Parameters, Quam]):
     qubit_pairs = node.namespace["qubit_pairs"]
     ds_fit = node.results["ds_fit"]
 
-    fig_jeff = plot_effective_coupling(ds_fit, qubit_pairs)
-    fig_decay = plot_decay_rate_data(ds_fit, qubit_pairs)
+    fig_jeff = plot_effective_coupling(ds_fit, qubit_pairs, log_y=True)
+    fig_decay = plot_decay_rate_data(ds_fit, qubit_pairs, log_y=True)
     fig_raw = plot_raw_data(node.results["ds_raw"], qubit_pairs)
     fig_fit = plot_fit_data(ds_fit, qubit_pairs)
 
     node.results["figures"] = {
-        "jeff_vs_amp": fig_jeff,
-        "decay_time": fig_decay,
+        **({"jeff_vs_amp": fig_jeff} if fig_jeff is not None else {}),
+        **({"decay_time": fig_decay} if fig_decay is not None else {}),
         "raw_data": fig_raw,
         **({"fit_data": fig_fit} if fig_fit is not None else {}),
     }
@@ -334,8 +317,8 @@ def update_state(node: QualibrationNode[Parameters, Quam]):
             # Update decouple_offset using the coupler amplitude from this run (accumulates across calibrations).
             # Analysis provides two candidates — choose one:
             #   optimal_amplitude: coupler amp where J_eff ≈ artificial_detuning (minimize residual ZZ).
-            #   max_decay_time_amplitude: coupler amp with longest decay time (diagnostic / alternative bias point).
             node.machine.qubit_pairs[qp.name].coupler.decouple_offset += fit_results[qp.name]["optimal_amplitude"]
+            #   max_decay_time_amplitude: coupler amp with longest decay time (diagnostic / alternative bias point).
             # node.machine.qubit_pairs[qp.name].coupler.decouple_offset += fit_results[qp.name]["max_decay_time_amplitude"]
 
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
@@ -127,79 +127,84 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):  # pylint: dis
 
     # The QUA program stored in the node namespace to be transfer to the simulation and execution run_actions
     with program() as node.namespace["qua_program"]:
-        I, I_st, Q, Q_st, n, n_st = node.machine.declare_qua_variables()
+        I, I_st, Q, Q_st, n, n_st = node.machine.declare_qua_variables(num_IQ_pairs=num_qubit_pairs)
         virtual_detuning_phase = declare(fixed)
         amp = declare(fixed)
         t = declare(int)
         if node.parameters.use_state_discrimination:
             state = [declare(int) for _ in range(num_qubit_pairs)]
-            state_st = [declare_stream() for _ in range(num_qubit_pairs)]
+            state_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
 
         for multiplexed_qubit_pairs in qubit_pairs.batch():
-            # Initialize the qubits
+            # Initialize the QPU
             for qp in multiplexed_qubit_pairs.values():
                 node.machine.initialize_qpu(target=qp.qubit_control)
                 node.machine.initialize_qpu(target=qp.qubit_target)
-            # Loop for averaging
+            align()
+
+            measured_qubits_map = {
+                ii: qp.qubit_control if node.parameters.measure_qubit == "control" else qp.qubit_target
+                for ii, qp in multiplexed_qubit_pairs.items()
+            }
+            partner_qubits_map = {
+                ii: qp.qubit_target if node.parameters.measure_qubit == "control" else qp.qubit_control
+                for ii, qp in multiplexed_qubit_pairs.items()
+            }
+
             with for_(n, 0, n < n_avg, n + 1):
                 save(n, n_st)
-                # Loop over the amplitude scale
                 with for_(*from_array(amp, amplitudes)):
                     with for_(*from_array(t, durations)):
                         assign(virtual_detuning_phase, Cast.mul_fixed_by_int(detuning * 1e-9, 4 * t))
+
+                        # Reset
                         for ii, qp in multiplexed_qubit_pairs.items():
-                            # Reset the qubits
                             qp.qubit_control.reset(node.parameters.reset_type, node.parameters.simulate)
                             qp.qubit_target.reset(node.parameters.reset_type, node.parameters.simulate)
-                            qp.align()
-                            # Reset the frames of both qubits
                             reset_frame(qp.qubit_target.xy.name)
                             reset_frame(qp.qubit_control.xy.name)
-                            qp.align()
-                            # setting the protagonist and antagonist qubits
-                            if node.parameters.measure_qubit == "control":
-                                protagonist_qubit = qp.qubit_control
-                                antagonist_qubit = qp.qubit_target
-                            else:
-                                protagonist_qubit = qp.qubit_target
-                                antagonist_qubit = qp.qubit_control
-                            qp.align()
-                            # play the x90 gate on the protagonist qubit
-                            protagonist_qubit.xy.play("x90")
-                            qp.coupler.wait(protagonist_qubit.xy.operations["x90"].length//4)
-                            antagonist_qubit.wait(protagonist_qubit.xy.operations["x90"].length//4)
-                            # play the coupler pulse
-                            qp.coupler.play(
-                                "const", amplitude_scale=amp / qp.coupler.operations["const"].amplitude, duration=t
-                            )
-                            protagonist_qubit.xy.wait(t)
-                            antagonist_qubit.xy.wait(t)
-                            # Echo pulse
-                            protagonist_qubit.xy.play("x180")
-                            antagonist_qubit.xy.play("x180")
-                            qp.coupler.wait(protagonist_qubit.xy.operations["x180"].length//4)
-                            # rotate the frame
-                            protagonist_qubit.xy.frame_rotation_2pi(virtual_detuning_phase)
-                            # play the coupler pulse
-                            qp.coupler.play(
-                                "const", amplitude_scale=amp / qp.coupler.operations["const"].amplitude, duration=t
-                            )
-                            protagonist_qubit.xy.wait(t)
-                            antagonist_qubit.xy.wait(t)
-                            # Tomographic rotation on the protagonist qubit
-                            protagonist_qubit.xy.play("x90")
-                            qp.align()
+                        align()
 
+                        # Qubit manipulation (JAZZ echo sequence)
+                        for ii, qp in multiplexed_qubit_pairs.items():
+                            measured_qubit = measured_qubits_map[ii]
+                            partner_qubit = partner_qubits_map[ii]
+                            measured_qubit.xy.play("x90")
+                            qp.coupler.wait(measured_qubit.xy.operations["x90"].length // 4)
+                            partner_qubit.wait(measured_qubit.xy.operations["x90"].length // 4)
+                            qp.coupler.play(
+                                "const",
+                                amplitude_scale=amp / qp.coupler.operations["const"].amplitude,
+                                duration=t,
+                            )
+                            measured_qubit.xy.wait(t)
+                            partner_qubit.xy.wait(t)
+                            measured_qubit.xy.play("x180")
+                            partner_qubit.xy.play("x180")
+                            qp.coupler.wait(measured_qubit.xy.operations["x180"].length // 4)
+                            measured_qubit.xy.frame_rotation_2pi(virtual_detuning_phase)
+                            qp.coupler.play(
+                                "const",
+                                amplitude_scale=amp / qp.coupler.operations["const"].amplitude,
+                                duration=t,
+                            )
+                            measured_qubit.xy.wait(t)
+                            partner_qubit.xy.wait(t)
+                            measured_qubit.xy.play("x90")
+                        align()
+
+                        # Qubit readout — measure the selected qubit only
+                        for ii, _ in multiplexed_qubit_pairs.items():
+                            measured_qubit = measured_qubits_map[ii]
                             if node.parameters.use_state_discrimination:
-                                # measure both qubits
-                                protagonist_qubit.readout_state(state[ii])
+                                measured_qubit.readout_state(state[ii])
                                 save(state[ii], state_st[ii])
                             else:
-                                protagonist_qubit.resonator.measure("readout", qua_vars=(I[ii], Q[ii]))
+                                measured_qubit.resonator.measure("readout", qua_vars=(I[ii], Q[ii]))
                                 save(I[ii], I_st[ii])
                                 save(Q[ii], Q_st[ii])
+                        align()
 
-            align()
         with stream_processing():
             n_st.save("n")
             for i in range(num_qubit_pairs):

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
@@ -66,7 +66,7 @@ node = QualibrationNode[Parameters, Quam](
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under calibration_utils/cz_conditional_phase/parameters.py
 )
-#instrument_calibration_node(node)
+# instrument_calibration_node(node)
 
 
 # Any parameters that should change for debugging purposes only should go in here
@@ -109,7 +109,9 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):  # pylint: dis
     # Extract the sweep parameters and axes from the node parameters
     n_avg = node.parameters.num_shots
     amplitudes = np.arange(node.parameters.amp_min, node.parameters.amp_max, node.parameters.amp_step)
-    durations = np.arange(node.parameters.time_min_in_ns, node.parameters.time_max_in_ns, node.parameters.time_step_in_ns) // 4
+    durations = (
+        np.arange(node.parameters.time_min_in_ns, node.parameters.time_max_in_ns, node.parameters.time_step_in_ns) // 4
+    )
     detuning = node.parameters.artificial_detuning_in_mhz * u.MHz
 
     # Register the sweep axes to be added to the dataset when fetching data

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
@@ -127,13 +127,13 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):  # pylint: dis
 
     # The QUA program stored in the node namespace to be transfer to the simulation and execution run_actions
     with program() as node.namespace["qua_program"]:
-        I_t, I_t_st, Q_t, Q_t_st, n, n_st = node.machine.declare_qua_variables()
+        I, I_st, Q, Q_st, n, n_st = node.machine.declare_qua_variables()
         virtual_detuning_phase = declare(fixed)
         amp = declare(fixed)
         t = declare(int)
         if node.parameters.use_state_discrimination:
-            state_t = [declare(int) for _ in range(num_qubit_pairs)]
-            state_t_st = [declare_stream() for _ in range(num_qubit_pairs)]
+            state = [declare(int) for _ in range(num_qubit_pairs)]
+            state_st = [declare_stream() for _ in range(num_qubit_pairs)]
 
         for multiplexed_qubit_pairs in qubit_pairs.batch():
             # Initialize the qubits
@@ -192,22 +192,22 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):  # pylint: dis
 
                             if node.parameters.use_state_discrimination:
                                 # measure both qubits
-                                protagonist_qubit.readout_state(state_t[ii])
-                                save(state_t[ii], state_t_st[ii])
+                                protagonist_qubit.readout_state(state[ii])
+                                save(state[ii], state_st[ii])
                             else:
-                                protagonist_qubit.resonator.measure("readout", qua_vars=(I_t[ii], Q_t[ii]))
-                                save(I_t[ii], I_t_st[ii])
-                                save(Q_t[ii], Q_t_st[ii])
+                                protagonist_qubit.resonator.measure("readout", qua_vars=(I[ii], Q[ii]))
+                                save(I[ii], I_st[ii])
+                                save(Q[ii], Q_st[ii])
 
             align()
         with stream_processing():
             n_st.save("n")
             for i in range(num_qubit_pairs):
                 if node.parameters.use_state_discrimination:
-                    state_t_st[i].buffer(len(durations)).buffer(len(amplitudes)).average().save(f"state_target{i + 1}")
+                    state_st[i].buffer(len(durations)).buffer(len(amplitudes)).average().save(f"state_measured{i + 1}")
                 else:
-                    I_t_st[i].buffer(len(durations)).buffer(len(amplitudes)).average().save(f"I_target{i + 1}")
-                    Q_t_st[i].buffer(len(durations)).buffer(len(amplitudes)).average().save(f"Q_target{i + 1}")
+                    I_st[i].buffer(len(durations)).buffer(len(amplitudes)).average().save(f"I_measured{i + 1}")
+                    Q_st[i].buffer(len(durations)).buffer(len(amplitudes)).average().save(f"Q_measured{i + 1}")
 
 
 # %% {Simulate}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
@@ -98,7 +98,9 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):  # pylint: dis
     # Extract the sweep parameters and axes from the node parameters
     n_avg = node.parameters.num_shots
     amplitudes = np.arange(node.parameters.amp_min, node.parameters.amp_max, node.parameters.amp_step)
-    durations = np.arange(node.parameters.time_min_in_ns, node.parameters.time_max_in_ns, node.parameters.time_step_in_ns) // 4
+    durations = (
+        np.arange(node.parameters.time_min_in_ns, node.parameters.time_max_in_ns, node.parameters.time_step_in_ns) // 4
+    )
     detuning = node.parameters.artificial_detuning_in_mhz * u.MHz
 
     # Register the sweep axes to be added to the dataset when fetching data

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
@@ -331,11 +331,12 @@ def update_state(node: QualibrationNode[Parameters, Quam]):
         for qp in node.namespace["qubit_pairs"]:
             if node.outcomes[qp.name] == "failed":
                 continue
+            # Update decouple_offset using the coupler amplitude from this run (accumulates across calibrations).
+            # Analysis provides two candidates — choose one:
+            #   optimal_amplitude: coupler amp where J_eff ≈ artificial_detuning (minimize residual ZZ).
+            #   max_decay_time_amplitude: coupler amp with longest decay time (diagnostic / alternative bias point).
             node.machine.qubit_pairs[qp.name].coupler.decouple_offset += fit_results[qp.name]["optimal_amplitude"]
-            # node.machine.qubit_pairs[qp.name].coupler.decouple_offset += fit_results[qp.name][
-            #     "max_decay_time_amplitude"
-            # ]
-            # pass
+            # node.machine.qubit_pairs[qp.name].coupler.decouple_offset += fit_results[qp.name]["max_decay_time_amplitude"]
 
 
 # %% {Save_results}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/24_zz_off_jazz.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/24_zz_off_jazz.py
@@ -1,0 +1,320 @@
+# %% {Imports}
+from dataclasses import asdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from calibration_utils.JAZZ_ZZ import (
+    FitResults,
+    Parameters,
+    fit_raw_data,
+    log_fitted_results,
+    plot_decay_rate_data,
+    plot_oscillation_data,
+    plot_raw_data_with_fit,
+    process_raw_dataset,
+)
+from qm import SimulationConfig
+from qm.qua import *
+from qualang_tools.bakery import baking
+from qualang_tools.loops import from_array
+from qualang_tools.multi_user import qm_session
+from qualang_tools.results import fetching_tool, progress_counter
+from qualang_tools.units import unit
+from qualibrate import QualibrationNode
+from qualibration_libs.core import tracked_updates
+from qualibration_libs.data import XarrayDataFetcher
+from qualibration_libs.parameters import get_qubit_pairs
+from qualibration_libs.runtime import simulate_and_plot
+from quam_config import Quam
+
+# %% {Initialisation}
+description = """
+JAZZ_ZZ CALIBRATION FOR COUPLER DECOUPLE OFFSET
+
+This calibration measures residual ZZ interaction in a qubit pair by sweeping the coupler pulse
+amplitude and interaction time in a JAZZ-style echo sequence.
+
+For each qubit pair, the sequence:
+1. Resets the control and target qubits
+2. Prepares the measured qubit in a superposition
+3. Applies two coupler pulses separated by echo pi-pulses on both qubits
+4. Applies a virtual phase rotation corresponding to the artificial detuning
+5. Measures the selected qubit using either state discrimination or IQ readout
+
+The experiment is repeated for a range of coupler amplitudes and pulse durations.
+For each amplitude, the measured oscillation versus interaction time is fitted to a damped cosine model
+to extract:
+1. The effective interaction strength J_eff
+2. The decay rate gamma
+3. The decay time constant tau = 1 / gamma
+
+The main calibration target is the coupler amplitude for which the extracted J_eff is closest to the
+requested artificial detuning. This amplitude is stored as the optimal_amplitude.
+For diagnostics, the analysis also records the amplitude that gives the maximum decay time constant.
+
+Prerequisites:
+- Calibrated single-qubit gates for both qubits in the pair
+
+State update:
+- qubit_pair.coupler.decouple_offset += optimal_amplitude
+"""
+
+# Be sure to include [Parameters, Quam] so the node has proper type hinting
+node = QualibrationNode[Parameters, Quam](
+    name="24_zz_off_jazz",  # Name should be unique
+    description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
+    parameters=Parameters(),  # Node parameters defined under calibration_utils/cz_conditional_phase/parameters.py
+)
+#instrument_calibration_node(node)
+
+
+# Any parameters that should change for debugging purposes only should go in here
+# These parameters are ignored when run through the GUI or as part of a graph
+@node.run_action(skip_if=node.modes.external)
+def custom_param(node: QualibrationNode[Parameters, Quam]):
+    """Allow the user to locally set the node parameters."""
+    # You can get type hinting in your IDE by typing node.parameters.
+    # node.parameters.qubit_pairs = ["q1-q2"]
+    # node.parameters.qubit_pairs = ["qC4-C5"]
+    # node.parameters.time_min_in_ns = 16
+    # node.parameters.time_max_in_ns = 500
+    # node.parameters.time_step_in_ns = 4
+    # node.parameters.artificial_detuning_in_mhz = 10
+    # node.parameters.amp_min = -0.04
+    # node.parameters.amp_max = 0.04
+    # node.parameters.amp_step = 0.001
+    # node.parameters.num_shots = 200
+    # node.parameters.use_state_discrimination = True
+    # node.parameters.reset_type = "active"
+    # node.parameters.measure_qubit = "target"
+    pass
+
+
+# Instantiate the QUAM class from the state file
+node.machine = Quam.load()
+
+
+# %% {Create_QUA_program}
+@node.run_action(skip_if=node.parameters.load_data_id is not None)
+def create_qua_program(node: QualibrationNode[Parameters, Quam]):  # pylint: disable=too-many-statements
+    """Create the sweep axes and generate the QUA program from the pulse sequence and the node parameters."""
+
+    # Class containing tools to help handle units and conversions.
+    u = unit(coerce_to_integer=True)
+    # Get the active qubit pairs from the node and organize them by batches
+    node.namespace["qubit_pairs"] = qubit_pairs = get_qubit_pairs(node)
+    num_qubit_pairs = len(qubit_pairs)
+
+    # Extract the sweep parameters and axes from the node parameters
+    n_avg = node.parameters.num_shots
+    amplitudes = np.arange(node.parameters.amp_min, node.parameters.amp_max, node.parameters.amp_step)
+    durations = np.arange(node.parameters.time_min_in_ns, node.parameters.time_max_in_ns, node.parameters.time_step_in_ns) // 4
+    detuning = node.parameters.artificial_detuning_in_mhz * u.MHz
+
+    # Register the sweep axes to be added to the dataset when fetching data
+    node.namespace["sweep_axes"] = {
+        "qubit_pair": xr.DataArray(qubit_pairs.get_names()),
+        "amp": xr.DataArray(amplitudes, attrs={"long_name": "coupler amplitude", "units": "V"}),
+        "time": xr.DataArray(durations * 4, attrs={"long_name": "coupler amplitude", "units": "ns"}),
+    }
+
+    # The QUA program stored in the node namespace to be transfer to the simulation and execution run_actions
+    with program() as node.namespace["qua_program"]:
+        I_t, I_t_st, Q_t, Q_t_st, n, n_st = node.machine.declare_qua_variables()
+        virtual_detuning_phase = declare(fixed)
+        amp = declare(fixed)
+        t = declare(int)
+        if node.parameters.use_state_discrimination:
+            state_t = [declare(int) for _ in range(num_qubit_pairs)]
+            state_t_st = [declare_stream() for _ in range(num_qubit_pairs)]
+
+        for multiplexed_qubit_pairs in qubit_pairs.batch():
+            # Initialize the qubits
+            for qp in multiplexed_qubit_pairs.values():
+                node.machine.initialize_qpu(target=qp.qubit_control)
+                node.machine.initialize_qpu(target=qp.qubit_target)
+            # Loop for averaging
+            with for_(n, 0, n < n_avg, n + 1):
+                save(n, n_st)
+                # Loop over the amplitude scale
+                with for_(*from_array(amp, amplitudes)):
+                    with for_(*from_array(t, durations)):
+                        assign(virtual_detuning_phase, Cast.mul_fixed_by_int(detuning * 1e-9, 4 * t))
+                        for ii, qp in multiplexed_qubit_pairs.items():
+                            # Reset the qubits
+                            qp.qubit_control.reset(node.parameters.reset_type, node.parameters.simulate)
+                            qp.qubit_target.reset(node.parameters.reset_type, node.parameters.simulate)
+                            qp.align()
+                            # Reset the frames of both qubits
+                            reset_frame(qp.qubit_target.xy.name)
+                            reset_frame(qp.qubit_control.xy.name)
+                            if node.parameters.measure_qubit == "control":
+                                protagonist_qubit = qp.qubit_control
+                                antagonist_qubit = qp.qubit_target
+                            else:
+                                protagonist_qubit = qp.qubit_target
+                                antagonist_qubit = qp.qubit_control
+                            protagonist_qubit.xy.play("x90")
+                            qp.align()
+                            qp.coupler.wait(10)
+                            # play the CZ gate
+                            qp.coupler.play(
+                                "const", amplitude_scale=amp / qp.coupler.operations["const"].amplitude, duration=t
+                            )
+                            qp.align()
+                            # Echo pulse
+                            protagonist_qubit.xy.play("x180")
+                            antagonist_qubit.xy.play("x180")
+                            qp.align()
+                            # rotate the frame
+                            protagonist_qubit.xy.frame_rotation_2pi(virtual_detuning_phase)
+                            qp.coupler.wait(10)
+                            # play the CZ gate
+                            qp.coupler.play(
+                                "const", amplitude_scale=amp / qp.coupler.operations["const"].amplitude, duration=t
+                            )
+                            qp.align()
+                            # Tomographic rotation on the target qubit
+                            protagonist_qubit.xy.play("x90")
+                            qp.align()
+
+                            if node.parameters.use_state_discrimination:
+                                # measure both qubits
+                                protagonist_qubit.readout_state(state_t[ii])
+                                save(state_t[ii], state_t_st[ii])
+
+                        else:
+                            protagonist_qubit.resonator.measure("readout", qua_vars=(I_t[ii], Q_t[ii]))
+                            save(I_t[ii], I_t_st[ii])
+                            save(Q_t[ii], Q_t_st[ii])
+
+            align()
+
+        with stream_processing():
+            n_st.save("n")
+            for i in range(num_qubit_pairs):
+                if node.parameters.use_state_discrimination:
+                    state_t_st[i].buffer(len(durations)).buffer(len(amplitudes)).average().save(f"state_target{i + 1}")
+                else:
+                    I_t_st[i].buffer(len(durations)).buffer(len(amplitudes)).average().save(f"I_target{i + 1}")
+                    Q_t_st[i].buffer(len(durations)).buffer(len(amplitudes)).average().save(f"Q_target{i + 1}")
+
+
+# %% {Simulate}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or not node.parameters.simulate)
+def simulate_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Connect to the QOP and simulate the QUA program"""
+    # Connect to the QOP
+    qmm = node.machine.connect()
+    # Get the config from the machine
+    config = node.machine.generate_config()
+    # Simulate the QUA program, generate the waveform report and plot the simulated samples
+    samples, fig, wf_report = simulate_and_plot(qmm, config, node.namespace["qua_program"], node.parameters)
+    # Store the figure, waveform report and simulated samples
+    node.results["simulation"] = {"figure": fig, "wf_report": wf_report.to_dict()}
+
+
+# %% {Execute}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or node.parameters.simulate)
+def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Connect to the QOP, execute the QUA program and fetch the raw data and store it in a xarray dataset."""
+    # Connect to the QOP
+    qmm = node.machine.connect()
+    # Get the config from the machine
+    config = node.machine.generate_config()
+    # Execute the QUA program only if the quantum machine is available (this is to avoid interrupting running jobs).
+    with qm_session(qmm, config, timeout=node.parameters.timeout) as qm:
+        # The job is stored in the node namespace to be reused in the fetching_data run_action
+        node.namespace["job"] = job = qm.execute(node.namespace["qua_program"])
+        # Display the progress bar
+        data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
+        for dataset in data_fetcher:
+            progress_counter(
+                data_fetcher.get("n", 0),
+                node.parameters.num_shots,
+                start_time=data_fetcher.t_start,
+            )
+        # Display the execution report to expose possible runtime errors
+        node.log(job.execution_report())
+    # Register the raw dataset
+    node.results["ds_raw"] = dataset
+
+
+# %% {Load_data}
+@node.run_action(skip_if=node.parameters.load_data_id is None)
+def load_data(node: QualibrationNode[Parameters, Quam]):
+    """Load a previously acquired dataset."""
+    load_data_id = node.parameters.load_data_id
+    # Load the specified dataset
+    node.load_from_id(node.parameters.load_data_id)
+    node.parameters.load_data_id = load_data_id
+    # Get the active qubit pairs from the loaded node parameters
+    node.namespace["qubit_pairs"] = get_qubit_pairs(node)
+
+
+# %% {Analyse_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def analyse_data(node: QualibrationNode[Parameters, Quam]):
+    """Analyse the raw data and store the fitted data in another xarray dataset and the fitted results."""
+    node.results["ds_raw"] = process_raw_dataset(node.results["ds_raw"], node)
+    node.results["ds_fit"], fit_results = fit_raw_data(node.results["ds_raw"], node)
+
+    # Store fit results in the format expected by the rest of the node
+    node.results["fit_results"] = {k: asdict(v) for k, v in fit_results.items()}
+
+    # Log the relevant information extracted from the data analysis
+    log_fitted_results(fit_results, log_callable=node.log)
+
+    # Set outcomes based on fit success
+    node.outcomes = {
+        qubit_pair_name: ("successful" if fit_result.success else "failed")
+        for qubit_pair_name, fit_result in fit_results.items()
+    }
+
+
+# %% {Plot_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def plot_data(node: QualibrationNode[Parameters, Quam]):
+    """Plot the JAZZ_ZZ coupling analysis, decay time constant analysis, and oscillation traces."""
+    qubit_pairs = node.namespace["qubit_pairs"]
+
+    # Plot coupling vs flux bias
+    fig_coupling = plot_raw_data_with_fit(node.results["ds_fit"], qubit_pairs, node)
+
+    # Plot decay time constant vs coupler amplitude
+    fig_decay_time = plot_decay_rate_data(node.results["ds_fit"], qubit_pairs, node)
+
+    # Plot oscillation traces for verification
+    fig_oscillations = plot_oscillation_data(node.results["ds_raw"], qubit_pairs)
+
+    node.results["coupling_figure"] = fig_coupling
+    node.results["decay_time_figure"] = fig_decay_time
+    node.results["oscillation_figure"] = fig_oscillations
+
+
+# %% {Update_state}
+@node.run_action(skip_if=node.parameters.simulate)
+def update_state(node: QualibrationNode[Parameters, Quam]):
+    """Update the relevant parameters if the qubit pair data analysis was successful."""
+
+    with node.record_state_updates():
+        fit_results = node.results["fit_results"]
+        for qp in node.namespace["qubit_pairs"]:
+            if node.outcomes[qp.name] == "failed":
+                continue
+            node.machine.qubit_pairs[qp.name].coupler.decouple_offset += fit_results[qp.name]["optimal_amplitude"]
+            # node.machine.qubit_pairs[qp.name].coupler.decouple_offset += fit_results[qp.name][
+            #     "max_decay_time_amplitude"
+            # ]
+            # pass
+
+
+# %% {Save_results}
+@node.run_action()
+def save_results(node: QualibrationNode[Parameters, Quam]):
+    """Save the calibration results to the node storage."""
+    node.save()
+
+
+# %%


### PR DESCRIPTION
**What**
- Adds qualibration node `19_zz_off_jazz` and utils package `calibration_utils/JAZZ_ZZ/`.
- Measures residual ZZ coupling by sweeping coupler amplitude and interaction time in a JAZZ echo sequence (`x90 → coupler → π echo → virtual Z → coupler → x90`).
- Fits damped cosines per amplitude to extract `J_eff`, decay rate, and updates `qubit_pair.coupler.decouple_offset` from the fitted bias point.

**Why** 
- Tunable-coupler QPUs need a dedicated step to minimize residual ZZ at the operating point before two-qubit calibrations.

**Notes for reviewers**
-  Aligns with other coupler-flux nodes (03c, 09b) for structure and plotting, so review and maintenance stay consistent.
-  non-deterministic `align` used in favour of explicit `waits`
- Coupling and decay figures can do both linear and log plots