### PR TITLE
refactor: move quam machine instantiation into QualibrationNode constructor

### DIFF
--- a/qualibration_graphs/nv_center/quam_config/populate_quam_lf_mw_fems.py
+++ b/qualibration_graphs/nv_center/quam_config/populate_quam_lf_mw_fems.py
@@ -17,7 +17,6 @@ from my_quam import Quam
 from quam.components.pulses import Pulse, SquarePulse, GaussianPulse
 import numpy as np
 
-
 ########################################################################################################################
 # %%                                 QUAM loading and auxiliary functions
 ########################################################################################################################

--- a/qualibration_graphs/superconducting/calibration_utils/readout_optimization_3d/make_qua_variables_per_qubit.py
+++ b/qualibration_graphs/superconducting/calibration_utils/readout_optimization_3d/make_qua_variables_per_qubit.py
@@ -7,7 +7,6 @@ from calibration_utils.readout_optimization_3d.parameters import (
     ReadoutOptimization3dParameters,
 )
 
-
 try:
     from qm.qua.type_hints import QuaVariable
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/00_close_other_qms.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/00_close_other_qms.py
@@ -8,12 +8,8 @@ description = """
 """
 
 node = QualibrationNode[NodeParameters, Quam](
-    name="00_close_other_qms", description=description, parameters=NodeParameters()
+    name="00_close_other_qms", description=description, parameters=NodeParameters(), machine=Quam.load()
 )
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Close_all_quantum_machines}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/00_close_other_qms.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/00_close_other_qms.py
@@ -2,7 +2,6 @@
 from qualibrate import QualibrationNode, NodeParameters
 from quam_config import Quam
 
-
 description = """
         CLOSE ALL OTHER QMs.
 """

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/00_hello_qua.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/00_hello_qua.py
@@ -16,13 +16,14 @@ from qualibration_libs.parameters import get_qubits
 from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 
-
 description = """
         Basic script to play with the QUA program and test the QOP connectivity.
 """
 
 
-node = QualibrationNode[Parameters, Quam](name="00_hello_qua", description=description, parameters=Parameters(), machine=Quam.load())
+node = QualibrationNode[Parameters, Quam](
+    name="00_hello_qua", description=description, parameters=Parameters(), machine=Quam.load()
+)
 
 
 # Any parameters that should change for debugging purposes only should go in here

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/00_hello_qua.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/00_hello_qua.py
@@ -22,7 +22,7 @@ description = """
 """
 
 
-node = QualibrationNode[Parameters, Quam](name="00_hello_qua", description=description, parameters=Parameters())
+node = QualibrationNode[Parameters, Quam](name="00_hello_qua", description=description, parameters=Parameters(), machine=Quam.load())
 
 
 # Any parameters that should change for debugging purposes only should go in here
@@ -34,10 +34,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # node.parameters.multiplexed = True
     # node.parameters.num_shots = 2
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/01a_mixer_calibration.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/01a_mixer_calibration.py
@@ -18,7 +18,7 @@ description = """
 
 
 node = QualibrationNode[Parameters, Quam](
-    name="01a_mixer_calibration", description=description, parameters=Parameters()
+    name="01a_mixer_calibration", description=description, parameters=Parameters(), machine=Quam.load()
 )
 
 
@@ -28,10 +28,6 @@ node = QualibrationNode[Parameters, Quam](
 def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Execute_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/01a_time_of_flight.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/01a_time_of_flight.py
@@ -52,7 +52,7 @@ State update:
 """
 
 
-node = QualibrationNode[Parameters, Quam](name="01a_time_of_flight", description=description, parameters=Parameters())
+node = QualibrationNode[Parameters, Quam](name="01a_time_of_flight", description=description, parameters=Parameters(), machine=Quam.load())
 
 
 # Any parameters that should change for debugging purposes only should go in here
@@ -62,10 +62,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/01a_time_of_flight.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/01a_time_of_flight.py
@@ -25,7 +25,6 @@ from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 from qualibration_libs.core import tracked_updates
 
-
 # %% {Node initialisation}
 description = """
         TIME OF FLIGHT - OPX+ & LF-FEM
@@ -52,7 +51,9 @@ State update:
 """
 
 
