### PR TITLE
Introduce QubitRoles for physics-driven qubit role resolution in 2Q gate calibrations

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/__init__.py
@@ -1,6 +1,6 @@
 """CZ / iSWAP flux bootstrap calibration utilities (node 30)."""
 
-from .parameters import Parameters, estimate_qubit_flux_shift
+from .parameters import Parameters, QubitRoles, estimate_qubit_flux_shift, verify_moving_qubit
 from .analysis import process_raw_dataset, fit_raw_data, log_fitted_results
 from .plotting import (
     plot_contrast_cut_debug,
@@ -11,6 +11,8 @@ from .plotting import (
 __all__ = [
     "Parameters",
     "estimate_qubit_flux_shift",
+    "QubitRoles",
+    "verify_moving_qubit",
     "process_raw_dataset",
     "fit_raw_data",
     "log_fitted_results",

--- a/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/analysis.py
@@ -2,7 +2,7 @@
 
 Pipeline (per qubit pair)
 -------------------------
-1. **2D contrast** — ``target − control`` (CZ) or ``control − target`` (iSWAP).
+1. **2D contrast** — ``stationary − moving`` (CZ) or ``moving − stationary`` (iSWAP).
 2. **Qubit flux** — average contrast over coupler; CZ → argmax, iSWAP → argmin.
 3. **1D cut** — contrast vs coupler flux at that qubit flux.
 4. **Coarse (heavy Savitzky–Golay)** — sliding-window FFT → flat vs oscillation masks;
@@ -19,7 +19,6 @@ import numpy as np
 import xarray as xr
 from qualibrate import QualibrationNode
 
-from .parameters import moving_qubit
 from scipy.signal import find_peaks, savgol_filter
 
 # Fringe band for sliding-window FFT (fixed; not exposed in presets).
@@ -129,13 +128,17 @@ def log_fitted_results(fit_results: Dict, log_callable=None):
 def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
     """Add absolute flux coordinates and detuning for plotting."""
     qubit_pairs = [node.machine.qubit_pairs[pair] for pair in node.parameters.qubit_pairs]
+    qubit_roles_map = node.namespace["qubit_roles_map"]
     fluxes_qp = node.namespace["fluxes_qp"]
     fluxes_coupler = ds.coupler_flux.values
     qubit_flux_full = np.array([fluxes_qp[qp.name] for qp in qubit_pairs])
     ds = ds.assign_coords({"qubit_flux_full": (["qubit_pair", "qubit_flux"], qubit_flux_full)})
 
     coupler_flux_full = np.array([fluxes_coupler + qp.coupler.decouple_offset for qp in qubit_pairs])
-    detuning = np.array([-fluxes_qp[qp.name] ** 2 * moving_qubit(qp).freq_vs_flux_01_quad_term for qp in qubit_pairs])
+    detuning = np.array(
+        [-fluxes_qp[qp.name] ** 2 * qubit_roles_map[qp.name].moving.freq_vs_flux_01_quad_term for qp in qubit_pairs]
+    )
+
     ds = ds.assign_coords({"coupler_flux_full": (["qubit_pair", "coupler_flux"], coupler_flux_full)})
     ds = ds.assign_coords({"detuning": (["qubit_pair", "qubit_flux"], detuning)})
 
@@ -152,12 +155,12 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
 # ---------------------------------------------------------------------------
 
 
-def _interaction_map(control: xr.DataArray, target: xr.DataArray, cz_or_iswap: str) -> xr.DataArray:
+def _interaction_map(moving: xr.DataArray, stationary: xr.DataArray, cz_or_iswap: str) -> xr.DataArray:
     """2D interaction contrast (sign depends on gate)."""
     if cz_or_iswap == "cz":
-        return target - control
+        return stationary - moving
     if cz_or_iswap == "iswap":
-        return control - target
+        return moving - stationary
     raise ValueError(f"cz_or_iswap must be 'cz' or 'iswap', got {cz_or_iswap!r}")
 
 
@@ -359,8 +362,8 @@ def _coupler_fit_is_valid(decouple_idx: int | None, gate_idx: int | None, n_coup
 
 
 def _fit_pair_from_contrast_cut(
-    control: xr.DataArray,
-    target: xr.DataArray,
+    moving: xr.DataArray,
+    stationary: xr.DataArray,
     coupler_rel: np.ndarray,
     coupler_full: xr.DataArray,
     qubit_full: xr.DataArray,
@@ -368,7 +371,7 @@ def _fit_pair_from_contrast_cut(
     cfg: dict,
 ) -> FitParameters:
     """Full contrast-cut fit for one pair (see module docstring pipeline)."""
-    contrast = _interaction_map(control, target, cz_or_iswap)
+    contrast = _interaction_map(moving, stationary, cz_or_iswap)
     qubit_idx = _qubit_flux_cut_index(contrast, cz_or_iswap)
     optimal_qubit_flux = float(qubit_full.isel(qubit_flux=qubit_idx).values)
 
@@ -395,7 +398,7 @@ def _fit_pair_from_contrast_cut(
     decouple_coarse, gate_coarse = _coarse_coupler_indices(y_heavy, flat_mask, osc_mask, coupler_rel, cfg)
     decouple_idx, gate_idx = _refine_coupler_indices(y_fine, flat_mask, decouple_coarse, gate_coarse, cfg)
 
-    success = not _index_on_sweep_boundary(qubit_idx, control.sizes["qubit_flux"]) and _coupler_fit_is_valid(
+    success = not _index_on_sweep_boundary(qubit_idx, moving.sizes["qubit_flux"]) and _coupler_fit_is_valid(
         decouple_idx, gate_idx, n_coupler
     )
 
@@ -430,16 +433,16 @@ def _extract_fit_parameters(fit: xr.Dataset, node: QualibrationNode):
     fit_results = {}
     for qp_name in fit.qubit_pair.values:
         qp_name = str(qp_name)
-        if use_sd and "state_control" in fit:
-            control = fit.state_control.sel(qubit_pair=qp_name)
-            target = fit.state_target.sel(qubit_pair=qp_name)
+        if use_sd and "state_moving" in fit:
+            moving = fit.state_moving.sel(qubit_pair=qp_name)
+            stationary = fit.state_stationary.sel(qubit_pair=qp_name)
         else:
-            control = fit.I_control.sel(qubit_pair=qp_name)
-            target = fit.I_target.sel(qubit_pair=qp_name)
+            moving = fit.I_moving.sel(qubit_pair=qp_name)
+            stationary = fit.I_stationary.sel(qubit_pair=qp_name)
 
         fit_results[qp_name] = _fit_pair_from_contrast_cut(
-            control,
-            target,
+            moving,
+            stationary,
             coupler_rel,
             fit.coupler_flux_full.sel(qubit_pair=qp_name),
             fit.qubit_flux_full.sel(qubit_pair=qp_name),

--- a/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/parameters.py
@@ -160,14 +160,26 @@ class QubitRoles(NamedTuple):
 def verify_moving_qubit(
     qp,
     gate_type: Literal["cz", "iswap"] = "cz",
+    operation: str = "cz_unipolar",
+    repair_routing: bool = False,
     log_callable: Optional[Callable[[str], None]] = None,
 ) -> None:
-    """Verify that qp.moving_qubit matches the physics-based calculation; update in-place if not.
+    """Verify and reconcile ``qp.moving_qubit``, then ``macros[operation]`` flux Z-line routing.
 
-    Recalculates the moving qubit from qubit frequencies and anharmonicity, then compares
-    it to the ``moving_qubit`` field stored on the QUAM qubit-pair object. If they disagree,
-    logs a warning, updates ``qp.moving_qubit`` in memory, and relies on the caller's state save
-    to persist the correction to state json.
+    Recalculates the moving qubit from qubit frequencies and anharmonicity via
+    :func:`QubitRoles.resolve`, updates ``qp.moving_qubit`` on the pair if needed, then
+    checks that ``macros[operation].flux_pulse_qubit`` is registered on that qubit's Z
+    channel. ``CZGate.apply()`` reads ``qp.moving_qubit`` to pick the Z line, so the
+    label is corrected before pulse routing is verified or repaired.
+
+    Flux routing is verified using ``flux_pulse_qubit.id`` as the Z-line operation name
+    (the same name passed to ``moving_qubit.z.play(...)`` at runtime). If the pulse is
+    missing from the moving qubit or present only on the stationary qubit's Z line,
+    raises :class:`ValueError` unless ``repair_routing=True``.
+
+    With ``repair_routing=True``, a new Z-line entry is created on the moving qubit and wired
+    to ``macros[operation].flux_pulse_qubit`` (same pattern as ``populate_quam``); any existing
+    entry on the stationary Z line is left unchanged.
 
     Parameters
     ----------
@@ -176,9 +188,21 @@ def verify_moving_qubit(
     gate_type:
         ``"cz"`` (default) or ``"iswap"`` — selects the physics rule used by
         :func:`QubitRoles.resolve`.
+    operation:
+        Pair macro to verify (e.g. ``"cz_unipolar"``), matching ``node.parameters.operation``.
+    repair_routing:
+        If True, add the flux pulse on the moving Z line instead of raising.
     log_callable:
         Callable that accepts a single string and emits it to the node's output
         (e.g. ``node.log``). Defaults to ``logging.getLogger(__name__).info``.
+
+    Raises
+    ------
+    ValueError
+        If ``operation`` is not in ``qp.macros``, if its flux pulse is not on the moving
+        qubit's Z line (and ``repair_routing`` is False), if the moving qubit has no Z
+        channel, or if ``qp.moving_qubit`` is set to a value other than ``"control"`` or
+        ``"target"``.
     """
     if log_callable is None:
         log_callable = logging.getLogger(__name__).info
@@ -195,10 +219,11 @@ def verify_moving_qubit(
         f"δ={delta_mhz:.1f} MHz, α_high={alpha_mhz:.1f} MHz"
     )
 
-    stored = getattr(qp, "moving_qubit", None)
-    stored_mq = qp.qubit_control if stored == "control" else qp.qubit_target
-    stored_sq = qp.qubit_target if stored == "control" else qp.qubit_control
+    if operation not in qp.macros:
+        raise ValueError(f"Pair {qp.name}: macro '{operation}' not found.")
 
+    stored = getattr(qp, "moving_qubit", None)
+    label_updated = False
     if stored is None:
         log_callable(
             f"WARNING Pair {qp.name}: qp.moving_qubit is not set. "
@@ -206,18 +231,78 @@ def verify_moving_qubit(
             f"from recalculation ({gate_type} gate). [{physics_ctx}]"
         )
         qp.moving_qubit = computed_label
+        label_updated = True
+    elif stored not in ("control", "target"):
+        raise ValueError(
+            f"Pair {qp.name}: qp.moving_qubit={stored!r} is invalid; expected 'control' or 'target'. "
+            f"[{physics_ctx}]"
+        )
     elif stored != computed_label:
+        stored_mq = qp.qubit_control if stored == "control" else qp.qubit_target
+        stored_sq = qp.qubit_target if stored == "control" else qp.qubit_control
         log_callable(
             f"WARNING Pair {qp.name}: moving={stored_mq.name}, stationary={stored_sq.name} "
             f"disagrees with recalculation: moving={roles.moving.name}, stationary={roles.stationary.name} "
-            f"for {gate_type} gate — updating. "
-            f"State will be persisted at the end of the node. [{physics_ctx}]"
+            f"for {gate_type} gate — updating qp.moving_qubit to '{computed_label}'. [{physics_ctx}]"
         )
         qp.moving_qubit = computed_label
-    else:
+        label_updated = True
+
+    moving_qubit = qp.qubit_control if qp.moving_qubit == "control" else qp.qubit_target
+    stationary_qubit = qp.qubit_target if qp.moving_qubit == "control" else qp.qubit_control
+    macro = qp.macros[operation]
+    flux_pulse = macro.flux_pulse_qubit
+    pulse_name = flux_pulse.id
+
+    moving_z = getattr(moving_qubit, "z", None)
+    stationary_z = getattr(stationary_qubit, "z", None)
+    on_moving = moving_z is not None and pulse_name in moving_z.operations
+    on_stationary = stationary_z is not None and pulse_name in stationary_z.operations
+    if not on_moving:
+        if moving_z is None:
+            raise ValueError(
+                f"Pair {qp.name}: moving qubit {moving_qubit.name} has no Z channel."
+            )
+        if repair_routing:
+            ref = flux_pulse.get_reference()
+            init = {
+                attr: getattr(flux_pulse, attr)
+                for attr in ("length", "amplitude", "flat_length", "sigma")
+                if hasattr(flux_pulse, attr) and isinstance(getattr(flux_pulse, attr), (int, float))
+            }
+            if flux_pulse.id is not None:
+                init["id"] = flux_pulse.id
+            moving_z.operations[pulse_name] = type(flux_pulse)(**init)
+            z_pulse = moving_z.operations[pulse_name]
+            for attr in ("length", "amplitude", "flat_length", "digital_marker", "axis_angle"):
+                if hasattr(flux_pulse, attr):
+                    setattr(z_pulse, attr, f"{ref}/{attr}")
+            if on_stationary:
+                log_callable(
+                    f"WARNING Pair {qp.name}: added macro '{operation}' flux pulse '{pulse_name}' "
+                    f"to {moving_qubit.name} Z line (wired to macro; copy still on "
+                    f"{stationary_qubit.name})."
+                )
+            else:
+                log_callable(
+                    f"WARNING Pair {qp.name}: added macro '{operation}' flux pulse '{pulse_name}' "
+                    f"to {moving_qubit.name} Z line (wired to macro)."
+                )
+        elif on_stationary:
+            raise ValueError(
+                f"Pair {qp.name}: macro '{operation}' flux pulse '{pulse_name}' is on stationary qubit "
+                f"{stationary_qubit.name} Z line but moving qubit is {moving_qubit.name}. "
+                f"Re-run populate_quam or set repair_routing=True."
+            )
+        else:
+            raise ValueError(
+                f"Pair {qp.name}: macro '{operation}' flux pulse '{pulse_name}' not found on moving qubit "
+                f"{moving_qubit.name} Z line. Re-run populate_quam or set repair_routing=True."
+            )
+    elif not label_updated:
         log_callable(
-            f"Pair {qp.name}: moving={roles.moving.name}, stationary={roles.stationary.name}. "
-            f"Consistent with recalculation ({gate_type} gate). [{physics_ctx}]"
+            f"Pair {qp.name}: moving={moving_qubit.name}, stationary={stationary_qubit.name}. "
+            f"Label and flux-pulse routing consistent with recalculation ({gate_type} gate)."
         )
 
 

--- a/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/parameters.py
@@ -260,9 +260,7 @@ def verify_moving_qubit(
     on_stationary = stationary_z is not None and pulse_name in stationary_z.operations
     if not on_moving:
         if moving_z is None:
-            raise ValueError(
-                f"Pair {qp.name}: moving qubit {moving_qubit.name} has no Z channel."
-            )
+            raise ValueError(f"Pair {qp.name}: moving qubit {moving_qubit.name} has no Z channel.")
         if repair_routing:
             ref = flux_pulse.get_reference()
             init = {

--- a/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/parameters.py
@@ -3,7 +3,7 @@
 # pylint: disable=too-few-public-methods
 
 import logging
-from typing import Callable, ClassVar, Literal, Optional
+from typing import Callable, ClassVar, Literal, NamedTuple, Optional
 import numpy as np
 from qualibrate import NodeParameters
 from qualibrate.core.parameters import RunnableParameters
@@ -107,18 +107,118 @@ class Parameters(
     targets_name: ClassVar[str] = "qubit_pairs"
 
 
-def moving_qubit(qp):
-    """Transmon that carries ``flux_pulse_qubit`` (``qubit_pair.moving_qubit``)."""
-    if qp.moving_qubit == "target":
-        return qp.qubit_target
-    return qp.qubit_control
+class QubitRoles(NamedTuple):
+    """Resolved qubit roles for a two-qubit gate on a pair.
+
+    moving:     transmon flux-tuned to the interaction point
+    stationary: partner that stays at its idle frequency
+    leakage:    transmon whose |2⟩ state is the dominant leakage channel
+    high:       higher-frequency qubit (control/target-agnostic)
+    low:        lower-frequency qubit (control/target-agnostic)
+    """
+
+    moving: object
+    stationary: object
+    leakage: object
+    high: object
+    low: object
+
+    @staticmethod
+    def _high_low(qp):
+        """(high_freq_qubit, low_freq_qubit) by f_01, control/target-agnostic."""
+        if qp.qubit_control.f_01 >= qp.qubit_target.f_01:
+            return qp.qubit_control, qp.qubit_target
+        return qp.qubit_target, qp.qubit_control
+
+    @classmethod
+    def resolve(cls, qp, gate_type: Literal["cz", "iswap"] = "cz") -> "QubitRoles":
+        """Resolve moving / stationary / leakage / high / low qubits for the interaction.
+
+        δ = f_high − f_low ≥ 0.
+
+        iSWAP (|10⟩↔|01⟩ at δ = 0):
+            High frequency qubit tunes down to the low frequency qubit. Leakage attributed to the
+            high frequency qubit (weak, off-resonant effect).
+
+        CZ via |11⟩↔|20⟩ (both photons in the HIGH frequency qubit, crossing at δ = |α_high|):
+            δ >  |α_high|  →  HIGH frequency qubit moves (δ shrinks to |α_high|)
+            δ ≤  |α_high|  →  LOW frequency qubit moves (δ grows   to |α_high|)
+            Leaker is ALWAYS the high frequency qubit, regardless of which qubit moves.
+        """
+        high_q, low_q = cls._high_low(qp)
+
+        if gate_type == "iswap":
+            return cls(moving=high_q, stationary=low_q, leakage=high_q, high=high_q, low=low_q)
+        if gate_type == "cz":
+            delta = high_q.f_01 - low_q.f_01
+            moving = high_q if delta > abs(high_q.anharmonicity) else low_q
+            stationary = low_q if moving is high_q else high_q
+            return cls(moving=moving, stationary=stationary, leakage=high_q, high=high_q, low=low_q)
+        raise ValueError(f"Invalid gate_type value: {gate_type!r}")
 
 
-def other_qubit(qp):
-    """Partner transmon of the moving qubit."""
-    if qp.moving_qubit == "target":
-        return qp.qubit_control
-    return qp.qubit_target
+def verify_moving_qubit(
+    qp,
+    gate_type: Literal["cz", "iswap"] = "cz",
+    log_callable: Optional[Callable[[str], None]] = None,
+) -> None:
+    """Verify that qp.moving_qubit matches the physics-based calculation; update in-place if not.
+
+    Recalculates the moving qubit from qubit frequencies and anharmonicity, then compares
+    it to the ``moving_qubit`` field stored on the QUAM qubit-pair object. If they disagree,
+    logs a warning, updates ``qp.moving_qubit`` in memory, and relies on the caller's state save
+    to persist the correction to state json.
+
+    Parameters
+    ----------
+    qp:
+        QUAM qubit-pair object with ``qubit_control``, ``qubit_target``, and ``moving_qubit``.
+    gate_type:
+        ``"cz"`` (default) or ``"iswap"`` — selects the physics rule used by
+        :func:`QubitRoles.resolve`.
+    log_callable:
+        Callable that accepts a single string and emits it to the node's output
+        (e.g. ``node.log``). Defaults to ``logging.getLogger(__name__).info``.
+    """
+    if log_callable is None:
+        log_callable = logging.getLogger(__name__).info
+
+    roles = QubitRoles.resolve(qp, gate_type)
+    computed_label = "control" if roles.moving is qp.qubit_control else "target"
+
+    # Build a compact physics context string for logging
+    delta_mhz = (roles.high.f_01 - roles.low.f_01) / 1e6
+    alpha_mhz = roles.high.anharmonicity / 1e6
+    physics_ctx = (
+        f"high={roles.high.name} ({roles.high.f_01/1e9:.4f} GHz), "
+        f"low={roles.low.name} ({roles.low.f_01/1e9:.4f} GHz), "
+        f"δ={delta_mhz:.1f} MHz, α_high={alpha_mhz:.1f} MHz"
+    )
+
+    stored = getattr(qp, "moving_qubit", None)
+    stored_mq = qp.qubit_control if stored == "control" else qp.qubit_target
+    stored_sq = qp.qubit_target if stored == "control" else qp.qubit_control
+
+    if stored is None:
+        log_callable(
+            f"WARNING Pair {qp.name}: qp.moving_qubit is not set. "
+            f"Setting moving={roles.moving.name}, stationary={roles.stationary.name} "
+            f"from recalculation ({gate_type} gate). [{physics_ctx}]"
+        )
+        qp.moving_qubit = computed_label
+    elif stored != computed_label:
+        log_callable(
+            f"WARNING Pair {qp.name}: moving={stored_mq.name}, stationary={stored_sq.name} "
+            f"disagrees with recalculation: moving={roles.moving.name}, stationary={roles.stationary.name} "
+            f"for {gate_type} gate — updating. "
+            f"State will be persisted at the end of the node. [{physics_ctx}]"
+        )
+        qp.moving_qubit = computed_label
+    else:
+        log_callable(
+            f"Pair {qp.name}: moving={roles.moving.name}, stationary={roles.stationary.name}. "
+            f"Consistent with recalculation ({gate_type} gate). [{physics_ctx}]"
+        )
 
 
 def estimate_qubit_flux_shift(
@@ -126,7 +226,52 @@ def estimate_qubit_flux_shift(
     qp,
     log_callable: Optional[Callable[[str], None]] = None,
 ) -> float:
-    """Centre the qubit flux sweep on saved or estimated detuning (CZ or iSWAP)."""
+    """Return the flux bias centre for the moving-qubit sweep (CZ or iSWAP).
+
+    If ``parameters.use_saved_detuning`` is True, reads ``qp.detuning`` directly from state json file.
+    Otherwise, resolves the qubit roles via :func:`QubitRoles.resolve` and estimates the flux
+    shift needed to reach the interaction point from the moving qubit's
+    ``freq_vs_flux_01_quad_term``.
+
+    Conventions
+    -----------
+    ``detuning_hz`` is the POSITIVE "distance to tune the moving qubit DOWN"
+    (freq_now − target_freq ≥ 0). With ``quad < 0`` (upper sweet spot), the flux solves
+    ``Φ² = -detuning_hz / quad ≥ 0``.
+
+    iSWAP (|10⟩↔|01⟩ at δ = 0):
+        Tune the moving (high) qubit down to the stationary (low) qubit:
+            detuning_hz = f_moving − f_stationary = δ ≥ 0.
+
+    CZ via the |11⟩↔|20⟩ avoided crossing (both photons in the HIGH qubit,
+    crossing at δ = |α_high|):
+        - HIGH qubit moves (δ > |α_high|): target = f_low + |α_high|
+              detuning_hz = (f_high − f_low) − |α_high| = δ − |α_high| ≥ 0
+        - LOW  qubit moves (δ ≤ |α_high|): target = f_high − |α_high|
+              detuning_hz = |α_high| − (f_high − f_low) = |α_high| − δ ≥ 0
+
+    Parameters
+    ----------
+    parameters:
+        Node parameters carrying ``cz_or_iswap`` and ``use_saved_detuning``.
+    qp:
+        QUAM qubit-pair object.
+    log_callable:
+        Callable for progress messages (e.g. ``node.log``). Defaults to the module logger.
+
+    Returns
+    -------
+    float
+        Flux bias centre in volts for the moving-qubit sweep axis.
+
+    Raises
+    ------
+    ValueError
+        If ``use_saved_detuning`` is True but ``qp.detuning`` is unset, if
+        ``freq_vs_flux_01_quad_term`` is zero on the moving qubit, if the iSWAP
+        moving qubit is below its partner, or if the computed flux ratio is
+        negative (inconsistent frequencies / anharmonicity / quad term).
+    """
     if log_callable is None:
         log_callable = logging.getLogger(__name__).info
 
@@ -139,27 +284,35 @@ def estimate_qubit_flux_shift(
         centre = qp.detuning
         source = "from qubit_pair.detuning"
     else:
-        qb = moving_qubit(qp)
-        other = other_qubit(qp)
-        quad = qb.freq_vs_flux_01_quad_term
+        roles = QubitRoles.resolve(qp, parameters.cz_or_iswap)
+        quad = roles.moving.freq_vs_flux_01_quad_term
         if quad == 0:
             raise ValueError(
-                f"Pair {qp.name}: moving qubit '{qb.name}' has freq_vs_flux_01_quad_term=0. "
-                f"Run 09a_ramsey_vs_flux_calibration on {qb.name} first, or set "
+                f"Pair {qp.name}: moving qubit '{roles.moving.name}' has freq_vs_flux_01_quad_term=0. "
+                f"Run 09a_ramsey_vs_flux_calibration on {roles.moving.name} first, or set "
                 "qubit_pair.detuning and use_saved_detuning=True."
             )
 
         if parameters.cz_or_iswap == "iswap":
-            detuning_hz = qb.xy.RF_frequency - other.xy.RF_frequency
+            detuning_hz = roles.moving.xy.RF_frequency - roles.stationary.xy.RF_frequency
             if detuning_hz < 0:
                 raise ValueError(
-                    f"Pair {qp.name} [iSWAP]: moving qubit '{qb.name}' "
-                    f"({qb.xy.RF_frequency/1e9:.4f} GHz) is below partner '{other.name}' "
-                    f"({other.xy.RF_frequency/1e9:.4f} GHz) by {abs(detuning_hz)/1e6:.1f} MHz. "
+                    f"Pair {qp.name} [iSWAP]: moving qubit '{roles.moving.name}' "
+                    f"({roles.moving.xy.RF_frequency/1e9:.4f} GHz) is below partner '{roles.stationary.name}' "
+                    f"({roles.stationary.xy.RF_frequency/1e9:.4f} GHz) by {abs(detuning_hz)/1e6:.1f} MHz. "
                     "iSWAP requires the flux-tunable qubit to tune down to the partner."
                 )
         elif parameters.cz_or_iswap == "cz":
-            detuning_hz = qb.xy.RF_frequency - other.xy.RF_frequency + other.anharmonicity
+            # |11>-|20> crossing, always referenced to |alpha_high| (abs() so this is
+            # correct whether anharmonicity is stored signed or as a positive magnitude):
+            #   high moves: target = f_low + |a_high|;  detuning = (f_high - f_low) - |a_high|
+            #   low  moves: target = f_high - |a_high|;  detuning = |a_high| - (f_high - f_low)
+            alpha_high = abs(roles.high.anharmonicity)
+            delta_rf = roles.high.xy.RF_frequency - roles.low.xy.RF_frequency
+            if roles.moving is roles.high:
+                detuning_hz = delta_rf - alpha_high
+            else:
+                detuning_hz = alpha_high - delta_rf
         else:
             raise ValueError(f"Invalid cz_or_iswap value: {parameters.cz_or_iswap}")
 

--- a/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_iswap_flux_bootstrap/plotting.py
@@ -15,6 +15,7 @@ def plot_raw_data_with_fit(
     ds: xr.Dataset,
     qubit_pairs: list,
     fits: Optional[Dict] = None,
+    qubit_roles_map: Optional[Dict] = None,
     analysis_debug: bool = False,
     cz_or_iswap: str = "cz",
 ) -> Dict[str, Figure]:
@@ -40,13 +41,13 @@ def plot_raw_data_with_fit(
     Returns
     -------
     dict[str, Figure]
-        At least ``"target"`` and ``"control"``; optionally ``"contrast_debug"``.
+        At least ``"stationary"`` and ``"moving"``; optionally ``"contrast_debug"``.
     """
     pair_by_name = {qp.name: qp for qp in qubit_pairs}
     grid_names, pair_names = grid_pair_names(qubit_pairs)
     figures: Dict[str, Figure] = {}
 
-    for state_type in ("target", "control"):
+    for state_type in ("stationary", "moving"):
         grid = QubitPairGrid(grid_names, pair_names)
         for ax, qubit in grid_iter(grid):
             qp_name = qubit["qubit"]
@@ -58,6 +59,7 @@ def plot_raw_data_with_fit(
                 fit_data,
                 data_var=state_type,
                 qubit_pair_obj=pair_by_name.get(qp_name),
+                qubit_role=qubit_roles_map.get(qp_name) if qubit_roles_map else None,
                 cz_or_iswap=cz_or_iswap,
             )
 
@@ -76,8 +78,9 @@ def plot_individual_data_with_fit(
     ds: xr.Dataset,
     qubit: dict[str, str],
     fit: Optional[Dict] = None,
-    data_var: str = "target",
+    data_var: str = "stationary",
     qubit_pair_obj=None,
+    qubit_role=None,
     cz_or_iswap: str = "cz",
 ):
     """Plot one qubit-pair 2D heatmap; optional fit and machine-state markers.
@@ -93,7 +96,7 @@ def plot_individual_data_with_fit(
     fit : dict, optional
         Fit result dict for this pair (from ``fit_results``).
     data_var : str
-        ``"target"`` or ``"control"`` readout to display.
+        ``"stationary"`` or ``"moving"`` readout to display.
     qubit_pair_obj : optional
         QUAM pair object; used to draw the current ``decouple_offset`` for reference.
     cz_or_iswap : str
@@ -101,16 +104,16 @@ def plot_individual_data_with_fit(
     """
     qubit_pair = qubit["qubit"]
 
-    if data_var == "control":
-        if "state_control" in ds:
-            data = ds.state_control.sel(qubit_pair=qubit_pair)
+    if data_var == "moving":
+        if "state_moving" in ds:
+            data = ds.state_moving.sel(qubit_pair=qubit_pair)
         else:
-            data = ds.I_control.sel(qubit_pair=qubit_pair)
+            data = ds.I_moving.sel(qubit_pair=qubit_pair)
     else:
-        if "state_target" in ds:
-            data = ds.state_target.sel(qubit_pair=qubit_pair)
+        if "state_stationary" in ds:
+            data = ds.state_stationary.sel(qubit_pair=qubit_pair)
         else:
-            data = ds.I_target.sel(qubit_pair=qubit_pair)
+            data = ds.I_stationary.sel(qubit_pair=qubit_pair)
 
     data.assign_coords(
         {
@@ -172,7 +175,11 @@ def plot_individual_data_with_fit(
             )
             has_legend = True
 
-    ax.set_title(f"{qubit_pair} ({data_var})")
+    if qubit_role is not None:
+        qb = qubit_role.moving if data_var == "moving" else qubit_role.stationary
+        ax.set_title(f"{qubit_pair} \n {data_var} qubit ({qb.name})")
+    else:
+        ax.set_title(f"{qubit_pair} ({data_var})")
 
     if has_legend:
         ax.legend(fontsize=7, loc="upper right")

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/30_cz_iswap_flux_bootstrap.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/30_cz_iswap_flux_bootstrap.py
@@ -12,6 +12,8 @@ from calibration_utils.cz_iswap_flux_bootstrap import (
     estimate_qubit_flux_shift,
     fit_raw_data,
     log_fitted_results,
+    QubitRoles,
+    verify_moving_qubit,
     plot_raw_data_with_fit,
     process_raw_dataset,
 )
@@ -38,15 +40,15 @@ Method
 ------
 2D sweep of coupler flux (relative to `coupler.decouple_offset`) and moving-qubit flux
 (centred via `estimate_qubit_flux_shift`). At each point: prepare |11⟩ (CZ) or |10⟩ (iSWAP),
-play ``macros[operation]`` with scaled flux amplitudes, measure control and target
+play ``macros[operation]`` with scaled flux amplitudes, measure both qubits
 (state discrimination or IQ).
 
 Prerequisites
 -------------
 - Tunable coupler pair with ``macros[operation]`` defined in QUAM.
-- CZ: GEF readout on control; iSWAP: standard state readout on both qubits.
+- CZ: GEF readout on both qubits; iSWAP: standard state readout on both qubits.
 - Moving qubit `freq_vs_flux_01_quad_term` (09a_ramsey_vs_flux); partner anharmonicity for CZ estimate.
-- Coupler sweep spans the idle plateau and the first interaction fringe.
+- Coupler sweep spans should be wide enough to cover the idle plateau and the first interaction fringe.
 
 State update
 ------------
@@ -118,10 +120,16 @@ def create_qua_program(
         "qubit_flux": xr.DataArray(fluxes_qubit, attrs={"long_name": "qubit flux", "units": "V"}),
     }
 
+    # Verify qp.moving_qubit against recalculation and precompute roles for QUA program loops.
+    # Logs a warning and corrects qp.moving_qubit in-memory if they disagree; state is saved
+    # at the end of the node.
+    qubit_roles_map = {}
     for qp in qubit_pairs:
-        node.log(f"Pair {qp.name}: control={qp.qubit_control.name}, target={qp.qubit_target.name}")
+        verify_moving_qubit(qp, node.parameters.cz_or_iswap, log_callable=node.log)
+        qubit_roles_map[qp.name] = QubitRoles.resolve(qp, node.parameters.cz_or_iswap)
         if "coupler_qubit_crosstalk" not in qp.extras:
-            node.log(f"No crosstalk compensation for {qp.name}")
+            node.log(f"Pair {qp.name}: no crosstalk compensation configured")
+    node.namespace["qubit_roles_map"] = qubit_roles_map
 
     with program() as node.namespace["qua_program"]:
         flux_coupler = declare(fixed)
@@ -131,22 +139,26 @@ def create_qua_program(
         if node.parameters.use_state_discrimination:
             n = declare(int)
             n_st = declare_output_stream()
-            state_c = [declare(int) for _ in range(num_qubit_pairs)]
-            state_t = [declare(int) for _ in range(num_qubit_pairs)]
-            state_c_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
-            state_t_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_mq = [declare(int) for _ in range(num_qubit_pairs)]
+            state_sq = [declare(int) for _ in range(num_qubit_pairs)]
+            state_mq_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_sq_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
         else:
-            I_c, I_c_st, Q_c, Q_c_st, n, n_st = node.machine.declare_qua_variables(num_IQ_pairs=num_qubit_pairs)
-            I_t, I_t_st, Q_t, Q_t_st, _, _ = node.machine.declare_qua_variables(num_IQ_pairs=num_qubit_pairs)
+            I_m, I_m_st, Q_m, Q_m_st, n, n_st = node.machine.declare_qua_variables(num_IQ_pairs=num_qubit_pairs)
+            I_s, I_s_st, Q_s, Q_s_st, _, _ = node.machine.declare_qua_variables(num_IQ_pairs=num_qubit_pairs)
 
         for multiplexed_qubit_pairs in qubit_pairs.batch():
             # Initialize the QPU for pairs in this batch
             for qp in multiplexed_qubit_pairs.values():
-                node.machine.initialize_qpu(target=qp.qubit_control)
-                node.machine.initialize_qpu(target=qp.qubit_target)
+                qubit_role = qubit_roles_map[qp.name]
+                mq, sq = qubit_role.moving, qubit_role.stationary
+                node.machine.initialize_qpu(target=mq)
+                node.machine.initialize_qpu(target=sq)
             align()
 
             for ii, qp in multiplexed_qubit_pairs.items():
+                qubit_role = qubit_roles_map[qp.name]
+                mq, sq = qubit_role.moving, qubit_role.stationary
                 has_crosstalk = "coupler_qubit_crosstalk" in qp.extras
                 crosstalk = qp.extras["coupler_qubit_crosstalk"] if has_crosstalk else 0.0
                 wait(1000)
@@ -156,8 +168,8 @@ def create_qua_program(
                     with for_(*from_array(flux_coupler, fluxes_coupler)):
                         with for_(*from_array(flux_qubit, fluxes_qp[qp.name])):
                             # Qubit initialization
-                            qp.qubit_control.reset(node.parameters.reset_type, node.parameters.simulate)
-                            qp.qubit_target.reset(node.parameters.reset_type, node.parameters.simulate)
+                            mq.reset(node.parameters.reset_type, node.parameters.simulate)
+                            sq.reset(node.parameters.reset_type, node.parameters.simulate)
                             align()
 
                             # Flux pulse amplitudes (with optional coupler-qubit crosstalk compensation)
@@ -168,9 +180,9 @@ def create_qua_program(
                             qp.align()
 
                             # State preparation
-                            qp.qubit_control.xy.play("x180")
+                            mq.xy.play("x180")
                             if node.parameters.cz_or_iswap == "cz":
-                                qp.qubit_target.xy.play("x180")
+                                sq.xy.play("x180")
                             align()
                             # Coupler and qubit flux pulses
                             qp.macros[operation].apply(
@@ -184,37 +196,37 @@ def create_qua_program(
                             # Qubit readout
                             if node.parameters.use_state_discrimination:
                                 if node.parameters.cz_or_iswap == "cz":
-                                    qp.qubit_control.readout_state_gef(state_c[ii])
-                                    qp.qubit_target.readout_state_gef(state_t[ii])
+                                    mq.readout_state_gef(state_mq[ii])
+                                    sq.readout_state_gef(state_sq[ii])
                                 else:
-                                    qp.qubit_control.readout_state(state_c[ii])
-                                    qp.qubit_target.readout_state(state_t[ii])
-                                save(state_c[ii], state_c_st[ii])
-                                save(state_t[ii], state_t_st[ii])
+                                    mq.readout_state(state_mq[ii])
+                                    sq.readout_state(state_sq[ii])
+                                save(state_mq[ii], state_mq_st[ii])
+                                save(state_sq[ii], state_sq_st[ii])
                             else:
-                                qp.qubit_control.resonator.measure("readout", qua_vars=(I_c[ii], Q_c[ii]))
-                                qp.qubit_target.resonator.measure("readout", qua_vars=(I_t[ii], Q_t[ii]))
-                                save(I_c[ii], I_c_st[ii])
-                                save(Q_c[ii], Q_c_st[ii])
-                                save(I_t[ii], I_t_st[ii])
-                                save(Q_t[ii], Q_t_st[ii])
+                                mq.resonator.measure("readout", qua_vars=(I_m[ii], Q_m[ii]))
+                                sq.resonator.measure("readout", qua_vars=(I_s[ii], Q_s[ii]))
+                                save(I_m[ii], I_m_st[ii])
+                                save(Q_m[ii], Q_m_st[ii])
+                                save(I_s[ii], I_s_st[ii])
+                                save(Q_s[ii], Q_s_st[ii])
             align()
 
         with stream_processing():
             n_st.save("n")
             for i in range(num_qubit_pairs):
                 if node.parameters.use_state_discrimination:
-                    state_c_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(
-                        f"state_control{i}"
+                    state_mq_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(
+                        f"state_moving{i}"
                     )
-                    state_t_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(
-                        f"state_target{i}"
+                    state_sq_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(
+                        f"state_stationary{i}"
                     )
                 else:
-                    I_c_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(f"I_control{i}")
-                    Q_c_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(f"Q_control{i}")
-                    I_t_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(f"I_target{i}")
-                    Q_t_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(f"Q_target{i}")
+                    I_m_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(f"I_moving{i}")
+                    Q_m_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(f"Q_moving{i}")
+                    I_s_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(f"I_stationary{i}")
+                    Q_s_st[i].buffer(len(fluxes_qubit)).buffer(len(fluxes_coupler)).average().save(f"Q_stationary{i}")
 
 
 # %% {Simulate}
@@ -256,8 +268,13 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
             )
         # Display the execution report to expose possible runtime errors
         node.log(job.execution_report())
-    # Register the raw dataset
+    # Register the raw dataset and the sweep/role data needed for reproducible re-analysis
     node.results["ds_raw"] = dataset
+    node.results["fluxes_qp"] = node.namespace["fluxes_qp"]
+    qubit_roles_map = node.namespace["qubit_roles_map"]
+    node.results["qubit_roles"] = {
+        name: {field: getattr(role, field).name for field in role._fields} for name, role in qubit_roles_map.items()
+    }
 
 
 # %% {Load_historical_data}
@@ -269,16 +286,11 @@ def load_data(node: QualibrationNode[Parameters, Quam]):
     node.load_from_id(node.parameters.load_data_id)
     node.parameters.load_data_id = load_data_id
     node.namespace["qubit_pairs"] = get_qubit_pairs(node)
-    fluxes_qubit = np.arange(
-        -node.parameters.qubit_flux_span / 2,
-        node.parameters.qubit_flux_span / 2,
-        node.parameters.qubit_flux_step,
-    )
-    fluxes_qp = {}
-    for qp in node.namespace["qubit_pairs"]:
-        est_flux_shift = estimate_qubit_flux_shift(node.parameters, qp, log_callable=node.log)
-        fluxes_qp[qp.name] = fluxes_qubit + est_flux_shift
-    node.namespace["fluxes_qp"] = fluxes_qp
+    node.namespace["fluxes_qp"] = {name: np.array(arr) for name, arr in node.results["fluxes_qp"].items()}
+    node.namespace["qubit_roles_map"] = {
+        name: QubitRoles(**{field: node.machine.qubits[qname] for field, qname in roles.items()})
+        for name, roles in node.results["qubit_roles"].items()
+    }
 
 
 # %% {Analyse_data}
@@ -309,13 +321,14 @@ def plot_data(node: QualibrationNode[Parameters, Quam]):
         node.results["ds_raw"],
         node.namespace["qubit_pairs"],
         node.results["fit_results"],
+        qubit_roles_map=node.namespace["qubit_roles_map"],
         analysis_debug=node.namespace.get("analysis_debug", node.parameters.analysis_debug),
         cz_or_iswap=node.parameters.cz_or_iswap,
     )
     plt.show()
     node.results["figures"] = {
-        "target": figs["target"],
-        "control": figs["control"],
+        "stationary": figs["stationary"],
+        "moving": figs["moving"],
     }
     if "contrast_debug" in figs:
         node.results["figures"]["contrast_debug"] = figs["contrast_debug"]

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/30_cz_iswap_flux_bootstrap.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/30_cz_iswap_flux_bootstrap.py
@@ -107,11 +107,6 @@ def create_qua_program(
         node.parameters.qubit_flux_span / 2,
         node.parameters.qubit_flux_step,
     )
-    fluxes_qp = {}
-    for qp in qubit_pairs:
-        est_flux_shift = estimate_qubit_flux_shift(node.parameters, qp, log_callable=node.log)
-        fluxes_qp[qp.name] = fluxes_qubit + est_flux_shift
-    node.namespace["fluxes_qp"] = fluxes_qp
 
     # Register the sweep axes to be added to the dataset when fetching data
     node.namespace["sweep_axes"] = {
@@ -120,16 +115,24 @@ def create_qua_program(
         "qubit_flux": xr.DataArray(fluxes_qubit, attrs={"long_name": "qubit flux", "units": "V"}),
     }
 
-    # Verify qp.moving_qubit against recalculation and precompute roles for QUA program loops.
-    # Logs a warning and corrects qp.moving_qubit in-memory if they disagree; state is saved
-    # at the end of the node.
+    # Reconcile moving qubit label / Z-line routing, then estimate flux sweep centre per pair.
     qubit_roles_map = {}
+    fluxes_qp = {}
     for qp in qubit_pairs:
-        verify_moving_qubit(qp, node.parameters.cz_or_iswap, log_callable=node.log)
+        verify_moving_qubit(
+            qp,
+            node.parameters.cz_or_iswap,
+            node.parameters.operation,
+            repair_routing=True,
+            log_callable=node.log,
+        )
         qubit_roles_map[qp.name] = QubitRoles.resolve(qp, node.parameters.cz_or_iswap)
         if "coupler_qubit_crosstalk" not in qp.extras:
             node.log(f"Pair {qp.name}: no crosstalk compensation configured")
+        est_flux_shift = estimate_qubit_flux_shift(node.parameters, qp, log_callable=node.log)
+        fluxes_qp[qp.name] = fluxes_qubit + est_flux_shift
     node.namespace["qubit_roles_map"] = qubit_roles_map
+    node.namespace["fluxes_qp"] = fluxes_qp
 
     with program() as node.namespace["qua_program"]:
         flux_coupler = declare(fixed)


### PR DESCRIPTION
**Summary**

Replaces the ad-hoc `moving_qubit` / `other_qubit` helper functions (which relied on the `qubit_pair.moving_qubit` config field) with a new `QubitRoles` named tuple that resolves qubit roles — moving, stationary, leakage, high, low — from first principles using qubit frequencies and anharmonicities.

**Why**

Previously, which qubit "moves" during a flux pulse was determined by a manually-set moving_qubit: "target" | "control" attribute on the pair. This was error-prone and required the user to know the correct role assignment upfront. The new `QubitRoles.resolve() `classmethod derives the correct role automatically:

iSWAP: the higher-frequency qubit tunes down to the lower one.
CZ (via |11⟩↔|20⟩): if freq_diff > |anharmonicity_high|, the high-frequency qubit moves; otherwise the low-frequency qubit moves. The leakage qubit is always the high-frequency one.

**Changes**
- `parameters.py:` Added `QubitRoles(NamedTuple)` with a `resolve()` classmethod and a `verify_moving_qubit()` helper that cross-checks the resolved role against the legacy qubit_pair.moving_qubit field.

- `__init__.py`: Exported `QubitRoles` and `verify_moving_qubit`.

- `analysis.py`: Renamed all control / target variable references to moving / stationary throughout the analysis pipeline (interaction map, fit extraction, dataset coordinates). Removed the direct import of the old `moving_qubit` function; roles are now read from `node.namespace["qubit_roles_map"]`.

- `30_cz_iswap_flux_bootstrap.py (node 30)`: Builds a `qubit_roles_map` in the setup step, passes it through the namespace and persists it in `node.results `so historical re-analysis is fully reproducible. QUA stream variables renamed from `state_control / state_target / I_control / I_target `to `state_moving / state_stationary / I_moving / I_stationary`.

**Reviewer Notes**
- No changes to the calibration logic or sweep parameters — this is purely a naming/role-resolution refactor.
- After this PR is approved, similar changes will be done on 31, 32a, 32b. 