### PR TITLE
Refactor CZ chevron (node 31) for QubitRoles and tunable-coupler support

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/chevron_cz/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/chevron_cz/__init__.py
@@ -1,12 +1,17 @@
 from .analysis import fit_raw_data, log_fitted_results, process_raw_dataset
-from .parameters import Parameters, baked_waveform
-from .plotting import plot_raw_data_with_fit
+from .parameters import Parameters, baked_waveform, estimate_cz_flux_amplitude
+from .plotting import plot_individual_qubit_chevron, plot_raw_data_with_fit
+from calibration_utils.cz_iswap_flux_bootstrap.parameters import QubitRoles, verify_moving_qubit
 
 __all__ = [
     "Parameters",
+    "QubitRoles",
+    "verify_moving_qubit",
     "process_raw_dataset",
     "fit_raw_data",
     "log_fitted_results",
     "plot_raw_data_with_fit",
+    "plot_individual_qubit_chevron",
     "baked_waveform",
+    "estimate_cz_flux_amplitude",
 ]

--- a/qualibration_graphs/superconducting/calibration_utils/chevron_cz/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/chevron_cz/analysis.py
@@ -5,17 +5,33 @@ from typing import Dict, Tuple
 import numpy as np
 import xarray as xr
 from qualibrate import QualibrationNode
-from qualibration_libs.analysis.fitting import fit_oscillation_decay_exp, oscillation_decay_exp
-from qualibration_libs.data import convert_IQ_to_V
+from qualibration_libs.analysis.fitting import fit_oscillation_decay_exp
 from scipy.optimize import curve_fit
-
-from quam.components.quantum_components import qubit
 
 
 def rabi_chevron_model(ft, J, f0, a, offset):
-    """Model the Rabi chevron response for a driven two-level (or effective two-qubit CZ) system."""
+    """Rabi-Chevron population model for the CZ |11⟩↔|20⟩ two-level system.
+
+    Parameters:
+    -----------
+    ft : tuple
+        Tuple ``(f, t)`` where ``f`` is the detuning array (Hz) and ``t`` is the
+        pulse duration array (s).
+    J : float
+        Coupling strength (Hz). The gate time at resonance is ``1/(2J)``.
+    f0 : float
+        Resonance detuning (Hz) at which the chevron is centred.
+    a : float
+        Amplitude scaling factor.
+    offset : float
+        Vertical offset of the population signal.
+
+    Returns:
+    --------
+    np.ndarray
+        Ravelled 1-D array of predicted population values.
+    """
     f, t = ft
-    J = J
     det = (f - f0) / 2
     # g = offset+a * np.sin(2*np.pi*np.sqrt(J**2 + (w-w0)**2) * t)**2*np.exp(-tau*np.abs((w-w0)))
     g = offset + a * (J**2) / (J**2 + det**2) * np.sin(2 * np.pi * np.sqrt(J**2 + det**2) * t) ** 2
@@ -24,11 +40,27 @@ def rabi_chevron_model(ft, J, f0, a, offset):
 
 
 def fit_rabi_chevron(ds_qp, init_length, init_detuning):
-    """Fit a Rabi chevron dataset to extract coupling (J), resonance frequency (f0), amplitude, and offset."""
-    if hasattr(ds_qp, "state_target"):
-        data = ds_qp.state_target
+    """Fit the Rabi-Chevron data for one qubit pair using ``rabi_chevron_model``.
+
+    Parameters:
+    -----------
+    ds_qp : xr.Dataset
+        Single-pair dataset containing ``state_stationary`` or ``I_stationary``,
+        with ``detuning`` and ``time`` coordinates.
+    init_length : float
+        Initial guess for the gate length (ns), used to seed ``J = 1e9/init_length``.
+    init_detuning : array-like
+        Initial guess for the resonance detuning ``f0`` (Hz).
+
+    Returns:
+    --------
+    tuple[float, float, float, float]
+        ``(J, f0, a, offset)`` fit parameters, or ``(nan, nan, nan, nan)`` on failure.
+    """
+    if hasattr(ds_qp, "state_stationary"):
+        data = ds_qp.state_stationary
     else:
-        data = ds_qp.I_target
+        data = ds_qp.I_stationary
 
     try:
         da_target = data
@@ -45,32 +77,46 @@ def fit_rabi_chevron(ds_qp, init_length, init_detuning):
         a = popt[2]
         offset = popt[3]
         return J, f0, a, offset
-    except Exception as e:
-        # Return NaN values if fitting fails
+    except Exception:
         return float("nan"), float("nan"), float("nan"), float("nan")
 
 
 @dataclass
 class FitParameters:
-    """Stores the relevant qubit spectroscopy experiment fit parameters for a single qubit"""
+    """Fit results for a single qubit pair from the CZ chevron calibration.
+
+    Attributes:
+    -----------
+    success : bool
+        True if the fit converged and the extracted parameters are physically valid.
+    J : float
+        Fitted coupling strength in Hz. The CZ gate time at resonance is ``1/(2J)``.
+    f0 : float
+        Fitted resonance detuning in Hz (centre of the chevron).
+    cz_len : int
+        Optimal CZ gate duration in nanoseconds, derived from ``1/(2J) * 1e9``.
+    cz_amp : float
+        Optimal CZ flux pulse amplitude in volts, derived from ``sqrt(-f0/quad_term)``.
+    """
 
     success: bool
-    J: float  # Rabi frequency
-    f0: float  # Frequency at which the Rabi oscillation is maximum
-    cz_len: int  # Length of the CZ gate in nanoseconds
-    cz_amp: float  # Amplitude of the CZ gate in volts
+    J: float
+    f0: float
+    cz_len: int
+    cz_amp: float
 
 
 def log_fitted_results(fit_results: Dict, log_callable=None):
     """
-    Logs the node-specific fitted results for all qubits from the fit xarray Dataset.
+    Log the CZ calibration fit results for all qubit pairs.
 
     Parameters:
     -----------
-    ds : xr.Dataset
-        Dataset containing the fitted results for all qubits.
+    fit_results : dict
+        Dictionary mapping qubit pair names to ``FitParameters`` instances or plain
+        dicts (as returned by ``dataclasses.asdict``).
     log_callable : callable, optional
-        Callable for logging the fitted results. If None, a default logger is used.
+        Logging function. Defaults to the module logger at INFO level.
     """
     if log_callable is None:
         log_callable = logging.getLogger(__name__).info
@@ -105,11 +151,34 @@ def log_fitted_results(fit_results: Dict, log_callable=None):
 
 
 def fit_chevron_cz(ds, dim):