-node = QualibrationNode[Parameters, Quam](name="01a_time_of_flight", description=description, parameters=Parameters(), machine=Quam.load())
+node = QualibrationNode[Parameters, Quam](
+    name="01a_time_of_flight", description=description, parameters=Parameters(), machine=Quam.load()
+)
 
 
 # Any parameters that should change for debugging purposes only should go in here

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/01b_time_of_flight_mw_fem.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/01b_time_of_flight_mw_fem.py
@@ -47,7 +47,7 @@ State update:
 
 
 node = QualibrationNode[Parameters, Quam](
-    name="01b_time_of_flight_mw_fem", description=description, parameters=Parameters()
+    name="01b_time_of_flight_mw_fem", description=description, parameters=Parameters(), machine=Quam.load()
 )
 
 
@@ -58,10 +58,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
@@ -48,6 +48,7 @@ node = QualibrationNode[Parameters, Quam](
     name="02a_resonator_spectroscopy",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -59,10 +60,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02b_resonator_spectroscopy_vs_power.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02b_resonator_spectroscopy_vs_power.py
@@ -54,6 +54,7 @@ node = QualibrationNode[Parameters, Quam](
     name="02b_resonator_spectroscopy_vs_power",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -65,10 +66,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2", "q3"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02b_resonator_spectroscopy_vs_power.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02b_resonator_spectroscopy_vs_power.py
@@ -26,7 +26,6 @@ from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 from qualibration_libs.core import tracked_updates
 
-
 # %% {Node initialisation}
 description = """
         RESONATOR SPECTROSCOPY VERSUS READOUT POWER

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02c_resonator_spectroscopy_vs_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02c_resonator_spectroscopy_vs_flux.py
@@ -57,6 +57,7 @@ node = QualibrationNode[Parameters, Quam](
     name="02c_resonator_spectroscopy_vs_flux",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -68,10 +69,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02c_resonator_spectroscopy_vs_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02c_resonator_spectroscopy_vs_flux.py
@@ -25,7 +25,6 @@ from qualibration_libs.parameters import get_qubits
 from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 
-
 # %% {Node initialisation}
 description = """
         RESONATOR SPECTROSCOPY VERSUS FLUX

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02d_resonator_spectroscopy_vs_coupler_flux.py
@@ -47,6 +47,7 @@ node = QualibrationNode[Parameters, Quam](
     name="02d_resonator_spectroscopy_vs_coupler_flux",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -58,10 +59,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubit_pairs = ["coupler_q1_q2", "coupler_q2_q3"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03a_qubit_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03a_qubit_spectroscopy.py
@@ -24,7 +24,6 @@ from qualibration_libs.parameters import get_qubits
 from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 
-
 # %% {Node initialisation}
 description = """
         QUBIT SPECTROSCOPY

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03a_qubit_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03a_qubit_spectroscopy.py
@@ -56,6 +56,7 @@ node = QualibrationNode[Parameters, Quam](
     name="03a_qubit_spectroscopy",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -67,10 +68,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03b_qubit_spectroscopy_vs_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03b_qubit_spectroscopy_vs_flux.py
@@ -45,6 +45,7 @@ node = QualibrationNode[Parameters, Quam](
     name="03b_qubit_spectroscopy_vs_flux",
     description=description,
     parameters=Parameters(),
+    machine=Quam.load(),
 )
 
 
@@ -56,10 +57,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # node.parameters.qubits = ["q1", "q3"]
 
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03c_qubit_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/03c_qubit_spectroscopy_vs_coupler_flux.py
@@ -47,6 +47,7 @@ node = QualibrationNode[Parameters, Quam](
     name="03c_qubit_spectroscopy_vs_coupler_flux",
     description=description,
     parameters=Parameters(),
+    machine=Quam.load(),
 )
 
 
@@ -57,10 +58,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     """Allow the user to locally set the node parameters."""
     # You can get type hinting in your IDE by typing node.parameters.
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/04a_rabi_chevron.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/04a_rabi_chevron.py
@@ -48,6 +48,7 @@ node = QualibrationNode[Parameters, Quam](
     name="04a_rabi_chevron",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -59,10 +60,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/04a_rabi_chevron.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/04a_rabi_chevron.py
@@ -25,7 +25,6 @@ from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 from qualibration_libs.core import tracked_updates
 
-
 # %% {Description}
 description = """
         RABI CHEVRON - DURATION VS AMPLITUDE

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/04b_power_rabi.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/04b_power_rabi.py
@@ -51,6 +51,7 @@ node = QualibrationNode[Parameters, Quam](
     name="04b_power_rabi",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -66,10 +67,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # node.parameters.max_amp_factor = 1.2
     # node.parameters.amp_factor_step = 0.01
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/04b_power_rabi.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/04b_power_rabi.py
@@ -25,7 +25,6 @@ from qualibration_libs.parameters import get_qubits
 from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 
-
 # %% {Description}
 description = """
         POWER RABI WITH ERROR AMPLIFICATION

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/05_T1.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/05_T1.py
@@ -45,6 +45,7 @@ node = QualibrationNode[Parameters, Quam](
     name="05_T1",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -55,10 +56,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/05_T1.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/05_T1.py
@@ -22,7 +22,6 @@ from calibration_utils.T1 import (
     plot_raw_data_with_fit,
 )
 
-
 # %% {Node initialisation}
 description = """
         T1 MEASUREMENT

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/06a_ramsey.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/06a_ramsey.py
@@ -46,7 +46,7 @@ State update:
     - T2*: qubit.T2ramsey.
 """
 
-node = QualibrationNode[Parameters, Quam](name="06a_ramsey", description=description, parameters=Parameters())
+node = QualibrationNode[Parameters, Quam](name="06a_ramsey", description=description, parameters=Parameters(), machine=Quam.load())
 
 
 # Any parameters that should change for debugging purposes only should go in here
@@ -56,10 +56,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-## Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/06a_ramsey.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/06a_ramsey.py
@@ -23,7 +23,6 @@ from qualibration_libs.parameters import get_qubits, get_idle_times_in_clock_cyc
 from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 
-
 # %% {Description}
 description = """
         RAMSEY WITH VIRTUAL Z ROTATIONS
@@ -46,7 +45,9 @@ State update:
     - T2*: qubit.T2ramsey.
 """
 
-node = QualibrationNode[Parameters, Quam](name="06a_ramsey", description=description, parameters=Parameters(), machine=Quam.load())
+node = QualibrationNode[Parameters, Quam](
+    name="06a_ramsey", description=description, parameters=Parameters(), machine=Quam.load()
+)
 
 
 # Any parameters that should change for debugging purposes only should go in here

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/06b_echo.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/06b_echo.py
@@ -40,7 +40,7 @@ Next steps before going to the next node:
 """
 
 
-node = QualibrationNode[Parameters, Quam](name="06b_echo", description=description, parameters=Parameters())
+node = QualibrationNode[Parameters, Quam](name="06b_echo", description=description, parameters=Parameters(), machine=Quam.load())
 
 
 # Any parameters that should change for debugging purposes only should go in here
@@ -50,10 +50,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/06b_echo.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/06b_echo.py
@@ -40,7 +40,9 @@ Next steps before going to the next node:
 """
 
 
-node = QualibrationNode[Parameters, Quam](name="06b_echo", description=description, parameters=Parameters(), machine=Quam.load())
+node = QualibrationNode[Parameters, Quam](
+    name="06b_echo", description=description, parameters=Parameters(), machine=Quam.load()
+)
 
 
 # Any parameters that should change for debugging purposes only should go in here

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/07_iq_blobs.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/07_iq_blobs.py
@@ -25,7 +25,6 @@ from qualibration_libs.parameters import get_qubits
 from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 
-
 # %% {Description}
 description = """
         IQ BLOBS

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/07_iq_blobs.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/07_iq_blobs.py
@@ -54,6 +54,7 @@ node = QualibrationNode[Parameters, Quam](
     name="07_iq_blobs",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -68,10 +69,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/08a_readout_frequency_optimization.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/08a_readout_frequency_optimization.py
@@ -47,6 +47,7 @@ node = QualibrationNode[Parameters, Quam](
     name="08a_readout_frequency_optimization",
     description=description,
     parameters=Parameters(),
+    machine=Quam.load(),
 )
 
 
@@ -57,10 +58,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-## Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/08b_readout_power_optimization.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/08b_readout_power_optimization.py
@@ -51,6 +51,7 @@ node = QualibrationNode[Parameters, Quam](
     name="08b_readout_power_optimization",
     description=description,
     parameters=Parameters(),
+    machine=Quam.load(),
 )
 
 
@@ -61,10 +62,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/08b_readout_power_optimization.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/08b_readout_power_optimization.py
@@ -25,7 +25,6 @@ from qualibration_libs.parameters import get_qubits
 from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 
-
 # %% {Description}
 description = """
         READOUT POWER OPTIMIZATION

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/09a_ramsey_vs_flux_calibration.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/09a_ramsey_vs_flux_calibration.py
@@ -52,6 +52,7 @@ node = QualibrationNode[Parameters, Quam](
     name="09a_ramsey_vs_flux_calibration",
     description=description,
     parameters=Parameters(),
+    machine=Quam.load(),
 )
 
 
@@ -62,10 +63,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q3"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/09b_ramsey_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/09b_ramsey_vs_coupler_flux.py
@@ -42,6 +42,7 @@ node = QualibrationNode[Parameters, Quam](
     name="09b_ramsey_vs_coupler_flux",
     description=description,
     parameters=Parameters(),
+    machine=Quam.load(),
 )
 
 
@@ -49,9 +50,6 @@ node = QualibrationNode[Parameters, Quam](
 def custom_param(node: QualibrationNode[Parameters, Quam]):
     """Allow the user to locally set the node parameters."""
     pass
-
-
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/10b_drag_calibration_180_minus_180.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/10b_drag_calibration_180_minus_180.py
@@ -53,6 +53,7 @@ node = QualibrationNode[Parameters, Quam](
     name="10b_drag_calibration_180_minus_180",
     description=description,
     parameters=Parameters(),
+    machine=Quam.load(),
 )
 
 
@@ -63,10 +64,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/10b_drag_calibration_180_minus_180.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/10b_drag_calibration_180_minus_180.py
@@ -25,7 +25,6 @@ from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 from qualibration_libs.core import tracked_updates
 
-
 # %% {Node initialisation}
 description = """
         DRAG PULSE CALIBRATION (GOOGLE METHOD)

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/11a_single_qubit_randomized_benchmarking.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/11a_single_qubit_randomized_benchmarking.py
@@ -60,6 +60,7 @@ node = QualibrationNode[Parameters, Quam](
     name="11a_single_qubit_randomized_benchmarking",
     description=description,
     parameters=Parameters(),
+    machine=Quam.load(),
 )
 
 
@@ -70,10 +71,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/11a_single_qubit_randomized_benchmarking.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/11a_single_qubit_randomized_benchmarking.py
@@ -25,7 +25,6 @@ from qualibration_libs.parameters import get_qubits
 from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 
-
 # %% {Node initialisation}
 description = """
         SINGLE QUBIT RANDOMIZED BENCHMARKING

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/11b_single_qubit_randomized_benchmarking_interleaved.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/11b_single_qubit_randomized_benchmarking_interleaved.py
@@ -27,7 +27,6 @@ from qualibration_libs.parameters import get_qubits
 from qualibration_libs.runtime import simulate_and_plot
 from qualibration_libs.data import XarrayDataFetcher
 
-
 # %% {Node initialisation}
 description = """
         SINGLE QUBIT RANDOMIZED BENCHMARKING - INTERLEAVED

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/11b_single_qubit_randomized_benchmarking_interleaved.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/11b_single_qubit_randomized_benchmarking_interleaved.py
@@ -63,6 +63,7 @@ node = QualibrationNode[Parameters, Quam](
     name="11b_single_qubit_randomized_benchmarking_interleaved",
     description=description,
     parameters=Parameters(),
+    machine=Quam.load(),
 )
 
 
@@ -73,10 +74,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/12_Qubit_Spectroscopy_E_to_F.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/12_Qubit_Spectroscopy_E_to_F.py
@@ -49,6 +49,7 @@ node = QualibrationNode[Parameters, Quam](
     name="12_qubit_spectroscopy_EF",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -60,10 +61,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/13_power_rabi_ef.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/13_power_rabi_ef.py
@@ -49,6 +49,7 @@ node = QualibrationNode[EfParameters, Quam](
     name="13_power_rabi_ef",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=EfParameters(),  # EF-specific parameters set
+    machine=Quam.load(),
 )
 
 
@@ -60,10 +61,6 @@ def custom_param(node: QualibrationNode[EfParameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubits = ["q1", "q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/14_gef_readout_frequency_optimization.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/14_gef_readout_frequency_optimization.py
@@ -65,6 +65,7 @@ node = QualibrationNode[Parameters, Quam](
     name="14_gef_readout_frequency_optimization",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -75,10 +76,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     """Allow the user to locally set the node parameters."""
     # You can get type hinting in your IDE by typing node.parameters.
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/15_iq_blobs_gef.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/15_iq_blobs_gef.py
@@ -47,6 +47,7 @@ node = QualibrationNode[Parameters, Quam](
     name="15_iq_blobs_gef",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -57,10 +58,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     """Allow the user to locally set the node parameters."""
     # You can get type hinting in your IDE by typing node.parameters.
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/16a_xyz_delay.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/16a_xyz_delay.py
@@ -47,6 +47,7 @@ node = QualibrationNode[Parameters, Quam](
     name="16_XY_Z_delay",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -56,10 +57,6 @@ node = QualibrationNode[Parameters, Quam](
 def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/16b_xy_coupler_z_delay.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/16b_xy_coupler_z_delay.py
@@ -55,6 +55,7 @@ node = QualibrationNode[Parameters, Quam](
     name="16b_xy_coupler_z_delay",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -63,10 +64,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     """Allow the user to locally set the node parameters."""
     # You can get type hinting in your IDE by typing node.parameters.
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/19_zz_off_jazz.py
@@ -61,6 +61,7 @@ node = QualibrationNode[Parameters, Quam](
     name="19_zz_off_jazz",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under calibration_utils/JAZZ_ZZ/parameters.py
+    machine=Quam.load(),
 )
 
 
@@ -71,10 +72,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     """Allow the user to locally set the node parameters."""
     # You can get type hinting in your IDE by typing node.parameters.
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/31_chevron_11_02.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/31_chevron_11_02.py
@@ -65,6 +65,7 @@ node = QualibrationNode[Parameters, Quam](
     name="31_chevron_1102",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -75,10 +76,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     """Allow the user to locally set the node parameters for debugging purposes, or execution in the Python IDE."""
     # node.parameters.qubit_pairs = ["q1-q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32a_cz_conditional_phase.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32a_cz_conditional_phase.py
@@ -64,6 +64,7 @@ node = QualibrationNode[Parameters, Quam](
     name="32a_cz_conditional_phase",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under calibration_utils/cz_conditional_phase/parameters.py
+    machine=Quam.load(),
 )
 
 
@@ -73,10 +74,6 @@ node = QualibrationNode[Parameters, Quam](
 def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32b_cz_conditional_phase_error_amp.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32b_cz_conditional_phase_error_amp.py
@@ -65,6 +65,7 @@ node = QualibrationNode[Parameters, Quam](
     name="32b_cz_conditional_phase_error_amp",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under calibration_utils/cz_conditional_phase/parameters.py
+    machine=Quam.load(),
 )
 
 
@@ -74,10 +75,6 @@ node = QualibrationNode[Parameters, Quam](
 def custom_param(node: QualibrationNode[Parameters, Quam]):
     # node.parameters.qubit_pairs = ["q1-q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/33_cz_phase_compensation.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/33_cz_phase_compensation.py
@@ -49,6 +49,7 @@ node = QualibrationNode[Parameters, Quam](
     name="33_cz_phase_compensation",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
     parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
+    machine=Quam.load(),
 )
 
 
@@ -60,10 +61,6 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     # You can get type hinting in your IDE by typing node.parameters.
     # node.parameters.qubit_pairs = ["q1-q2"]
     pass
-
-
-# Instantiate the QUAM class from the state file
-node.machine = Quam.load()
 
 
 # %% {Create_QUA_program}

--- a/qualibration_graphs/superconducting/calibrations/README.md
+++ b/qualibration_graphs/superconducting/calibrations/README.md
@@ -20,12 +20,8 @@ Each calibration script instantiates a `QualbirationNode` close to the top of th
 
 ### `QualibrationNode` attributes
 
-- **`node.machine`**: The QUAM root-level object, typically loaded as follows:
-  ```python
-  from quam_config import Quam
-  node.machine = Quam.load()
-  ```
-  This step is optional, if it is omitted, the QUAM state won't be saved in the data folder when calling `node.save()`.
+- **`node.machine`**: The QUAM root-level object, initialized by passing `machine=Quam.load()` to the QualibrationNode constructor.
+  If this attribute is not initialized, the QUAM state won't be saved in the data folder when calling `node.save()`.
 - **`node.modes`**: A collection of different modes in which the node is used.  
   For example, the node may be run from the web app (`modes.external is True`), or directly through the IDE (`modes.interactive is True`).
 - **`node.name`**: The unique name of the `QualibrationNode`, typically matches the filename.

--- a/qualibration_graphs/superconducting/calibrations/node_anatomy.ipynb
+++ b/qualibration_graphs/superconducting/calibrations/node_anatomy.ipynb
@@ -130,6 +130,7 @@
     "    name=\"02a_resonator_spectroscopy\",  # Name should be unique\n",
     "    description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI\n",
     "    parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name\n",
+    "    machine = Quam.load(),    # Instantiate the QUAM class from the state file\n",
     ")\n",
     "\n",
     "\n",
@@ -140,11 +141,7 @@
     "    \"\"\"Allow the user to locally set the node parameters for debugging purposes, or execution in the Python IDE.\"\"\"\n",
     "    # You can get type hinting in your IDE by typing node.parameters.\n",
     "    node.parameters.qubits = [\"q1\", \"q2\"]\n",
-    "    pass\n",
-    "\n",
-    "\n",
-    "# Instantiate the QUAM class from the state file\n",
-    "node.machine = Quam.load()"
+    "    pass"
    ]
   },
   {
@@ -161,11 +158,10 @@
     "    - `name=\"02a_resonator_spectroscopy\"`: Assigns a unique identifier to this node type. This name is crucial for QUAlibrate to track and manage the node.\n",
     "    - `description=description`: Passes the description string defined above.\n",
     "    - `parameters=Parameters()`: Passes an *instance* of the imported `Parameters` class. QUAlibrate uses this to manage the node's input parameters (reading defaults, accepting user input via the UI).\n",
+    "    - `machine=Quam.load()`: Loads the state of the quantum machine from the configuration file specified within the QUAM parameters (often defined in a base `Parameters` class). The loaded `Quam` object is stored in `node.machine`, making the entire machine configuration accessible to subsequent run actions.\n",
     "- **Custom Parameter Run Action (`custom_param`):**\n",
     "    - `@node.run_action(skip_if=node.modes.external)`: Defines a function `custom_param` as a run action. The `skip_if=node.modes.external` argument ensures this function *only* runs when the script is executed directly (standalone mode, e.g., in an IDE) and is *skipped* when run via the QUAlibrate UI or as part of a graph.\n",
-    "    - **Purpose:** This action allows developers to temporarily override parameters (like `node.parameters.qubits = [\"q1\", \"q2\"]`) for local debugging or testing without affecting the default parameters used in automated runs.\n",
-    "- **QUAM Loading:**\n",
-    "    - `node.machine = Quam.load()`: Loads the state of the quantum machine from the configuration file specified within the QUAM parameters (often defined in a base `Parameters` class). The loaded `Quam` object is stored in `node.machine`, making the entire machine configuration accessible to subsequent run actions."
+    "    - **Purpose:** This action allows developers to temporarily override parameters (like `node.parameters.qubits = [\"q1\", \"q2\"]`) for local debugging or testing without affecting the default parameters used in automated runs."
    ]
   },
   {


### PR DESCRIPTION
The qubits field is populated from the loaded QUAM machine
<img width="1992" height="1203" alt="image" src="https://github.com/user-attachments/assets/bec8e017-f14e-4da5-9592-19bc2ae50e1a" />
