### PR TITLE
fix/add readout_GEF setup to GEF calibration nodes 14 and 15

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/iq_blobs_ef/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/iq_blobs_ef/__init__.py
@@ -1,3 +1,5 @@
+"""IQ blobs GEF calibration utilities for three-state (g, e, f) discrimination."""
+
 from .parameters import Parameters
 from .analysis import process_raw_dataset, fit_raw_data, log_fitted_results
 from .plotting import plot_iq_blobs, plot_confusion_matrices

--- a/qualibration_graphs/superconducting/calibration_utils/iq_blobs_ef/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/iq_blobs_ef/analysis.py
@@ -1,3 +1,5 @@
+"""Analysis utilities for IQ blobs GEF: Gaussian fitting for g, e, f state centers."""
+
 import logging
 import re
 from dataclasses import dataclass
@@ -12,7 +14,7 @@ from scipy.optimize import curve_fit, minimize
 
 @dataclass
 class FitParameters:
-    """Stores the relevant qubit spectroscopy experiment fit parameters for a single qubit"""
+    """Stores the IQ blob center positions for g, e, f states of a single qubit."""
 
     I_g_center: float
     Q_g_center: float
@@ -53,6 +55,8 @@ def log_fitted_results(fit_results: Dict, log_callable=None):
 
 
 def find_biggest_gaussian(da):
+    """Fit a Gaussian to histogram data and return the peak position (mu)."""
+
     # Define Gaussian function
     def gaussian(x, amp, mu, sigma):
         return amp * np.exp(-((x - mu) ** 2) / (2 * sigma**2))
@@ -118,6 +122,8 @@ def fit_gaussian_centers(ds: xr.Dataset, node: QualibrationNode) -> xr.Dataset:
 
 
 def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
+    """Convert raw IQ data to voltage and fix tuple structure in dataset."""
+
     # Fix the structure of ds to avoid tuples
     def extract_value(element):
         if isinstance(element, tuple):
@@ -182,6 +188,7 @@ def _extract_relevant_fit_parameters(fit: xr.Dataset, node: QualibrationNode):
 
 
 def center_matrix(da: xr.DataArray) -> xr.DataArray:
+    """Build center matrix from fitted g, e, f state IQ centers."""
     center = np.array(
         [
             [da.I_g_center.item(), da.Q_g_center.item()],

--- a/qualibration_graphs/superconducting/calibration_utils/iq_blobs_ef/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/iq_blobs_ef/parameters.py
@@ -1,3 +1,5 @@
+"""Parameter definitions for IQ blobs GEF calibration experiment."""
+
 from typing import Literal
 from qualibrate import NodeParameters
 from qualibrate.core.parameters import RunnableParameters
@@ -5,10 +7,12 @@ from qualibration_libs.parameters import QubitsExperimentNodeParameters, CommonN
 
 
 class NodeSpecificParameters(RunnableParameters):
+    """IQ blobs GEF specific parameters for three-state measurement."""
+
     num_shots: int = 2000
     """Number of runs to perform. Default is 2000."""
-    operation: Literal["readout", "readout_QND"] = "readout"
-    """Type of operation to perform. Default is "readout"."""
+    operation: Literal["readout", "readout_QND", "readout_GEF"] = "readout_GEF"
+    """Type of operation to perform. Default is "readout_GEF"."""
 
 
 class Parameters(
@@ -17,4 +21,6 @@ class Parameters(
     NodeSpecificParameters,
     QubitsExperimentNodeParameters,
 ):
+    """Combined parameters for IQ blobs GEF calibration node."""
+
     pass

--- a/qualibration_graphs/superconducting/calibration_utils/iq_blobs_ef/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/iq_blobs_ef/plotting.py
@@ -1,3 +1,5 @@
+"""Plotting utilities for IQ blobs GEF calibration visualizations."""
+
 from typing import List
 
 import numpy as np
@@ -180,7 +182,7 @@ def plot_individual_confusion_matrix(ax: Axes, ds: xr.Dataset, qubit: dict[str, 
         dist_f = np.sqrt((fit.I_f_center - fit[f"I{prep_state}"]) ** 2 + (fit.Q_f_center - fit[f"Q{prep_state}"]) ** 2)
         dist = np.stack([dist_g, dist_e, dist_f], axis=0)
         counts = np.argmin(dist, axis=0)
-        confusion[p][0] = np.sum(counts == 0) / len(counts)
+        confusion[p][0] = np.sum(counts == 0) / len(counts)  # pylint: disable=C1805
         confusion[p][1] = np.sum(counts == 1) / len(counts)
         confusion[p][2] = np.sum(counts == 2) / len(counts)
 

--- a/qualibration_graphs/superconducting/calibration_utils/readout_gef_frequency_optimization/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/readout_gef_frequency_optimization/__init__.py
@@ -1,3 +1,5 @@
+"""GEF readout frequency optimization utilities for three-state discrimination."""
+
 from .analysis import fit_raw_data, log_fitted_results, process_raw_dataset
 from .parameters import Parameters
 from .plotting import plot_distances_with_fit

--- a/qualibration_graphs/superconducting/calibration_utils/readout_gef_frequency_optimization/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/readout_gef_frequency_optimization/analysis.py
@@ -1,3 +1,5 @@
+"""Analysis utilities for GEF readout frequency optimization: centroid distance fitting."""
+
 import logging
 from dataclasses import dataclass
 from typing import Tuple, Dict
@@ -41,6 +43,7 @@ def log_fitted_results(fit_results: Dict, log_callable=None):
 
 
 def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
+    """Convert raw IQ data to voltage for all g, e, f states."""
     # Convert IQ data into volts
     ds = convert_IQ_to_V(ds, node.namespace["qubits"], IQ_list=["Ig", "Qg", "Ie", "Qe", "If", "Qf"])
     return ds

--- a/qualibration_graphs/superconducting/calibration_utils/readout_gef_frequency_optimization/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/readout_gef_frequency_optimization/parameters.py
@@ -1,17 +1,22 @@
+"""Parameter definitions for GEF readout frequency optimization experiment."""
+
+from typing import Literal
 from qualibrate import NodeParameters
 from qualibrate.core.parameters import RunnableParameters
 from qualibration_libs.parameters import QubitsExperimentNodeParameters, CommonNodeParameters
 
 
 class NodeSpecificParameters(RunnableParameters):
+    """GEF readout frequency optimization parameters for frequency sweep configuration."""
+
     num_shots: int = 100
     """Number of averages to perform. Default is 100."""
     frequency_span_in_mhz: float = 2
     """Span of frequencies to sweep in MHz. Default is 2 MHz."""
     frequency_step_in_mhz: float = 0.01
     """Step size for frequency sweep in MHz. Default is 0.01 MHz."""
-    operation: str = "readout"
-    """Operation to perform, e.g., 'readout'. Default is 'readout'."""
+    operation: Literal["readout", "readout_QND", "readout_GEF"] = "readout_GEF"
+    """Operation to perform, e.g., 'readout', 'readout_QND', or 'readout_GEF'. Default is 'readout_GEF'."""
 
 
 class Parameters(
@@ -20,4 +25,6 @@ class Parameters(
     NodeSpecificParameters,
     QubitsExperimentNodeParameters,
 ):
+    """Combined parameters for GEF readout frequency optimization node."""
+
     pass

--- a/qualibration_graphs/superconducting/calibration_utils/readout_gef_frequency_optimization/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/readout_gef_frequency_optimization/plotting.py
@@ -1,3 +1,5 @@
+"""Plotting utilities for GEF readout frequency optimization visualizations."""
+
 from typing import List
 
 import xarray as xr
@@ -45,7 +47,7 @@ def plot_distances_with_fit(ds: xr.Dataset, qubits: List[AnyTransmon], fits: xr.
 
 def plot_individual_distance_with_fit(ax: Axes, ds: xr.Dataset, qubit: dict[str, str], fit: xr.Dataset = None):
     """
-    Plots the distance between the resonator responses when the qubit is in |g> and |e> on a given axis with optional fit.
+    Plot IQ distance vs frequency for g, e, f states with optimal detuning marker.
 
     Parameters
     ----------

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/14_gef_readout_frequency_optimization.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/14_gef_readout_frequency_optimization.py
@@ -1,4 +1,5 @@
 # %% {Imports}
+import dataclasses
 from dataclasses import asdict
 
 import matplotlib.pyplot as plt
@@ -61,7 +62,7 @@ Notes:
 
 # Be sure to include [Parameters, Quam] so the node has proper type hinting
 node = QualibrationNode[Parameters, Quam](
-    name="14_gef_frequency_optimization",  # Name should be unique
+    name="14_gef_readout_frequency_optimization",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
 )
@@ -71,12 +72,8 @@ node = QualibrationNode[Parameters, Quam](
 # These parameters are ignored when run through the GUI or as part of a graph
 @node.run_action(skip_if=node.modes.external)
 def custom_param(node: QualibrationNode[Parameters, Quam]):
-    """
-    Allow the user to locally set the node parameters for debugging purposes, or
-    execution in the Python IDE.
-    """
+    """Allow the user to locally set the node parameters."""
     # You can get type hinting in your IDE by typing node.parameters.
-    # node.parameters.qubits = ["q1", "q2"]
     pass
 
 
@@ -96,6 +93,18 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     # Get the active qubits from the node and organize them by batches
     node.namespace["qubits"] = qubits = get_qubits(node)
     num_qubits = len(qubits)
+
+    for qubit_obj in qubits:
+        if "readout_GEF" in qubit_obj.resonator.operations:
+            continue
+        readout_op = qubit_obj.resonator.operations["readout"]
+        new_length = int(round(readout_op.length * 1.5 / 4) * 4)  # multiple of 4 ns
+        qubit_obj.resonator.operations["readout_GEF"] = dataclasses.replace(
+            readout_op,
+            length=new_length,
+            threshold=None,
+            rus_exit_threshold=None,
+        )
 
     n_runs = node.parameters.num_shots  # Number of runs
     operation = node.parameters.operation
@@ -227,7 +236,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )
@@ -304,6 +313,7 @@ def update_state(node: QualibrationNode[Parameters, Quam]):
 # %% {Save_results}
 @node.run_action()
 def save_results(node: QualibrationNode[Parameters, Quam]):
+    """Save all node results and state updates."""
     node.save()
 
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/15_iq_blobs_gef.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/15_iq_blobs_gef.py
@@ -49,6 +49,7 @@ node = QualibrationNode[Parameters, Quam](
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
 )
 
+
 # Any parameters that should change for debugging purposes only should go in here
 # These parameters are ignored when run through the GUI or as part of a graph
 @node.run_action(skip_if=node.modes.external)

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/15_iq_blobs_gef.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/15_iq_blobs_gef.py
@@ -1,4 +1,5 @@
 # %% {Imports}
+import dataclasses
 from dataclasses import asdict
 
 import matplotlib.pyplot as plt
@@ -48,17 +49,12 @@ node = QualibrationNode[Parameters, Quam](
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
 )
 
-
 # Any parameters that should change for debugging purposes only should go in here
 # These parameters are ignored when run through the GUI or as part of a graph
 @node.run_action(skip_if=node.modes.external)
 def custom_param(node: QualibrationNode[Parameters, Quam]):
-    """
-    Allow the user to locally set the node parameters for debugging purposes, or
-    execution in the Python IDE.
-    """
+    """Allow the user to locally set the node parameters."""
     # You can get type hinting in your IDE by typing node.parameters.
-    node.parameters.qubits = ["qD1", "qD2"]
     pass
 
 
@@ -80,6 +76,18 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     # Get the active qubits from the node and organize them by batches
     node.namespace["qubits"] = qubits = get_qubits(node)
     num_qubits = len(qubits)
+
+    for qubit_obj in qubits:
+        if "readout_GEF" in qubit_obj.resonator.operations:
+            continue
+        readout_op = qubit_obj.resonator.operations["readout"]
+        new_length = int(round(readout_op.length * 1.5 / 4) * 4)  # multiple of 4 ns
+        qubit_obj.resonator.operations["readout_GEF"] = dataclasses.replace(
+            readout_op,
+            length=new_length,
+            threshold=None,
+            rus_exit_threshold=None,
+        )
 
     n_runs = node.parameters.num_shots  # Number of runs
     operation = node.parameters.operation
@@ -199,7 +207,7 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )
@@ -273,6 +281,7 @@ def update_state(node: QualibrationNode[Parameters, Quam]):
 # %% {Save_results}
 @node.run_action()
 def save_results(node: QualibrationNode[Parameters, Quam]):
+    """Save all node results and state updates."""
     node.save()
 
 


### PR DESCRIPTION
**What**

- `14_gef_readout_frequency_optimization` and `15_iq_blobs_gef`: at the start of `create_qua_program`, create `resonator.operations["readout_GEF"]` from readout when it is missing (1.5× length, thresholds cleared), matching the pattern used in the legacy GEF nodes.
-` calibration_utils/readout_gef_frequency_optimization/` and `calibration_utils/iq_blobs_ef/`: supporting updates for these nodes (parameters, analysis, plotting).
- Small fixes in the node scripts (e.g. data_fetcher.get("n", 0), docstrings, pylint).

**Why**
- After the `quam-builder` upgrade (https://github.com/qua-platform/quam-builder/pull/116), new machines get both `readout` and `readout_GEF` from `add_default_transmon_pulses()`. Older saved QuAM states often only have readout.
- Nodes 14 and 15 are the first calibrations that measure with readout_GEF (three-level g/e/f readout). On a legacy state that would cause: `KeyError: 'readout_GEF'`

- The update lets 14 and 15 run on old states (pulse created in memory, then saved) and on new populates (pulse already there—unchanged). After 14 → 15 and save, downstream nodes that use readout_state_gef() (e.g. CZ / coupler calibrations) can find `readout_GEF` and `gef_centers` in the state.