+    """Fit the Rabi-Chevron pattern for every qubit pair using a groupby-apply loop.
+
+    For each pair the routine:
+    1. Finds the amplitude with the largest oscillation contrast as an initial guess.
+    2. Fits a decaying oscillation to estimate the initial gate time.
+    3. Calls ``fit_rabi_chevron`` with these seeds to obtain ``(J, f0, a, offset)``.
+
+    Parameters:
+    -----------
+    ds : xr.Dataset
+        Processed dataset with ``qubit_pair``, ``amplitude``, ``time``,
+        ``detuning``, ``amp_full``, and ``quad_term_moving`` coordinates.
+    dim : str
+        Dimension name to group by (``"qubit_pair"``).
+
+    Returns:
+    --------
+    xr.Dataset
+        Dataset with a ``fit_vals`` dimension containing ``[J, f0, a, offset]``
+        per qubit pair.
+    """
+
     def fit_routine(ds_qp):
-        if hasattr(ds_qp, "state_target"):
-            data = ds_qp.state_target
+        """Fit one qubit pair's chevron and return ``[J, f0, a, offset]`` as a DataArray."""
+        if hasattr(ds_qp, "state_stationary"):
+            data = ds_qp.state_stationary
         else:
-            data = ds_qp.I_target
+            data = ds_qp.I_stationary
         try:
             # ds_qp is a Dataset for a single qubit_pair
             amp_guess = data.max("time") - data.min("time")
@@ -125,7 +194,7 @@ def fit_chevron_cz(ds, dim):
                 flux_time = 50  # default 50 ns
 
             amplitudes = flux_amp
-            detunings = -(flux_amp**2) * ds_qp.quad_term_control
+            detunings = -(flux_amp**2) * ds_qp.quad_term_moving
             lengths = flux_time - flux_time % 4 + 4
 
             t = ds_qp.time * 1e-9
@@ -139,14 +208,13 @@ def fit_chevron_cz(ds, dim):
                 return xr.DataArray([float("nan"), float("nan"), float("nan"), float("nan")], dims=["fit_vals"])
 
             detunings = f0
-            amplitudes = np.sqrt(-detunings / ds_qp.quad_term_control)
+            amplitudes = np.sqrt(-detunings / ds_qp.quad_term_moving)
             flux_time = int(1 / (2 * J) * 1e9)
             lengths = flux_time - flux_time % 4 + 4
 
             # Return as DataArray for stacking
             return xr.DataArray([J, f0, a, offset], dims=["fit_vals"])
-        except Exception as e:
-            # Return NaN values if any step fails
+        except Exception:
             return xr.DataArray([float("nan"), float("nan"), float("nan"), float("nan")], dims=["fit_vals"])
 
     # Use groupby-apply pattern
@@ -156,11 +224,32 @@ def fit_chevron_cz(ds, dim):
 
 
 def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
-    if not node.parameters.use_state_discrimination:
-        ds = convert_IQ_to_V(ds, qubit_pairs=node.namespace["qubit_pairs"], IQ_list=["I_control", "Q_control"])
+    """Add physical coordinates to the raw dataset.
+
+    Computes and assigns:
+    - ``detuning`` — flux-induced frequency shift of the moving qubit (Hz).
+    - ``amp_full`` — absolute flux pulse amplitude in volts.
+    - ``quad_term_moving`` — ``freq_vs_flux_01_quad_term`` of the moving qubit, stored
+      per pair for use in the fitting step.
+
+    Parameters:
+    -----------
+    ds : xr.Dataset
+        Raw dataset as returned by the QUA data fetcher.
+    node : QualibrationNode
+        Calibration node providing ``pulse_amplitudes`` and qubit pair objects.
+
+    Returns:
+    --------
+    xr.Dataset
+        Dataset with the additional coordinates described above.
+    """
 
     def detuning(qp, amp):
-        return -((amp * node.namespace["pulse_amplitudes"][qp.name]) ** 2) * qp.qubit_control.freq_vs_flux_01_quad_term
+        return (
+            -((amp * node.namespace["pulse_amplitudes"][qp.name]) ** 2)
+            * node.namespace["qubit_roles_map"][qp.name].moving.freq_vs_flux_01_quad_term
+        )
 
     def abs_amp(qp, amp):
         return amp * node.namespace["pulse_amplitudes"][qp.name]
@@ -176,9 +265,11 @@ def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
 
     ds = ds.assign_coords(
         {
-            "quad_term_control": (
+            "quad_term_moving": (
                 ["qubit_pair"],
-                np.array([qp.qubit_control.freq_vs_flux_01_quad_term for qp in qubit_pairs]),
+                np.array(
+                    [node.namespace["qubit_roles_map"][qp.name].moving.freq_vs_flux_01_quad_term for qp in qubit_pairs]
+                ),
             )
         }
     )
@@ -188,19 +279,19 @@ def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
 
 def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, dict[str, FitParameters]]:
     """
-    Fit the qubit frequency and FWHM for each qubit in the dataset.
+    Fit the Rabi-Chevron pattern for each qubit pair and extract CZ gate parameters.
 
     Parameters:
     -----------
     ds : xr.Dataset
         Dataset containing the raw data.
-    node_parameters : Parameters
-        Parameters related to the node, including whether state discrimination is used.
+    node : QualibrationNode
+        The calibration node containing parameters and qubit pairs.
 
     Returns:
     --------
-    xr.Dataset
-        Dataset containing the fit results.
+    Tuple[xr.Dataset, dict[str, FitParameters]]
+        Dataset containing the fit results and dictionary of fit parameters for each qubit pair.
     """
 
     ds_fit_res = fit_chevron_cz(ds, "qubit_pair")
@@ -213,7 +304,27 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
 
 
 def _extract_relevant_fit_parameters(fit: xr.Dataset, node: QualibrationNode):
-    """Add metadata to the dataset and fit results."""
+    """Derive ``cz_len``, ``cz_amp``, and success flags from raw fit values.
+
+    For each qubit pair, converts the fitted ``J`` and ``f0`` into physically
+    meaningful gate parameters and validates them against the swept ranges.
+    Assigns ``cz_len`` and ``cz_amp`` as coordinates on the dataset.
+
+    Parameters:
+    -----------
+    fit : xr.Dataset
+        Dataset containing a ``fit`` DataArray with ``fit_vals`` dimension
+        (``J``, ``f0``, ``a``, ``offset``) and ``quad_term_moving``, ``amp_full``
+        coordinates.
+    node : QualibrationNode
+        Unused; retained for API consistency with other ``_extract_*`` helpers.
+
+    Returns:
+    --------
+    Tuple[xr.Dataset, dict[str, FitParameters]]
+        Updated dataset with ``cz_len`` and ``cz_amp`` coordinates, and a
+        dictionary of ``FitParameters`` keyed by qubit pair name.
+    """
 
     # Populate the FitParameters class with fitted values
     fit_results = {}
@@ -230,7 +341,7 @@ def _extract_relevant_fit_parameters(fit: xr.Dataset, node: QualibrationNode):
             else:
                 try:
                     cz_len_val = int(1 / (2 * J_val) * 1e9)
-                    cz_amp_val = np.sqrt(-f0_val / fit.quad_term_control.sel(qubit_pair=qp).values.item())
+                    cz_amp_val = np.sqrt(-f0_val / fit.quad_term_moving.sel(qubit_pair=qp).values.item())
 
                     # Determine success based on reasonable parameter ranges
                     amp_min = fit.amp_full.sel(qubit_pair=qp).min().item()
@@ -253,8 +364,7 @@ def _extract_relevant_fit_parameters(fit: xr.Dataset, node: QualibrationNode):
                 cz_len=cz_len_val,
                 cz_amp=cz_amp_val,
             )
-        except Exception as e:
-            # If any step fails, mark as failed
+        except Exception:
             fit_results[qp] = FitParameters(
                 success=False,
                 J=float("nan"),
@@ -269,5 +379,4 @@ def _extract_relevant_fit_parameters(fit: xr.Dataset, node: QualibrationNode):
             "cz_amp": ("qubit_pair", [fit_results[qp].cz_amp for qp in fit.qubit_pair.values]),
         }
     )
-    return fit, fit_results
     return fit, fit_results

--- a/qualibration_graphs/superconducting/calibration_utils/chevron_cz/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/chevron_cz/analysis.py
@@ -299,11 +299,11 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
     ds_fit = xr.merge([ds, ds_fit_res.rename("fit")])
 
     # Extract the relevant fitted parameters
-    fit_data, fit_results = _extract_relevant_fit_parameters(ds_fit, node)
+    fit_data, fit_results = _extract_relevant_fit_parameters(ds_fit)
     return fit_data, fit_results
 
 
-def _extract_relevant_fit_parameters(fit: xr.Dataset, node: QualibrationNode):
+def _extract_relevant_fit_parameters(fit: xr.Dataset):
     """Derive ``cz_len``, ``cz_amp``, and success flags from raw fit values.
 
     For each qubit pair, converts the fitted ``J`` and ``f0`` into physically
@@ -316,8 +316,6 @@ def _extract_relevant_fit_parameters(fit: xr.Dataset, node: QualibrationNode):
         Dataset containing a ``fit`` DataArray with ``fit_vals`` dimension
         (``J``, ``f0``, ``a``, ``offset``) and ``quad_term_moving``, ``amp_full``
         coordinates.
-    node : QualibrationNode
-        Unused; retained for API consistency with other ``_extract_*`` helpers.
 
     Returns:
     --------

--- a/qualibration_graphs/superconducting/calibration_utils/chevron_cz/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/chevron_cz/parameters.py
@@ -1,24 +1,37 @@
-from typing import ClassVar, List, Literal, Optional
+from types import SimpleNamespace
+from typing import Callable, ClassVar, Optional
 
-import numpy as np
 from qualang_tools.bakery import baking
 from qualibrate import NodeParameters
 from qualibrate.core.parameters import RunnableParameters
 from qualibration_libs.parameters import CommonNodeParameters, QubitPairExperimentNodeParameters
 
+from calibration_utils.cz_iswap_flux_bootstrap.parameters import estimate_qubit_flux_shift
+
 
 class NodeSpecificParameters(RunnableParameters):
-    """
-    Parameters for configuring a qubit spectroscopy experiment.
+    """Parameters for the CZ chevron calibration (node 31).
 
-    Attributes:
-        num_shots (int): Number of averages to perform. Default is 100.
-        frequency_span_in_mhz (float): Span of frequencies to sweep in MHz. Default is 100 MHz.
-        frequency_step_in_mhz (float): Step size for frequency sweep in MHz. Default is 0.25 MHz.
-        operation (str): Type of operation to perform. Default is "saturation".
-        operation_amplitude_factor (Optional[float]): Amplitude pre-factor for the operation. Default is 1.0.
-        operation_len_in_ns (Optional[int]): Length of the operation in nanoseconds. Default is None.
-        target_peak_width (Optional[float]): Target peak width in Hz. Default is 3e6 Hz.
+    Attributes
+    ----------
+    num_shots : int
+        Number of averages per point.
+    max_time_in_ns : int
+        Maximum flux pulse duration in ns.
+    amp_range : float
+        Fractional half-range around the base amplitude (sweep covers
+        ``[1 - amp_range, 1 + amp_range]`` times the base).
+    amp_step : float
+        Step size for the amplitude scaling sweep.
+    use_state_discrimination : bool
+        If True, use threshold-based state discrimination; otherwise raw IQ.
+    use_saved_detuning : bool
+        If True, read the CZ flux amplitude from ``qubit_pair.detuning``
+        (written by node 30) instead of computing it from qubit frequencies.
+        Use this for a fast re-run or when node 30 is not in the graph.
+    operation : str
+        Pair macro to calibrate and update (e.g. ``"cz_unipolar"``).
+        Used when looking up the saved macro amplitude and in state update.
     """
 
     num_shots: int = 100
@@ -26,7 +39,8 @@ class NodeSpecificParameters(RunnableParameters):
     amp_range: float = 0.1
     amp_step: float = 0.003
     use_state_discrimination: bool = True
-    update_all_pulses: bool = True
+    use_saved_detuning: bool = False
+    operation: str = "cz_unipolar"
 
 
 class Parameters(
@@ -38,12 +52,31 @@ class Parameters(
     targets_name: ClassVar[str] = "qubit_pairs"
 
 
+def estimate_cz_flux_amplitude(
+    parameters: NodeSpecificParameters,
+    qp,
+    log_callable: Optional[Callable[[str], None]] = None,
+) -> float:
+    """Estimate the CZ (11→20) flux-pulse base amplitude for the moving qubit.
+
+    Thin wrapper around :func:`estimate_qubit_flux_shift` pinned to the CZ interaction.
+    """
+    cz_params = SimpleNamespace(use_saved_detuning=parameters.use_saved_detuning, cz_or_iswap="cz")
+    return estimate_qubit_flux_shift(cz_params, qp, log_callable)
+
+
 def baked_waveform(qubit, baked_config, base_level: float = 0.5, max_samples: int = 16):
     """Create truncated baked waveforms for the chevron CZ calibration.
 
     Generates a list of baking objects, each containing an incrementally longer flux pulse
     (1..max_samples samples) at the specified base_level. Each baked pulse is registered
     as an operation named "flux_pulse{i}" on the provided qubit z line.
+
+    The coupler (when present) is intentionally NOT baked here. Baking both qubit z and
+    coupler in the same context causes an internal ``align()`` inside ``run()`` that
+    conflicts with ``strict_timing_()`` and produces timing gaps on the qubit element.
+    Instead the coupler is played separately in the QUA program with 4 ns granularity,
+    which is sufficient since the coupler only needs to hold a DC bias level.
 
     Args:
         qubit: The qubit object whose z line is used.
@@ -62,6 +95,4 @@ def baked_waveform(qubit, baked_config, base_level: float = 0.5, max_samples: in
             b.add_op(f"flux_pulse{i}", qubit.z.name, wf)
             b.play(f"flux_pulse{i}", qubit.z.name)
         pulse_segments.append(b)
-    return pulse_segments
-    return pulse_segments
     return pulse_segments

--- a/qualibration_graphs/superconducting/calibration_utils/chevron_cz/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/chevron_cz/plotting.py
@@ -1,104 +1,111 @@
-from typing import List
+from typing import Literal, Optional
 
-import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
-from qualang_tools.units import unit
-from qualibration_libs.plotting import QubitGrid, grid_iter
-from quam_builder.architecture.superconducting.qubit import AnyTransmon
+from qualibration_libs.plotting import grid_iter
 
-u = unit(coerce_to_integer=True)
+from calibration_utils.pair_grid import QubitPairGrid, grid_pair_names
 
 
-def plot_raw_data_with_fit(ds: xr.Dataset, qubit_pairs: List[AnyTransmon], fits: xr.Dataset):
-    """
-    Plots the resonator spectroscopy amplitude IQ_abs with fitted curves for the given qubits.
+def plot_raw_data_with_fit(
+    ds: xr.Dataset,
+    qubit_pairs: list,
+    fits: xr.Dataset,
+    qubit_role: Literal["stationary", "moving"] = "stationary",
+    qubit_roles_map: Optional[dict] = None,
+) -> Figure:
+    """Plot the chevron 2D map for every qubit pair on a chip-topology grid.
 
     Parameters
     ----------
     ds : xr.Dataset
-        The dataset containing the quadrature data.
-    qubits : list of AnyTransmon
-        A list of qubits to plot.
+        Processed dataset (must contain ``amp_full``, ``detuning``, and either
+        ``state_{qubit_role}`` or ``I_{qubit_role}``).
+    qubit_pairs : list
+        Qubit pair objects used for grid placement.
     fits : xr.Dataset
-        The dataset containing the fit parameters.
+        Dataset containing fit parameters (``cz_len``, ``cz_amp``).
+    qubit_role : {"stationary", "moving"}
+        Which qubit's data to display. Defaults to ``"stationary"``.
 
     Returns
     -------
     Figure
-        The matplotlib figure object containing the plots.
-
-    Notes
-    -----
-    - The function creates a grid of subplots, one for each qubit.
-    - Each subplot contains the raw data and the fitted curve.
+        Matplotlib figure with one chevron panel per pair.
     """
-    fig, axs = plt.subplots(nrows=len(qubit_pairs), ncols=1, figsize=(15, 9))
-    for ii, qp in enumerate(qubit_pairs):
-        ax = axs[ii] if len(qubit_pairs) > 1 else axs
+    grid_names, pair_names = grid_pair_names(qubit_pairs)
+    grid = QubitPairGrid(grid_names, pair_names)
 
-        # Try to get fit data for this qubit pair, handle if missing
+    qp_map = {qp.name: qp for qp in qubit_pairs}
+    for ax, qubit in grid_iter(grid):
+        qp_name = qubit["qubit"]
         try:
-            fit_data = fits.sel(qubit_pair=qp.id) if fits is not None else None
+            fit_data = fits.sel(qubit_pair=qp_name) if fits is not None else None
         except (KeyError, ValueError):
-            # If this qubit pair is not in the fit results, set fit_data to None
             fit_data = None
+        qubit_role_obj = qubit_roles_map.get(qp_name) if qubit_roles_map else None
+        plot_individual_qubit_chevron(
+            ax, ds, qp_name, qubit_role, fit_data, qp_map.get(qp_name), qubit_role_obj=qubit_role_obj
+        )
 
-        plot_individual_data_with(ax, ds, qp.id, fit_data)
-
-    fig.suptitle("CZ Chevron")
-    fig.set_size_inches(15, 9)
-    fig.tight_layout()
-
-    return fig
+    grid.fig.suptitle(f"CZ Chevron — {qubit_role} qubit")
+    grid.fig.tight_layout()
+    return grid.fig
 
 
-def plot_individual_data_with(ax: Axes, ds: xr.Dataset, qubit_pair: str, fit: xr.Dataset = None):
-    """
-    Plots individual qubit data on a given axis with optional fit.
+def plot_individual_qubit_chevron(
+    ax: Axes,
+    ds: xr.Dataset,
+    qp_name: str,
+    qubit_role: Literal["stationary", "moving"],
+    fit: Optional[xr.Dataset] = None,
+    qp=None,
+    qubit_role_obj=None,
+):
+    """Plot the chevron 2D map for one qubit pair and one qubit role.
 
     Parameters
     ----------
-    ax : matplotlib.axes.Axes
-        The axis on which to plot the data.
+    ax : Axes
+        Axis to draw on.
     ds : xr.Dataset
-        The dataset containing the quadrature data.
-    qubit : dict[str, str]
-        mapping to the qubit to plot.
+        Processed dataset with ``amp_full`` and ``detuning`` coordinates.
+    qp_name : str
+        Qubit pair name used to select data from ``ds``.
+    qubit_role : {"stationary", "moving"}
+        Which qubit to display.  ``"stationary"`` uses ``state_stationary`` /
+        ``I_stationary``; ``"moving"`` uses ``state_moving`` / ``I_moving``.
     fit : xr.Dataset, optional
-        The dataset containing the fit parameters (default is None).
-
-    Notes
-    -----
-    - If the fit dataset is provided, the fitted curve is plotted along with the raw data.
+        Fit parameters for this pair.  When valid, the optimal CZ point
+        (``cz_len``, ``cz_amp``) is marked with a red star.
+    qp : qubit pair object, optional
+        When provided, the moving and stationary qubit names are shown in
+        the panel title.
     """
+    state_var = f"state_{qubit_role}"
+    iq_var = f"I_{qubit_role}"
+    data = getattr(ds, state_var) if hasattr(ds, state_var) else getattr(ds, iq_var)
+    data.sel(qubit_pair=qp_name).plot(y="amp_full", ax=ax)
 
-    if hasattr(ds, "state_target"):
-        # If the dataset has 'state_target', use it for plotting
-        data = ds.state_target
-    else:
-        data = ds.I_target
-
-    data.sel(qubit_pair=qubit_pair).plot(y="amp_full", ax=ax)
-
-    # Only plot fit results if they exist and are valid
     if fit is not None:
         try:
-            # Check if fit values exist and are valid (not NaN)
             cz_len = float(fit.cz_len)
             cz_amp = float(fit.cz_amp)
             if not (np.isnan(cz_len) or np.isnan(cz_amp)):
-                ax.scatter(cz_len, cz_amp, color="red", label="Fitted", marker="*", s=100)
-                ax.set_title(f"{qubit_pair} - Fit Successful")
-                ax.legend()
-            else:
-                ax.set_title(f"{qubit_pair} - Fit Failed (Invalid Parameters)")
-        except (ValueError, TypeError, AttributeError):
-            ax.set_title(f"{qubit_pair} - Fit Failed")
+                ax.axvline(cz_len, color="red", ls="--", lw=1.2)
+                ax.axhline(cz_amp, color="orange", ls="--", lw=1.2)
+                ax.scatter(cz_len, cz_amp, color="red", marker="*", s=200, zorder=5, label="CZ point")
+                ax.legend(fontsize=8)
+        except (ValueError, TypeError, AttributeError, KeyError):
+            pass
+
+    if qubit_role_obj is not None:
+        qb_name = qubit_role_obj.moving.name if qubit_role == "moving" else qubit_role_obj.stationary.name
+        ax.set_title(f"{qp_name}\n{qubit_role}: {qb_name}")
     else:
-        ax.set_title(f"{qubit_pair} - No Fit Data")
+        ax.set_title(qp_name)
 
     ax.set_xlabel("Time [ns]")
-    ax.set_ylabel("Target State")
+    ax.set_ylabel("Amplitude [V]")

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/31_chevron_11_20.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/31_chevron_11_20.py
@@ -97,7 +97,12 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     # qp.moving_qubit in-memory if they disagree; state is persisted at the end of the node.
     qubit_roles_map = {}
     for qp in qubit_pairs:
-        verify_moving_qubit(qp, log_callable=node.log)
+        verify_moving_qubit(
+            qubit_pair=qp,
+            operation=node.parameters.operation,
+            repair_routing=True,
+            log_callable=node.log,
+        )
         qubit_roles_map[qp.name] = QubitRoles.resolve(qp)
     node.namespace["qubit_roles_map"] = qubit_roles_map
 

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/31_chevron_11_20.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/31_chevron_11_20.py
@@ -1,14 +1,16 @@
 # %% {Imports}
 from dataclasses import asdict
-
 import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from calibration_utils.chevron_cz import (
     Parameters,
     baked_waveform,
+    estimate_cz_flux_amplitude,
     fit_raw_data,
     log_fitted_results,
+    QubitRoles,
+    verify_moving_qubit,
     plot_raw_data_with_fit,
     process_raw_dataset,
 )
@@ -16,56 +18,55 @@ from qm.qua import *
 from qualang_tools.loops import from_array
 from qualang_tools.multi_user import qm_session
 from qualang_tools.results import progress_counter
-from qualang_tools.units import unit
 from qualibrate import QualibrationNode
 from qualibration_libs.data import XarrayDataFetcher
 from qualibration_libs.parameters import get_qubit_pairs
 from qualibration_libs.runtime import simulate_and_plot
-from quam_builder.architecture.superconducting.custom_gates.flux_tunable_transmon_pair.two_qubit_gates import CZGate
 from quam_config import Quam
 
 # %% {Node_parameters}
 description = """
-Unipolar CPhase Gate Calibration
-This sequence measures the time and detuning required for a unipolar CPhase gate. The process involves:
+CZ |11⟩↔|20⟩ Flux Chevron Calibration
 
-1. Preparing both qubits in their excited states.
-2. Applying a flux pulse with varying amplitude and duration.
-3. Measuring the resulting state populations as a function of these parameters.
-4. Fitting the results to a Ramsey-Chevron pattern.
+Measures the time and amplitude required for the CZ gate by sweeping the moving-qubit flux
+pulse amplitude (around the estimated |11⟩↔|20⟩ operating point) and duration (1 ns
+granularity via baking). The resulting 2D Chevron pattern is fitted to extract the optimal gate amplitude and duration.
 
-From this pattern, we extract:
-- The coupling strength (J2) between the qubits.
-- The optimal gate parameters (amplitude and duration) for the CPhase gate.
+The |11⟩↔|20⟩ avoided crossing always involves the higher-frequency qubit as the leakage channel
+(2 photons on the high qubit). The moving qubit is the one that tunes to reach the crossing.
 
-The Ramsey-Chevron pattern emerges due to the interplay between the qubit-qubit coupling and the flux-induced detuning,
-allowing us to precisely calibrate the CPhase gate.
+For tunable-coupler architectures the coupler is held at its CZ bias point
+(``macros[operation].coupler_flux_pulse.amplitude``) throughout each flux pulse. For fixed-coupler
+architectures no coupler element is needed.
+
+Method
+------
+1. Prepare |11⟩ by applying x180 to both qubits.
+2. Apply the moving-qubit flux pulse at scaled amplitude and variable duration, bringing it
+   to the |11⟩↔|20⟩ avoided crossing. For tunable couplers, the coupler is simultaneously
+   held at the CZ bias.
+3. Measure both qubits (state discrimination or raw IQ).
+4. Fit the 2D population map to a Rabi-Chevron model to extract the resonance amplitude and gate time.
 
 Prerequisites:
 - Calibrated single-qubit gates for both qubits in the pair.
 - Calibrated readout for both qubits.
-- Initial estimate of the flux pulse amplitude range.
+- Initial estimate of the coupler flux amplitude in case of tunable couplers.
 
 Outcomes:
-- Extracted J2 coupling strength.
-- Optimal flux pulse amplitude and duration for the CPhase gate.
-- Fitted Ramsey-Chevron pattern for visualization and verification.
+- Optimal flux pulse amplitude and duration for the CZ gate.
+- Fitted Chevron pattern for visualization and verification.
 
 State update:
-        - (If missing) adds unipolar and flattop CZ gate macros to each calibrated qubit pair
-            (node.machine.qubit_pairs[<pair_name>].macros["cz_unipolar"]).
-        - Updates their flux pulse amplitude
-            (qp.macros["cz_unipolar"].flux_pulse_qubit.amplitude) to the fitted CZ amplitude.
-        - Updates their flux pulse duration (qp.macros["cz_unipolar"].flux_pulse_qubit.length) to the
-            fitted CZ length rounded up to the next multiple of 4 ns.
+- Updates the amplitude and duration of the flux pulse in ``macros[operation]``
+  to the fitted CZ values (duration rounded up to the next multiple of 4 ns).
 """
 
 # Be sure to include [Parameters, Quam] so the node has proper type hinting
 node = QualibrationNode[Parameters, Quam](
     name="31_chevron_1102",  # Name should be unique
     description=description,  # Describe what the node is doing, which is also reflected in the QUAlibrate GUI
-    parameters=Parameters(),  # Node parameters defined under quam_experiment/experiments/node_name
-    machine=Quam.load(),
+    parameters=Parameters(),  # Node parameters defined under calibration_utils/chevron_cz/parameters.py
 )
 
 
@@ -78,22 +79,32 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
     pass
 
 
+# Instantiate the QUAM class from the state file
+node.machine = Quam.load()
+
+
 # %% {Create_QUA_program}
 @node.run_action(skip_if=node.parameters.load_data_id is not None)
 def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     """Create the sweep axes and generate the QUA program from the pulse sequence and the node parameters."""
 
-    u = unit(coerce_to_integer=True)
-
     # Get the qubit pairs to be calibrated
     node.namespace["qubit_pairs"] = qubit_pairs = get_qubit_pairs(node)
     num_qubit_pairs = len(qubit_pairs)
 
+    # Verify that qp.moving_qubit in state matches the recalculation from qubit frequencies and
+    # anharmonicity, then precompute roles for QUA program loops. Logs a warning and corrects
+    # qp.moving_qubit in-memory if they disagree; state is persisted at the end of the node.
+    qubit_roles_map = {}
+    for qp in qubit_pairs:
+        verify_moving_qubit(qp, log_callable=node.log)
+        qubit_roles_map[qp.name] = QubitRoles.resolve(qp)
+    node.namespace["qubit_roles_map"] = qubit_roles_map
+
     # define the amplitudes for the flux pulses
     pulse_amplitudes = {}
     for qp in qubit_pairs:
-        detuning = qp.qubit_control.xy.RF_frequency - qp.qubit_target.xy.RF_frequency - qp.qubit_target.anharmonicity
-        pulse_amplitudes[qp.name] = float(np.sqrt(-detuning / qp.qubit_control.freq_vs_flux_01_quad_term))
+        pulse_amplitudes[qp.name] = estimate_cz_flux_amplitude(node.parameters, qp, log_callable=node.log)
 
     node.namespace["pulse_amplitudes"] = pulse_amplitudes
 
@@ -112,10 +123,23 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
 
     baked_config = node.machine.generate_config()
 
-    # Pre-compute the baked short segments (1..16 samples) for each control qubit in the pairs
+    # Detect tunable coupler presence for each pair (Python-time, not QUA-time).
+    operation = node.parameters.operation
+    has_coupler = {}
+    coupler_amplitudes = {}
+    for qp in qubit_pairs:
+        macro = qp.macros[operation]
+        has_coupler[qp.name] = macro.coupler_flux_pulse is not None
+        if has_coupler[qp.name]:
+            coupler_amplitudes[qp.name] = macro.coupler_flux_pulse.amplitude
+            node.namespace["has_coupler"] = has_coupler
+            node.namespace["coupler_amplitudes"] = coupler_amplitudes
+
+    # Pre-compute baked short segments (1..16 ns) for each moving qubit (qubit only —
+    # the coupler is played separately with 4 ns granularity to avoid strict_timing gaps).
     baked_signals = {
-        qp.qubit_control.name: baked_waveform(
-            qp.qubit_control, baked_config, base_level=pulse_amplitudes[qp.name], max_samples=16
+        qp.name: baked_waveform(
+            qubit_roles_map[qp.name].moving, baked_config, base_level=pulse_amplitudes[qp.name], max_samples=16
         )
         for qp in qubit_pairs
     }
@@ -125,23 +149,23 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     with program() as node.namespace["qua_program"]:
         t = declare(int)  # QUA variable for the flux pulse segment index
         a = declare(fixed)
-        n = declare(int)
-        n_st = declare_stream()
         t_left_ns = declare(int)  # QUA variable for the flux pulse segment index
         t_cycles = declare(int)  # QUA variable for the flux pulse segment index
-        I_c, I_c_st, Q_c, Q_c_st, n, n_st = node.machine.declare_qua_variables()
-        I_t, I_t_st, Q_t, Q_t_st, _, _ = node.machine.declare_qua_variables()
+        I_m, I_m_st, Q_m, Q_m_st, n, n_st = node.machine.declare_qua_variables()
+        I_s, I_s_st, Q_s, Q_s_st, _, _ = node.machine.declare_qua_variables()
         if node.parameters.use_state_discrimination:
-            state_c = [declare(int) for _ in range(num_qubit_pairs)]
-            state_t = [declare(int) for _ in range(num_qubit_pairs)]
-            state_c_st = [declare_stream() for _ in range(num_qubit_pairs)]
-            state_t_st = [declare_stream() for _ in range(num_qubit_pairs)]
+            state_mq = [declare(int) for _ in range(num_qubit_pairs)]
+            state_sq = [declare(int) for _ in range(num_qubit_pairs)]
+            state_mq_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_sq_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
 
         for multiplexed_qubit_pairs in qubit_pairs.batch():
             # Initialize the QPU in terms of flux points (flux tunable transmons and/or tunable couplers)
             for qp in multiplexed_qubit_pairs.values():
-                node.machine.initialize_qpu(target=qp.qubit_control)
-                node.machine.initialize_qpu(target=qp.qubit_target)
+                qubit_role = qubit_roles_map[qp.name]
+                mq, sq = qubit_role.moving, qubit_role.stationary
+                node.machine.initialize_qpu(target=mq)
+                node.machine.initialize_qpu(target=sq)
             align()
             # Averaging loop
             with for_(n, 0, n < n_avg, n + 1):
@@ -156,15 +180,20 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
                     ################################################################################################
                     with for_(*from_array(t, times_cycles)):
                         for ii, qp in multiplexed_qubit_pairs.items():
+                            qubit_role = qubit_roles_map[qp.name]
+                            mq, sq = qubit_role.moving, qubit_role.stationary
                             # Qubit initialization
-                            qp.qubit_control.reset(node.parameters.reset_type, node.parameters.simulate)
-                            qp.qubit_target.reset(node.parameters.reset_type, node.parameters.simulate)
+                            mq.reset(node.parameters.reset_type, node.parameters.simulate)
+                            sq.reset(node.parameters.reset_type, node.parameters.simulate)
                             align()
-                            # set both qubits to the excited state
-                            qp.qubit_control.xy.play("x180")
-                            qp.qubit_target.xy.play("x180")
+                            # set both qubits to the excited state to prepare |11⟩
+                            mq.xy.play("x180")
+                            sq.xy.play("x180")
 
                             align()
+
+                            if has_coupler[qp.name]:
+                                coupler_scale = coupler_amplitudes[qp.name] / qp.coupler.operations["const"].amplitude
 
                             # For the first 16ns we play baked pulses exclusively. Loop the time index until 16.
                             with if_(t <= 16):
@@ -172,9 +201,13 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
                                     # Switch case to select the baked pulse with duration t ns
                                     for j in range(1, 17):
                                         with case_(j):
-                                            baked_signals[qp.qubit_control.name][j - 1].run(
-                                                amp_array=[(qp.qubit_control.z.name, a)]
-                                            )
+                                            baked_signals[qp.name][j - 1].run(amp_array=[(mq.z.name, a)])
+                                            if has_coupler[qp.name]:
+                                                # Coupler only needs to hold the CZ bias level — 4 ns granularity is sufficient.
+                                                # ceil(j/4) cycles ensures the hold covers the full j ns qubit baked pulse.
+                                                qp.coupler.play(
+                                                    "const", duration=(j + 3) // 4, amplitude_scale=coupler_scale
+                                                )
 
                             # For pulse durations above 16ns we combine baking with regular play statements.
                             with else_():
@@ -188,55 +221,61 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
                                     with case_(0):
                                         align()
                                         p = pulse_amplitudes[qp.name]
-                                        denom = qp.qubit_control.z.operations["const"].amplitude
+                                        denom = mq.z.operations["const"].amplitude
                                         scale = (p / denom) * a
-                                        qp.qubit_control.z.play(
+                                        mq.z.play(
                                             "const",
                                             duration=t_cycles,
                                             amplitude_scale=scale,
                                         )
+                                        if has_coupler[qp.name]:
+                                            qp.coupler.play("const", duration=t_cycles, amplitude_scale=coupler_scale)
                                     # Play the pulse multiple of 4 followed by the baked pulse of the missing duration
                                     for j in range(1, 4):
                                         with case_(j):
                                             align()
                                             p = pulse_amplitudes[qp.name]
-                                            denom = qp.qubit_control.z.operations["const"].amplitude
+                                            denom = mq.z.operations["const"].amplitude
                                             scale = (p / denom) * a
+                                            if has_coupler[qp.name]:
+                                                qp.coupler.play(
+                                                    "const", duration=t_cycles + 1, amplitude_scale=coupler_scale
+                                                )
                                             with strict_timing_():
-                                                qp.qubit_control.z.play(
+                                                mq.z.play(
                                                     "const",
                                                     duration=t_cycles,
                                                     amplitude_scale=scale,
                                                 )
-                                                baked_signals[qp.qubit_control.name][j - 1].run(
-                                                    amp_array=[(qp.qubit_control.z.name, a)]
-                                                )
+                                                baked_signals[qp.name][j - 1].run(amp_array=[(mq.z.name, a)])
                             align()
 
                             if node.parameters.use_state_discrimination:
-                                qp.qubit_control.readout_state_gef(state_c[ii])
-                                qp.qubit_target.readout_state(state_t[ii])
-                                save(state_c[ii], state_c_st[ii])
-                                save(state_t[ii], state_t_st[ii])
+                                mq.readout_state_gef(state_mq[ii])
+                                sq.readout_state_gef(state_sq[ii])
+                                save(state_mq[ii], state_mq_st[ii])
+                                save(state_sq[ii], state_sq_st[ii])
                             else:
-                                qp.qubit_control.resonator.measure("readout", qua_vars=(I_c[ii], Q_c[ii]))
-                                qp.qubit_target.resonator.measure("readout", qua_vars=(I_t[ii], Q_t[ii]))
-                                save(I_c[ii], I_c_st[ii])
-                                save(Q_c[ii], Q_c_st[ii])
-                                save(I_t[ii], I_t_st[ii])
-                                save(Q_t[ii], Q_t_st[ii])
+                                mq.resonator.measure("readout", qua_vars=(I_m[ii], Q_m[ii]))
+                                sq.resonator.measure("readout", qua_vars=(I_s[ii], Q_s[ii]))
+                                save(I_m[ii], I_m_st[ii])
+                                save(Q_m[ii], Q_m_st[ii])
+                                save(I_s[ii], I_s_st[ii])
+                                save(Q_s[ii], Q_s_st[ii])
 
         with stream_processing():
             n_st.save("n")
             for i in range(num_qubit_pairs):
                 if node.parameters.use_state_discrimination:
-                    state_c_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(f"state_control{i}")
-                    state_t_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(f"state_target{i}")
+                    state_mq_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(f"state_moving{i}")
+                    state_sq_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(
+                        f"state_stationary{i}"
+                    )
                 else:
-                    I_c_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(f"I_control{i}")
-                    Q_c_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(f"Q_control{i}")
-                    I_t_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(f"I_target{i}")
-                    Q_t_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(f"Q_target{i}")
+                    I_m_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(f"I_moving{i}")
+                    Q_m_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(f"Q_moving{i}")
+                    I_s_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(f"I_stationary{i}")
+                    Q_s_st[i].buffer(len(times_cycles)).buffer(len(amplitudes)).average().save(f"Q_stationary{i}")
 
 
 # %% {Simulate}
@@ -272,14 +311,19 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_shots,
                 start_time=data_fetcher.t_start,
             )
         # Display the execution report to expose possible runtime errors
         node.log(job.execution_report())
-    # Register the raw dataset
+    # Register the raw dataset and sweep/role data needed for reproducible re-analysis
     node.results["ds_raw"] = dataset
+    node.results["pulse_amplitudes"] = node.namespace["pulse_amplitudes"]
+    qubit_roles_map = node.namespace["qubit_roles_map"]
+    node.results["qubit_roles"] = {
+        name: {field: getattr(role, field).name for field in role._fields} for name, role in qubit_roles_map.items()
+    }
 
 
 # %% {Load_data}
@@ -290,15 +334,15 @@ def load_data(node: QualibrationNode[Parameters, Quam]):
     # Load the specified dataset
     node.load_from_id(node.parameters.load_data_id)
     node.parameters.load_data_id = load_data_id
-    qubit_pairs = [node.machine.qubit_pairs[pair] for pair in node.parameters.qubit_pairs]
-    # define the amplitudes for the flux pulses
-    pulse_amplitudes = {}
-    for qp in qubit_pairs:
-        detuning = qp.qubit_control.xy.RF_frequency - qp.qubit_target.xy.RF_frequency - qp.qubit_target.anharmonicity
-        pulse_amplitudes[qp.name] = float(np.sqrt(-detuning / qp.qubit_control.freq_vs_flux_01_quad_term))
-    node.namespace["pulse_amplitudes"] = pulse_amplitudes
-    node.namespace["qubits"] = [qp.qubit_control for qp in qubit_pairs] + [qp.qubit_target for qp in qubit_pairs]
-    node.namespace["qubit_pairs"] = [node.machine.qubit_pairs[pair] for pair in node.parameters.qubit_pairs]
+    node.namespace["qubit_pairs"] = get_qubit_pairs(node)
+    node.namespace["pulse_amplitudes"] = {name: float(amp) for name, amp in node.results["pulse_amplitudes"].items()}
+    node.namespace["qubit_roles_map"] = {
+        name: QubitRoles(**{field: node.machine.qubits[qname] for field, qname in roles.items()})
+        for name, roles in node.results["qubit_roles"].items()
+    }
+    node.namespace["qubits"] = [r.moving for r in node.namespace["qubit_roles_map"].values()] + [
+        r.stationary for r in node.namespace["qubit_roles_map"].values()
+    ]
 
 
 # %% {Analyse_data}
@@ -325,11 +369,25 @@ def analyse_data(node: QualibrationNode[Parameters, Quam]):
 @node.run_action(skip_if=node.parameters.simulate)
 def plot_data(node: QualibrationNode[Parameters, Quam]):
     """Plot the raw and fitted data in specific figures whose shape is given by qubit.grid_location."""
-    fig_raw_fit = plot_raw_data_with_fit(node.results["ds_raw"], node.namespace["qubit_pairs"], node.results["ds_fit"])
+    fig_stationary = plot_raw_data_with_fit(
+        node.results["ds_raw"],
+        node.namespace["qubit_pairs"],
+        node.results["ds_fit"],
+        qubit_role="stationary",
+        qubit_roles_map=node.namespace.get("qubit_roles_map"),
+    )
+    fig_moving = plot_raw_data_with_fit(
+        node.results["ds_raw"],
+        node.namespace["qubit_pairs"],
+        node.results["ds_fit"],
+        qubit_role="moving",
+        qubit_roles_map=node.namespace.get("qubit_roles_map"),
+    )
     plt.show()
     # Store the generated figures
     node.results["figures"] = {
-        "amplitude": fig_raw_fit,
+        "stationary_qubit": fig_stationary,
+        "moving_qubit": fig_moving,
     }
 
 
@@ -338,32 +396,20 @@ def plot_data(node: QualibrationNode[Parameters, Quam]):
 def update_state(node: QualibrationNode[Parameters, Quam]):
     """Update the relevant parameters if the qubit data analysis was successful."""
 
+    operation = node.parameters.operation
     with node.record_state_updates():
         for qp in node.namespace["qubit_pairs"]:
             if node.outcomes[qp.name] == "failed":
+                node.log(f"Skipping state update for {qp.name}: fit flagged unsuccessful.")
                 continue
-            else:
-                qp.macros["cz_unipolar"].flux_pulse_qubit.amplitude = node.results["fit_results"][qp.name]["cz_amp"]
-                # Round up to the upper 4 ns to be compatible with the hardware time resolution
-                qp.macros["cz_unipolar"].flux_pulse_qubit.length = int(
-                    np.ceil(node.results["fit_results"][qp.name]["cz_len"] / 4) * 4
-                )
-                if node.parameters.update_all_pulses:
-                    qp.macros["cz_bipolar"].flux_pulse_qubit.amplitude = node.results["fit_results"][qp.name]["cz_amp"]
-                    qp.macros["cz_flattop"].flux_pulse_qubit.amplitude = node.results["fit_results"][qp.name]["cz_amp"]
-                    # Round up to the upper 4 ns to be compatible with the hardware time resolution
-                    qp.macros["cz_flattop"].flux_pulse_qubit.flat_length = int(
-                        np.ceil(node.results["fit_results"][qp.name]["cz_len"] / 2) * 2
-                    )
-                    qp.macros["cz_bipolar"].flux_pulse_qubit.flat_length = int(
-                        np.ceil(node.results["fit_results"][qp.name]["cz_len"] / 2) * 2
-                    )
+            qp.macros[operation].flux_pulse_qubit.amplitude = node.results["fit_results"][qp.name]["cz_amp"]
+            # Round up to the upper 4 ns to be compatible with the hardware time resolution
+            qp.macros[operation].flux_pulse_qubit.length = int(
+                np.ceil(node.results["fit_results"][qp.name]["cz_len"] / 4) * 4
+            )
 
 
 # %% {Save_results}
 @node.run_action()
 def save_results(node: QualibrationNode[Parameters, Quam]):
     node.save()
-
-
-# %%


### PR DESCRIPTION
## Summary

Refactors the CZ chevron calibration (node 31) to use physics-driven **moving/stationary qubit roles** instead of hardcoded control/target, and adds **tunable-coupler** support. Renames the node file to `31_chevron_11_20.py` to reflect the |11⟩↔|20⟩ interaction.

## What

- **Qubit roles**: Resolves moving vs. stationary qubits via `QubitRoles` / `verify_moving_qubit` (from the node 30 bootstrap utils). The moving qubit carries the flux pulse; the stationary qubit is the |11⟩↔|20⟩ leakage channel used for fitting.
- **Tunable coupler**: Detects `macros[operation].coupler_flux_pulse` and holds the coupler at its CZ bias during each flux sweep. The coupler is played separately at 4 ns granularity (not baked) to avoid `strict_timing_` conflicts with baked qubit pulses.
- **Analysis & plotting**: Fitting and detuning math now use the **moving** qubit's `freq_vs_flux_01_quad_term`; fit data comes from the **stationary** qubit. Plotting uses `QubitPairGrid` chip topology and produces separate figures for moving and stationary qubits.
- **Parameters & state update**: Adds `operation` (default `"cz_unipolar"`) and `use_saved_detuning`; removes `update_all_pulses`. State update writes fitted amplitude/length only to the configured macro (macro must already exist from populate).
- **Re-analysis**: Saves `pulse_amplitudes` and `qubit_roles` in results so loaded data can be re-analyzed without re-running the sweep.