### PR TITLE
Refactor CZ phase calibrations (nodes 32a/32b) for QubitRoles

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase/__init__.py
@@ -1,12 +1,25 @@
-from .analysis import FitResults, fit_raw_data, log_fitted_results, process_raw_dataset
+from .analysis import (
+    FitResults,
+    fit_raw_data,
+    fix_oscillation_phi_2pi,
+    log_fitted_results,
+    process_raw_dataset,
+    tanh_fit,
+)
 from .parameters import Parameters
-from .plotting import plot_raw_data_with_fit
+from .plotting import plot_leakage_qubit_populations, plot_raw_data_with_fit
+from calibration_utils.cz_iswap_flux_bootstrap.parameters import QubitRoles, verify_moving_qubit  # noqa: F401
 
 __all__ = [
     "Parameters",
+    "fix_oscillation_phi_2pi",
+    "tanh_fit",
+    "QubitRoles",
+    "verify_moving_qubit",
     "process_raw_dataset",
     "fit_raw_data",
     "log_fitted_results",
     "FitResults",
     "plot_raw_data_with_fit",
+    "plot_leakage_qubit_populations",
 ]

--- a/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase/analysis.py
@@ -11,14 +11,34 @@ from scipy.optimize import curve_fit
 
 @dataclass
 class FitResults:
-    """Stores the relevant CZ conditional phase experiment fit parameters for a single qubit pair"""
+    """Fit results for a single qubit pair from the CZ conditional phase calibration.
+
+    Attributes:
+    -----------
+    optimal_amplitude : float
+        Flux pulse amplitude (V) at which the conditional phase equals π.
+    success : bool
+        True if the tanh fit converged and the optimal amplitude lies within
+        the swept range.
+    """
 
     optimal_amplitude: float
     success: bool
 
 
 def fix_oscillation_phi_2pi(fit_data):
-    """Extract the phase parameter from oscillation fit data."""
+    """Extract and normalise the oscillation phase to the [0, 1) range (representing 0 to 2π).
+
+    Parameters:
+    -----------
+    fit_data : xr.DataArray
+        Oscillation fit result with a ``fit_vals`` dimension containing ``"phi"``.
+
+    Returns:
+    --------
+    xr.DataArray
+        Phase values normalised to [0, 1).
+    """
     # Extract the phase parameter from the fit results
     phase = fit_data.sel(fit_vals="phi")
     # Normalize phase to [0, 1] range (representing 0 to 2π)
@@ -27,7 +47,20 @@ def fix_oscillation_phi_2pi(fit_data):
 
 
 def tanh_fit(x, a, b, c, d):
-    """Tanh fitting function for phase difference vs amplitude."""
+    """Tanh model for phase difference vs flux amplitude: ``a * tanh(b*x + c) + d``.
+
+    Parameters:
+    -----------
+    x : array-like
+        Flux pulse amplitude values (V).
+    a, b, c, d : float
+        Shape, slope, offset, and vertical shift parameters.
+
+    Returns:
+    --------
+    np.ndarray
+        Predicted phase difference values in [0, 1) units.
+    """
     return a * np.tanh(b * x + c) + d
 
 
@@ -84,7 +117,7 @@ def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
 
     def detuning(qp, amp):
         amplitude_squared = (amp * qp.macros[operation].flux_pulse_qubit.amplitude) ** 2
-        return -amplitude_squared * qp.qubit_control.freq_vs_flux_01_quad_term
+        return -amplitude_squared * node.namespace["qubit_roles_map"][qp.name].moving.freq_vs_flux_01_quad_term
 
     ds = ds.assign_coords({"amp_full": (["qubit_pair", "amp"], np.array([abs_amp(qp, ds.amp) for qp in qubit_pairs]))})
     ds = ds.assign_coords({"detuning": (["qubit_pair", "amp"], np.array([detuning(qp, ds.amp) for qp in qubit_pairs]))})
@@ -117,11 +150,28 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, Di
 
 
 def fit_routine(da):
+    """Fit the frame-rotation oscillation and extract the optimal CZ amplitude for one qubit pair.
 
-    if hasattr(da, "state_target"):
-        data = "state_target"
+    For each amplitude point, fits a sinusoidal oscillation over the ``frame`` axis for
+    both moving-qubit states (``control_axis`` 0 and 1), computes the conditional phase
+    difference, and fits a tanh curve to find the amplitude where phase_diff = 0.5 (π).
+
+    Parameters:
+    -----------
+    da : xr.Dataset
+        Single-pair dataset with ``e_state_stationary`` or ``I_stationary``, ``frame``,
+        ``amp_full``, and ``control_axis`` dimensions.
+
+    Returns:
+    --------
+    xr.Dataset
+        Input dataset extended with ``fitted``, ``phase_diff``, ``optimal_amplitude``,
+        ``fitted_curve``, and ``success`` data variables.
+    """
+    if "e_state_stationary" in da:
+        data = "e_state_stationary"
     else:
-        data = "I_target"
+        data = "I_stationary"
     # Fit oscillation for each control state and amplitude
     fit_data = fit_oscillation(da[data], "frame")
 
@@ -157,8 +207,7 @@ def fit_routine(da):
         fitted_curve = tanh_fit(phase_diff.amp_full, *fit_params)
         success = True
 
-    except Exception as e:
-        # Fallback: find amplitude closest to π phase difference (0.5 in normalized units)
+    except Exception:
         optimal_amp = np.nan
         fitted_curve = (phase_diff.dims, np.full_like(phase_diff.values, np.nan))
         success = False
@@ -181,19 +230,22 @@ def _extract_relevant_parameters(
     ds_fit: xr.Dataset, node: QualibrationNode
 ) -> Tuple[xr.Dataset, Dict[str, FitResults]]:
     """
-    Extract relevant fit parameters and create FitResults for each qubit pair.
+    Assign xarray metadata attributes and build the FitResults dictionary.
 
     Parameters:
     -----------
     ds_fit : xr.Dataset
-        Dataset containing the fit results from fit_routine.
+        Dataset produced by applying ``fit_routine`` per qubit pair. Must contain
+        ``optimal_amplitude``, ``phase_diff``, ``fitted_curve``, and ``success``
+        data variables.
     node : QualibrationNode
-        The calibration node containing parameters and qubit pairs.
+        Calibration node providing ``qubit_pairs`` from its namespace.
 
     Returns:
     --------
     Tuple[xr.Dataset, Dict[str, FitResults]]
-        Dataset with additional metadata and dictionary of FitResults for each qubit pair.
+        Dataset with ``long_name`` / ``units`` attrs set on key variables, and a
+        dictionary of ``FitResults`` keyed by qubit pair name.
     """
     qubit_pairs = node.namespace["qubit_pairs"]
 

--- a/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase/plotting.py
@@ -32,11 +32,10 @@ def plot_raw_data_with_fit(
     grid_names, pair_names = grid_pair_names(qubit_pairs)
     grid = QubitPairGrid(grid_names, pair_names)
 
-    qp_map = {qp.name: qp for qp in qubit_pairs}
     for ax, qubit in grid_iter(grid):
         qp_name = qubit["qubit"]
         qubit_role_obj = qubit_roles_map.get(qp_name) if qubit_roles_map else None
-        plot_individual_data_with_fit(ax, ds_fit, qp_name, qp_map[qp_name], qubit_role_obj=qubit_role_obj)
+        plot_individual_data_with_fit(ax, ds_fit, qp_name, qubit_role_obj=qubit_role_obj)
 
     grid.fig.suptitle("CZ phase calibration — phase difference vs amplitude")
     grid.fig.tight_layout()
@@ -47,7 +46,6 @@ def plot_individual_data_with_fit(
     ax: Axes,
     ds_fit: xr.Dataset,
     qp_name: str,
-    qp,
     qubit_role_obj=None,
 ):
     """Plot phase difference + fit curve for one qubit pair.
@@ -61,8 +59,8 @@ def plot_individual_data_with_fit(
         ``optimal_amplitude``, and ``success`` for this pair.
     qp_name : str
         Qubit pair name used to select data.
-    qp : qubit pair object
-        Used to compute the secondary detuning axis via the moving qubit.
+    qubit_role_obj : optional
+        Resolved ``QubitRoles`` for this pair; used for the secondary detuning axis.
     """
     fit = ds_fit.sel(qubit_pair=qp_name)
 
@@ -124,11 +122,10 @@ def plot_leakage_qubit_populations(
     grid_names, pair_names = grid_pair_names(qubit_pairs)
     grid = QubitPairGrid(grid_names, pair_names)
 
-    qp_map = {qp.name: qp for qp in qubit_pairs}
     for ax, qubit in grid_iter(grid):
         qp_name = qubit["qubit"]
         qubit_role_obj = qubit_roles_map.get(qp_name) if qubit_roles_map else None
-        plot_individual_leakage_qubit_populations(ax, ds_fit, qp_name, qp_map[qp_name], qubit_role_obj=qubit_role_obj)
+        plot_individual_leakage_qubit_populations(ax, ds_fit, qp_name, qubit_role_obj=qubit_role_obj)
 
     grid.fig.suptitle("CZ phase calibration — leakage qubit populations")
     grid.fig.tight_layout()
@@ -139,7 +136,6 @@ def plot_individual_leakage_qubit_populations(
     ax: Axes,
     ds_fit: xr.Dataset,
     qp_name: str,
-    qp,
     qubit_role_obj=None,
 ):
     """Plot g/e/f populations of the leakage qubit vs amplitude for one qubit pair.
@@ -157,8 +153,8 @@ def plot_individual_leakage_qubit_populations(
         and ``optimal_amplitude``.
     qp_name : str
         Qubit pair name used to select data.
-    qp : qubit pair object
-        Used to resolve qubit roles and compute the secondary detuning axis.
+    qubit_role_obj : optional
+        Resolved ``QubitRoles`` for this pair; selects leakage populations and detuning axis.
     """
     fit = ds_fit.sel(qubit_pair=qp_name)
 

--- a/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase/plotting.py
@@ -1,95 +1,201 @@
-from typing import Dict
+from typing import Optional
 
-import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
-from calibration_utils.cz_conditional_phase.analysis import FitResults
-from qualibration_libs.core import BatchableList
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from qualibration_libs.plotting import grid_iter
+
+from calibration_utils.pair_grid import QubitPairGrid, grid_pair_names
 
 
 def plot_raw_data_with_fit(
-    fit_results: xr.Dataset,
-    qubit_pairs: BatchableList,
-) -> plt.Figure:
+    ds_fit: xr.Dataset,
+    qubit_pairs: list,
+    qubit_roles_map: Optional[dict] = None,
+) -> Figure:
+    """Plot phase difference vs amplitude with fit for every qubit pair on a chip-topology grid.
+
+    Parameters
+    ----------
+    ds_fit : xr.Dataset
+        Fit dataset (must contain ``phase_diff``, ``fitted_curve``,
+        ``optimal_amplitude``, ``success``).
+    qubit_pairs : list
+        Qubit pair objects used for grid placement.
+
+    Returns
+    -------
+    Figure
+        Matplotlib figure with one phase-diff panel per pair.
     """
-    Plot the CZ phase calibration data showing phase difference vs amplitude with fit.
+    grid_names, pair_names = grid_pair_names(qubit_pairs)
+    grid = QubitPairGrid(grid_names, pair_names)
 
-    Parameters:
-    -----------
-    fit_results : xr.Dataset
-        Fit results for each qubit pair
-        Optimal amplitudes for each qubit pair
-    qubit_pairs : BatchableList
-        List of qubit pairs
+    qp_map = {qp.name: qp for qp in qubit_pairs}
+    for ax, qubit in grid_iter(grid):
+        qp_name = qubit["qubit"]
+        qubit_role_obj = qubit_roles_map.get(qp_name) if qubit_roles_map else None
+        plot_individual_data_with_fit(ax, ds_fit, qp_name, qp_map[qp_name], qubit_role_obj=qubit_role_obj)
 
-    Returns:
-    --------
-    plt.Figure
-        The generated figure
+    grid.fig.suptitle("CZ phase calibration — phase difference vs amplitude")
+    grid.fig.tight_layout()
+    return grid.fig
+
+
+def plot_individual_data_with_fit(
+    ax: Axes,
+    ds_fit: xr.Dataset,
+    qp_name: str,
+    qp,
+    qubit_role_obj=None,
+):
+    """Plot phase difference + fit curve for one qubit pair.
+
+    Parameters
+    ----------
+    ax : Axes
+        Axis to draw on.
+    ds_fit : xr.Dataset
+        Fit dataset containing ``phase_diff``, ``fitted_curve``,
+        ``optimal_amplitude``, and ``success`` for this pair.
+    qp_name : str
+        Qubit pair name used to select data.
+    qp : qubit pair object
+        Used to compute the secondary detuning axis via the moving qubit.
     """
-    n_pairs = len(qubit_pairs)
-    cols = min(4, n_pairs)  # Max 4 columns
-    rows = (n_pairs + cols - 1) // cols  # Ceiling division
+    fit = ds_fit.sel(qubit_pair=qp_name)
 
-    fig, axes = plt.subplots(2 * rows, cols, figsize=(4 * cols, 4 * rows * 2), squeeze=False)
-    axes = axes.flatten()
+    fit.phase_diff.plot.line(ax=ax, x="amp_full")
 
-    for i, qp in enumerate(qubit_pairs):
-        ax = axes[2 * i]
-        qp_name = qp.name
-        fit_result = fit_results.sel(qubit_pair=qp_name)
+    success = bool(fit.success) if hasattr(fit, "success") else False
+    if success and not np.all(np.isnan(fit.fitted_curve.values)):
+        ax.plot(fit.phase_diff.amp_full, fit.fitted_curve, color="orange", lw=1.5, label="fit")
 
-        # Plot phase difference data
-        fit_result.phase_diff.plot.line(ax=ax, x="amp_full")
+    opt_amp = float(fit.optimal_amplitude)
+    ax.axvline(opt_amp, color="red", ls="--", lw=0.8)
+    ax.axhline(0.5, color="red", ls="--", lw=0.8)
+    ax.scatter([opt_amp], [0.5], color="red", zorder=5, label="optimal")
+    ax.legend(fontsize=8)
 
-        # Plot fitted curve if available
-        if hasattr(fit_result, "success") and fit_result.success and not np.all(np.isnan(fit_result.fitted_curve)):
-            ax.plot(fit_result.phase_diff.amp_full, fit_result.fitted_curve)
+    mq = qubit_role_obj.moving if qubit_role_obj is not None else None
 
-        # Mark optimal point
-        ax.plot([fit_result.optimal_amplitude], [0.5], marker="o", color="red")
-        ax.axhline(y=0.5, color="red", linestyle="--", lw=0.5)
-        ax.axvline(x=fit_result.optimal_amplitude, color="red", linestyle="--", lw=0.5)
+    if mq is not None:
 
-        # Add secondary x-axis for detuning in MHz
         def amp_to_detuning_MHz(amp):
-            return -(amp**2) * qp.qubit_control.freq_vs_flux_01_quad_term / 1e6  # Convert Hz to MHz
+            return -(amp**2) * mq.freq_vs_flux_01_quad_term / 1e6
 
         def detuning_MHz_to_amp(detuning_MHz):
-            return np.sqrt(-detuning_MHz * 1e6 / qp.qubit_control.freq_vs_flux_01_quad_term)
+            return np.sqrt(-detuning_MHz * 1e6 / mq.freq_vs_flux_01_quad_term)
 
         secax = ax.secondary_xaxis("top", functions=(amp_to_detuning_MHz, detuning_MHz_to_amp))
         secax.set_xlabel("Detuning (MHz)")
 
+    ax.set_title(f"{qp_name}")
+    ax.set_xlabel("Amplitude (V)")
+    ax.set_ylabel("Phase difference")
+
+
+def plot_leakage_qubit_populations(
+    ds_fit: xr.Dataset,
+    qubit_pairs: list,
+    qubit_roles_map: Optional[dict] = None,
+) -> Figure:
+    """Plot leakage-qubit g/e/f populations vs amplitude for every pair on a chip-topology grid.
+
+    The leakage qubit (always the higher-frequency qubit, whose |1⟩→|2⟩ transition
+    is resonant at the |11⟩↔|20⟩ crossing) is resolved via ``QubitRoles.resolve``
+    (.leakage) from qubit frequencies and anharmonicity, so this works regardless of
+    which qubit is moving.
+
+    Parameters
+    ----------
+    ds_fit : xr.Dataset
+        Fit dataset (must contain ``g/e/f_state_moving`` and ``g/e/f_state_stationary``,
+        plus ``optimal_amplitude``).
+    qubit_pairs : list
+        Qubit pair objects used for grid placement.
+
+    Returns
+    -------
+    Figure
+        Matplotlib figure with one population panel per pair.
+    """
+    grid_names, pair_names = grid_pair_names(qubit_pairs)
+    grid = QubitPairGrid(grid_names, pair_names)
+
+    qp_map = {qp.name: qp for qp in qubit_pairs}
+    for ax, qubit in grid_iter(grid):
+        qp_name = qubit["qubit"]
+        qubit_role_obj = qubit_roles_map.get(qp_name) if qubit_roles_map else None
+        plot_individual_leakage_qubit_populations(ax, ds_fit, qp_name, qp_map[qp_name], qubit_role_obj=qubit_role_obj)
+
+    grid.fig.suptitle("CZ phase calibration — leakage qubit populations")
+    grid.fig.tight_layout()
+    return grid.fig
+
+
+def plot_individual_leakage_qubit_populations(
+    ax: Axes,
+    ds_fit: xr.Dataset,
+    qp_name: str,
+    qp,
+    qubit_role_obj=None,
+):
+    """Plot g/e/f populations of the leakage qubit vs amplitude for one qubit pair.
+
+    Populations for both the moving and stationary qubits are stored in the dataset.
+    This function selects the correct set (``_moving`` or ``_stationary``) by
+    checking whether ``roles.leakage`` is the moving or stationary qubit.
+
+    Parameters
+    ----------
+    ax : Axes
+        Axis to draw on.
+    ds_fit : xr.Dataset
+        Fit dataset containing ``g/e/f_state_moving``, ``g/e/f_state_stationary``,
+        and ``optimal_amplitude``.
+    qp_name : str
+        Qubit pair name used to select data.
+    qp : qubit pair object
+        Used to resolve qubit roles and compute the secondary detuning axis.
+    """
+    fit = ds_fit.sel(qubit_pair=qp_name)
+
+    roles = qubit_role_obj
+    lq = roles.leakage if roles is not None else None
+    mq = roles.moving if roles is not None else None
+    leakage_key = "moving" if (roles is not None and roles.leakage is roles.moving) else "stationary"
+
+    data_g = fit[f"g_state_{leakage_key}"].sel(control_axis=1).mean(dim="frame")
+    data_e = fit[f"e_state_{leakage_key}"].sel(control_axis=1).mean(dim="frame")
+    data_f = fit[f"f_state_{leakage_key}"].sel(control_axis=1).mean(dim="frame")
+
+    amps = fit.amp_full.values if "amp_full" in fit.coords else fit.amp.values
+    ax.plot(amps, data_g, label="g", color="steelblue")
+    ax.plot(amps, data_e, label="e", color="tomato")
+    ax.plot(amps, data_f, label="f (leakage)", color="seagreen")
+
+    opt_amp = float(fit.optimal_amplitude)
+    ax.axvline(opt_amp, color="red", ls="--", lw=0.8, label="optimal")
+    ax.axhline(0.0, color="grey", ls=":", lw=0.5)
+    ax.axhline(1.0, color="grey", ls=":", lw=0.5)
+    ax.legend(fontsize=8)
+
+    if mq is not None:
+
+        def amp_to_detuning_MHz(amp):
+            return -(amp**2) * mq.freq_vs_flux_01_quad_term / 1e6
+
+        def detuning_MHz_to_amp(detuning_MHz):
+            return np.sqrt(-detuning_MHz * 1e6 / mq.freq_vs_flux_01_quad_term)
+
+        secax = ax.secondary_xaxis("top", functions=(amp_to_detuning_MHz, detuning_MHz_to_amp))
+        secax.set_xlabel("Detuning (MHz)")
+
+    if lq is not None and mq is not None:
+        ax.set_title(f"{qp_name} \n leakage qubit: {lq.name}")
+    else:
         ax.set_title(qp_name)
-        ax.set_xlabel("Amplitude (V)")
-        ax.set_ylabel("Phase difference")
-
-        # Add secondary plot below: state_control for control_axis=1 averaged over frame
-        ax_sub = axes[2 * i + 1]
-
-        data_g = fit_results.g_state_control.sel(qubit_pair=qp_name, control_axis=1).mean(dim="frame")
-        data_e = fit_results.e_state_control.sel(qubit_pair=qp_name, control_axis=1).mean(dim="frame")
-        data_f = fit_results.f_state_control.sel(qubit_pair=qp_name, control_axis=1).mean(dim="frame")
-        # Try to get axes for mesh
-        amps = fit_result.amp_full.values if "amp_full" in fit_result.coords else fit_result.amp.values
-        ax_sub.plot(amps, data_g, label="g", color="blue")
-        ax_sub.plot(amps, data_e, label="e", color="red")
-        ax_sub.plot(amps, data_f, label="f", color="green")
-        ax_sub.axvline(fit_result.optimal_amplitude.item(), color="red", linestyle="--", lw=0.5, label="optimal")
-        ax_sub.axhline(0.0, color="red", linestyle="--", lw=0.5)
-        ax_sub.axhline(1.0, color="red", linestyle="--", lw=0.5)
-        ax_sub.set_ylabel("Control qubit population")
-        ax_sub.set_xlabel("Amplitude (V)")
-        secax2 = ax_sub.secondary_xaxis("top", functions=(amp_to_detuning_MHz, detuning_MHz_to_amp))
-        secax2.set_xlabel("Detuning (MHz)")
-        ax_sub.legend()
-
-    # Hide unused axes
-    for i in range(2 * n_pairs, len(axes)):
-        axes[i].axis("off")
-
-    fig.suptitle("CZ phase calibration (phase difference + fit)")
-    fig.tight_layout()
-
-    return fig
+    ax.set_xlabel("Amplitude (V)")
+    ax.set_ylabel("Leakage qubit population")

--- a/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase_error_amp/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase_error_amp/__init__.py
@@ -1,12 +1,16 @@
 from .analysis import FitResults, fit_raw_data, log_fitted_results, process_raw_dataset
 from .parameters import Parameters
-from .plotting import plot_raw_data_with_fit
+from .plotting import plot_leakage_qubit_populations, plot_raw_data_with_fit
+from calibration_utils.cz_iswap_flux_bootstrap.parameters import QubitRoles, verify_moving_qubit  # noqa: F401
 
 __all__ = [
     "Parameters",
+    "QubitRoles",
+    "verify_moving_qubit",
     "process_raw_dataset",
     "fit_raw_data",
     "log_fitted_results",
     "FitResults",
     "plot_raw_data_with_fit",
+    "plot_leakage_qubit_populations",
 ]

--- a/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase_error_amp/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase_error_amp/analysis.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Dict, Tuple
 
 import numpy as np
@@ -7,29 +7,25 @@ import xarray as xr
 from qualibrate import QualibrationNode
 from qualibration_libs.analysis import fit_oscillation, oscillation
 from scipy.ndimage import gaussian_filter1d
-from scipy.optimize import curve_fit
+
+from calibration_utils.cz_conditional_phase.analysis import fix_oscillation_phi_2pi
 
 
 @dataclass
 class FitResults:
-    """Stores the relevant CZ conditional phase experiment fit parameters for a single qubit pair"""
+    """Fit results for a single qubit pair from the CZ conditional phase (error amplification) calibration.
+
+    Attributes:
+    -----------
+    optimal_amplitude : float
+        Flux pulse amplitude (V) at which the conditional phase equals π, selected
+        by minimising the trimmed-mean phase distance across all repetition counts.
+    success : bool
+        True if a finite optimal amplitude was found within the swept range.
+    """
 
     optimal_amplitude: float
     success: bool
-
-
-def fix_oscillation_phi_2pi(fit_data):
-    """Extract and fix the phase parameter from oscillation fit data."""
-    # Extract the phase parameter from the fit results
-    phase = fit_data.sel(fit_vals="phi")
-    # Normalize phase to [0, 1] range (representing 0 to 2π)
-    phase = (phase / (2 * np.pi)) % 1
-    return phase
-
-
-def tanh_fit(x, a, b, c, d):
-    """Tanh fitting function for phase difference vs amplitude."""
-    return a * np.tanh(b * x + c) + d
 
 
 def log_fitted_results(fit_results: Dict[str, FitResults], log_callable=None):
@@ -84,7 +80,7 @@ def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
 
     def detuning(qp, amp):
         amplitude_squared = (amp * qp.macros[operation].flux_pulse_qubit.amplitude) ** 2
-        return -amplitude_squared * qp.qubit_control.freq_vs_flux_01_quad_term
+        return -amplitude_squared * node.namespace["qubit_roles_map"][qp.name].moving.freq_vs_flux_01_quad_term
 
     ds = ds.assign_coords({"amp_full": (["qubit_pair", "amp"], np.array([abs_amp(qp, ds.amp) for qp in qubit_pairs]))})
     ds = ds.assign_coords({"detuning": (["qubit_pair", "amp"], np.array([detuning(qp, ds.amp) for qp in qubit_pairs]))})
@@ -93,33 +89,70 @@ def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
 
 
 def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, Dict[str, FitResults]]:
-    """Fit oscillations and derive optimal amplitude per qubit pair.
+    """
+    Fit frame-rotation oscillations and extract the optimal CZ amplitude per qubit pair.
 
-    Returns dataset with added data variables:
-      - fitted, phase_diff (per number_of_operations) from oscillation fits
-      - optimal_amplitude (per amp dimension collapsed)
-      - success (bool)
-    Also returns dict of FitResults referenced by qubit pair name.
+    Parameters:
+    -----------
+    ds : xr.Dataset
+        Processed dataset (output of ``process_raw_dataset``) containing
+        ``state_stationary`` or ``I_stationary``, ``frame``, ``amp_full``,
+        ``number_of_operations``, and ``control_axis`` dimensions.
+    node : QualibrationNode
+        Calibration node (used by ``_extract_relevant_parameters``).
+
+    Returns:
+    --------
+    Tuple[xr.Dataset, Dict[str, FitResults]]
+        Dataset with ``phase_diff``, ``fitted``, ``optimal_amplitude``, and
+        ``success`` added, and a dictionary of ``FitResults`` keyed by qubit pair name.
     """
     ds_fit = ds.groupby("qubit_pair").apply(fit_routine)
+    # Extract the relevant fitted parameters
+    ds_fit, fit_results = _extract_relevant_parameters(ds_fit, node)
+    return ds_fit, fit_results
 
-    # Derive optimal amplitude per qubit pair using robust column cost over number_of_operations.
+
+def _extract_relevant_parameters(
+    ds_fit: xr.Dataset, node: QualibrationNode
+) -> Tuple[xr.Dataset, Dict[str, FitResults]]:
+    """
+    Derive the optimal CZ amplitude from the error-amplified phase-diff and build FitResults.
+
+    For each qubit pair the ``phase_diff`` 2D array (number_of_operations × amplitude) is
+    passed to ``_fit_full_amp``, which selects the amplitude column that minimises the
+    trimmed-mean circular distance to 0.5 (π) across all repetition counts.
+
+    Parameters:
+    -----------
+    ds_fit : xr.Dataset
+        Dataset produced by ``fit_routine`` containing ``phase_diff``
+        (dims: ``number_of_operations``, ``amp``) and ``amp_full`` coordinates.
+    node : QualibrationNode
+        Unused; retained for API consistency.
+
+    Returns:
+    --------
+    Tuple[xr.Dataset, Dict[str, FitResults]]
+        Dataset with ``optimal_amplitude``, ``optimal_index``, and ``success``
+        coordinates added, and a dictionary of ``FitResults`` keyed by qubit pair name.
+    """
+    qp_names = ds_fit.qubit_pair.values
     opt_amps = []
     opt_idxs = []
     successes = []
-    qp_names = ds_fit.qubit_pair.values
+
     for qp in qp_names:
         sub = ds_fit.sel(qubit_pair=qp)
-        # phase_diff dims: number_of_operations, amp (no frame after fitting)
         if "phase_diff" not in sub:
             opt_amps.append(np.nan)
+            opt_idxs.append(np.nan)
             successes.append(False)
             continue
-        phase = sub.phase_diff  # already reduced over frame by fit_routine
+        phase = sub.phase_diff
         try:
             amp_coord = sub.amp_full if "amp_full" in sub.coords else sub.amp
             X = amp_coord.values
-            # Ensure (ny, nx) ordering (number_of_operations, amp)
             Z = phase.transpose("number_of_operations", "amp").values
             x_star = _fit_full_amp(X, Z)
             idx = int(np.argmin(np.abs(X - x_star)))
@@ -133,11 +166,13 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, Di
 
     ds_fit = ds_fit.assign_coords({"optimal_amplitude": ("qubit_pair", np.array(opt_amps))})
     ds_fit["optimal_amplitude"] = ds_fit["optimal_amplitude"].astype(float)
+    ds_fit["optimal_amplitude"].attrs = {"long_name": "optimal CZ amplitude", "units": "a.u."}
     ds_fit = ds_fit.assign_coords({"optimal_index": ("qubit_pair", np.array(opt_idxs))})
     ds_fit["optimal_index"] = ds_fit["optimal_index"].astype(int)
     ds_fit = ds_fit.assign_coords({"success": ("qubit_pair", np.array(successes, dtype=bool))})
+    if "phase_diff" in ds_fit.data_vars:
+        ds_fit.phase_diff.attrs = {"long_name": "phase difference", "units": "2π"}
 
-    # Build FitResults dict
     fit_results: Dict[str, FitResults] = {}
     for qp, amp, succ in zip(qp_names, opt_amps, successes):
         fit_results[str(qp)] = FitResults(optimal_amplitude=float(amp), success=bool(succ))
@@ -146,16 +181,27 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, Di
 
 
 def fit_routine(da):
-    """Fit oscillations per number_of_operations and aggregate results.
+    """Fit frame-rotation oscillations for every repetition count and aggregate.
 
-    For each number_of_operations value:
-        - Fit oscillation of the selected signal.
-        - Store fitted oscillatory curve.
-        - Compute and store phase difference between control_axis 0 and 1 (normalized 0..1 for 0..2π).
-    Returns the original dataset with two new data variables: 'fitted' and 'phase_diff'.
+    For each ``number_of_operations`` value:
+    - Fits a sinusoidal oscillation over the ``frame`` axis for both moving-qubit
+      states (``control_axis`` 0 and 1).
+    - Stores the fitted oscillatory curve.
+    - Computes the conditional phase difference (normalised to [0, 1) for 0 to 2π).
+
+    Parameters:
+    -----------
+    da : xr.Dataset
+        Single-pair dataset with ``e_state_stationary`` or ``I_stationary``, ``frame``,
+        ``number_of_operations``, ``amp_full``, and ``control_axis`` dimensions.
+
+    Returns:
+    --------
+    xr.Dataset
+        Input dataset extended with ``fitted`` and ``phase_diff`` data variables.
     """
 
-    data_var = "state_target" if "state_target" in da else "I_target"
+    data_var = "e_state_stationary" if "e_state_stationary" in da else "I_stationary"
     nops_vals = da.number_of_operations.values
 
     fitted_list = []
@@ -216,12 +262,34 @@ def _circ_dist_to_half(Z):
 
 
 def _fit_full_amp(X, Z, row_mask=None, trim=0.2, smooth_rows_sigma=0.6, smooth_cols_sigma=1.0):
-    """Robustly select single amplitude minimizing distance of phase to 0.5 across repetitions.
+    """Robustly select the single amplitude that minimises the phase distance to 0.5 (π).
 
-    Parameters mirror the exploratory implementation embedded previously in node file.
-    X: (nx,) amplitude array
-    Z: (ny, nx) phase_diff array in [0,1)
-    Returns best amplitude.
+    Applies optional Gaussian smoothing along the repetition axis, trims outlier rows
+    via a trimmed mean, then finds the amplitude column with the smallest mean circular
+    distance to 0.5.  Sub-pixel refinement via parabolic interpolation is applied when
+    the optimum is not on a boundary.
+
+    Parameters:
+    -----------
+    X : np.ndarray
+        1D array of amplitude values, shape (nx,).
+    Z : np.ndarray
+        2D phase-diff array in [0, 1), shape (ny, nx) where ny = number_of_operations.
+    row_mask : np.ndarray or None
+        Boolean mask selecting which rows (repetitions) to include.
+        If None, all rows are used.
+    trim : float
+        Fraction of rows to trim from each end of the sorted cost distribution (default 0.2).
+    smooth_rows_sigma : float
+        Gaussian smoothing sigma along the repetition axis before trimming (default 0.6).
+    smooth_cols_sigma : float
+        Gaussian smoothing sigma along the amplitude axis after trimming (default 1.0).
+
+    Returns:
+    --------
+    float
+        Best-estimate amplitude value (may be sub-pixel interpolated).  Returns ``np.nan``
+        if no rows survive masking/trimming.
     """
     Zw = Z.copy()
     if smooth_rows_sigma and smooth_rows_sigma > 0:
@@ -249,45 +317,3 @@ def _fit_full_amp(X, Z, row_mask=None, trim=0.2, smooth_rows_sigma=0.6, smooth_c
             delta = 0.5 * (y1 - y3) / denom
             j_star = j0 + np.clip(delta, -0.5, 0.5)
     return float(np.interp(j_star, np.arange(len(X)), X))
-
-
-def _extract_relevant_parameters(
-    ds_fit: xr.Dataset, node: QualibrationNode
-) -> Tuple[xr.Dataset, Dict[str, FitResults]]:
-    """
-    Extract relevant fit parameters and create FitResults for each qubit pair.
-
-    Parameters:
-    -----------
-    ds_fit : xr.Dataset
-        Dataset containing the fit results from fit_routine.
-    node : QualibrationNode
-        The calibration node containing parameters and qubit pairs.
-
-    Returns:
-    --------
-    Tuple[xr.Dataset, Dict[str, FitResults]]
-        Dataset with additional metadata and dictionary of FitResults for each qubit pair.
-    """
-    qubit_pairs = node.namespace["qubit_pairs"]
-
-    # Add metadata attributes to the dataset
-    if "optimal_amplitude" in ds_fit.data_vars:
-        ds_fit.optimal_amplitude.attrs = {"long_name": "optimal CZ amplitude", "units": "a.u."}
-    if "phase_diff" in ds_fit.data_vars:
-        ds_fit.phase_diff.attrs = {"long_name": "phase difference", "units": "2π"}
-    if "fitted_curve" in ds_fit.data_vars:
-        ds_fit.fitted_curve.attrs = {"long_name": "fitted tanh curve", "units": "2π"}
-
-    # Create FitResults for each qubit pair
-    fit_results = {}
-    for qp in qubit_pairs:
-        qp_name = qp.name
-        qp_data = ds_fit.sel(qubit_pair=qp_name)
-
-        fit_results[qp_name] = FitResults(
-            optimal_amplitude=float(qp_data.optimal_amplitude.values),
-            success=bool(qp_data.success.values),
-        )
-
-    return ds_fit, fit_results

--- a/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase_error_amp/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase_error_amp/plotting.py
@@ -174,7 +174,12 @@ def plot_individual_leakage_qubit_populations(
             .sel(amp=fr.optimal_amplitude, method="nearest")
             .mean(dim="frame")
         )
-        data_f = ds_fit[f"f_state_{leakage_key}"].sel(qubit_pair=qp_name, control_axis=1).sel(amp=fr.optimal_amplitude, method="nearest").mean(dim="frame")
+        data_f = (
+            ds_fit[f"f_state_{leakage_key}"]
+            .sel(qubit_pair=qp_name, control_axis=1)
+            .sel(amp=fr.optimal_amplitude, method="nearest")
+            .mean(dim="frame")
+        )
         ax.plot(n_ops, data_g, label="g", color="steelblue")
         ax.plot(n_ops, data_e, label="e", color="tomato")
         ax.plot(n_ops, data_f, label="f (leakage)", color="seagreen")

--- a/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase_error_amp/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase_error_amp/plotting.py
@@ -1,57 +1,80 @@
-from typing import Dict
+from typing import Optional
 
-import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
-from calibration_utils.cz_conditional_phase_error_amp.analysis import FitResults
-from qualibration_libs.core import BatchableList
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from qualibration_libs.plotting import grid_iter
+
+from calibration_utils.pair_grid import QubitPairGrid, grid_pair_names
 
 
 def plot_raw_data_with_fit(
-    fit_results: xr.Dataset,
-    qubit_pairs: BatchableList,
-    node=None,
-) -> plt.Figure:
-    """Plot phase difference as 2D heatmap (number_of_operations vs amplitude) with optimal amplitude line.
+    ds_fit: xr.Dataset,
+    qubit_pairs: list,
+    qubit_roles_map: Optional[dict] = None,
+) -> Figure:
+    """Plot phase-diff heatmap (# operations × amplitude) for every pair on a chip-topology grid.
 
-    For each qubit pair we display:
-      - pcolormesh of phase_diff (dims: number_of_operations x amp)
-      - vertical line at optimal_amplitude
-      - horizontal dashed line at phase=0.5 reference (shown via colorbar context)
-      - secondary x-axis with detuning (MHz)
+    Parameters
+    ----------
+    ds_fit : xr.Dataset
+        Fit dataset containing ``phase_diff``, ``optimal_amplitude``.
+    qubit_pairs : list
+        Qubit pair objects used for grid placement.
+
+    Returns
+    -------
+    Figure
+        Matplotlib figure with one heatmap panel per pair.
     """
-    n_pairs = len(qubit_pairs)
-    cols = min(4, n_pairs)
-    rows = (n_pairs + cols - 1) // cols
-    fig, axes = plt.subplots(2 * rows, cols, figsize=(4 * cols, 3.5 * rows * 2), squeeze=False)
-    axes = axes.flatten()
+    grid_names, pair_names = grid_pair_names(qubit_pairs)
+    grid = QubitPairGrid(grid_names, pair_names)
 
-    for i, qp in enumerate(qubit_pairs):
-        # Main plot (top)
-        ax_main = axes[2 * i]
-        qp_name = qp.name
-        fr = fit_results.sel(qubit_pair=qp_name)
+    qp_map = {qp.name: qp for qp in qubit_pairs}
+    for ax, qubit in grid_iter(grid):
+        qp_name = qubit["qubit"]
+        qubit_role_obj = qubit_roles_map.get(qp_name) if qubit_roles_map else None
+        plot_individual_data_with_fit(ax, ds_fit, qp_name, qp_map[qp_name], qubit_role_obj=qubit_role_obj)
 
-        phase = fr.phase_diff  # dims: number_of_operations, amp
-        # Coordinates
-        amps = (fr.amp_full if "amp_full" in fr.coords else fr.amp).values
-        n_ops = fr.number_of_operations.values if "number_of_operations" in phase.dims else np.arange(phase.sizes[0])
+    grid.fig.suptitle("CZ conditional phase error amplification - phase difference")
+    grid.fig.tight_layout()
+    return grid.fig
 
-        # Create mesh
-        X, Y = np.meshgrid(amps, n_ops)
-        pcm = ax_main.pcolormesh(
-            X,
-            Y,
-            phase.values,
-            cmap="twilight_shifted",
-            shading="auto",
-            vmin=0.0,
-            vmax=1.0,
-        )
-        ax_main.axvline(fr.optimal_amplitude.item(), color="lime", lw=2, label="optimal")
 
-        # Secondary x-axis: detuning (MHz)
-        quad = qp.qubit_control.freq_vs_flux_01_quad_term
+def plot_individual_data_with_fit(
+    ax: Axes,
+    ds_fit: xr.Dataset,
+    qp_name: str,
+    qp,
+    qubit_role_obj=None,
+):
+    """Plot phase-diff heatmap for one qubit pair.
+
+    Parameters
+    ----------
+    ax : Axes
+        Axis to draw on.
+    ds_fit : xr.Dataset
+        Fit dataset containing ``phase_diff`` and ``optimal_amplitude``.
+    qp_name : str
+        Qubit pair name used to select data.
+    qp : qubit pair object
+        Used to compute the secondary detuning axis via the moving qubit.
+    """
+    fr = ds_fit.sel(qubit_pair=qp_name)
+    phase = fr.phase_diff  # dims: number_of_operations, amp
+
+    amps = (fr.amp_full if "amp_full" in fr.coords else fr.amp).values
+    n_ops = fr.number_of_operations.values if "number_of_operations" in phase.dims else np.arange(phase.sizes[0])
+
+    X, Y = np.meshgrid(amps, n_ops)
+    pcm = ax.pcolormesh(X, Y, phase.values, cmap="twilight_shifted", shading="auto", vmin=0.0, vmax=1.0)
+    ax.axvline(fr.optimal_amplitude.item(), color="lime", lw=2, label="optimal")
+    ax.legend(loc="upper right", fontsize=8)
+
+    if qubit_role_obj is not None:
+        quad = qubit_role_obj.moving.freq_vs_flux_01_quad_term
 
         def amp_to_detuning_MHz(a):
             return -(a**2) * quad / 1e6
@@ -59,48 +82,109 @@ def plot_raw_data_with_fit(
         def detuning_MHz_to_amp(d):
             return np.sqrt(np.maximum(0, -d * 1e6 / quad))
 
-        secax = ax_main.secondary_xaxis("top", functions=(amp_to_detuning_MHz, detuning_MHz_to_amp))
+        secax = ax.secondary_xaxis("top", functions=(amp_to_detuning_MHz, detuning_MHz_to_amp))
         secax.set_xlabel("Detuning (MHz)")
 
-        ax_main.set_title(qp_name)
-        ax_main.set_xlabel("Amplitude (V)")
-        ax_main.set_ylabel("# CZ operations")
-        ax_main.legend(loc="upper right", fontsize=8)
-        cbar = fig.colorbar(pcm, ax=ax_main, shrink=0.85)
-        cbar.set_label("Phase diff (2π units)")
+    ax.figure.colorbar(pcm, ax=ax, shrink=0.85).set_label("Phase diff (2π units)")
+    ax.set_title(qp_name)
+    ax.set_xlabel("Amplitude (V)")
+    ax.set_ylabel("# CZ operations")
 
-        # New: Add subplot below with state_control plot
-        ax_sub = axes[2 * i + 1]
 
-        try:
-            data_g = (
-                fit_results.g_state_control.sel(qubit_pair=qp_name, control_axis=1)
-                .sel(amp=fr.optimal_amplitude, method="nearest")
-                .mean(dim="frame")
-            )
-            data_e = (
-                fit_results.e_state_control.sel(qubit_pair=qp_name, control_axis=1)
-                .sel(amp=fr.optimal_amplitude, method="nearest")
-                .mean(dim="frame")
-            )
-            data_f = (
-                fit_results.f_state_control.sel(qubit_pair=qp_name, control_axis=1)
-                .sel(amp=fr.optimal_amplitude, method="nearest")
-                .mean(dim="frame")
-            )
-            ax_sub.plot(n_ops, data_g, label="g", color="blue")
-            ax_sub.plot(n_ops, data_f, label="f", color="green")
-            ax_sub.set_ylabel("Control qubit state fractions")
-            ax_sub.set_xlabel("# CZ operations")
-            ax_sub.legend()
+def plot_leakage_qubit_populations(
+    ds_fit: xr.Dataset,
+    qubit_pairs: list,
+    qubit_roles_map: Optional[dict] = None,
+) -> Figure:
+    """Plot leakage-qubit g/f populations vs # operations for every pair on a chip-topology grid.
 
-        except Exception as e:
-            ax_sub.text(0.5, 0.5, f"Plot failed: {e}", ha="center", va="center")
+    Populations are shown at the optimal amplitude for each pair. The leakage qubit
+    (always the higher-frequency qubit) is determined via ``QubitRoles.resolve``
+    and the correct set of streams (``_moving`` or ``_stationary``) is selected.
 
-    # Hide unused axes
-    for j in range(2 * n_pairs, len(axes)):
-        axes[j].axis("off")
+    Parameters
+    ----------
+    ds_fit : xr.Dataset
+        Fit dataset containing ``g/e/f_state_moving``, ``g/e/f_state_stationary``,
+        ``optimal_amplitude``.
+    qubit_pairs : list
+        Qubit pair objects used for grid placement.
 
-    fig.suptitle("CZ conditional phase error amplification")
-    fig.tight_layout(rect=(0, 0, 1, 0.97))
-    return fig
+    Returns
+    -------
+    Figure
+        Matplotlib figure with one population panel per pair.
+    """
+    grid_names, pair_names = grid_pair_names(qubit_pairs)
+    grid = QubitPairGrid(grid_names, pair_names)
+
+    qp_map = {qp.name: qp for qp in qubit_pairs}
+    for ax, qubit in grid_iter(grid):
+        qp_name = qubit["qubit"]
+        qubit_role_obj = qubit_roles_map.get(qp_name) if qubit_roles_map else None
+        plot_individual_leakage_qubit_populations(ax, ds_fit, qp_name, qp_map[qp_name], qubit_role_obj=qubit_role_obj)
+
+    grid.fig.suptitle("CZ conditional phase error amplification — leakage qubit populations")
+    grid.fig.tight_layout()
+    return grid.fig
+
+
+def plot_individual_leakage_qubit_populations(
+    ax: Axes,
+    ds_fit: xr.Dataset,
+    qp_name: str,
+    qp,
+    qubit_role_obj=None,
+):
+    """Plot leakage-qubit g/f populations vs # operations for one pair at its optimal amplitude.
+
+    Selects ``g/f_state_moving`` or ``g/f_state_stationary`` depending on which
+    qubit is the leakage qubit (the higher-frequency qubit).
+
+    Parameters
+    ----------
+    ax : Axes
+        Axis to draw on.
+    ds_fit : xr.Dataset
+        Fit dataset containing ``g/e/f_state_moving``, ``g/e/f_state_stationary``,
+        and ``optimal_amplitude``.
+    qp_name : str
+        Qubit pair name used to select data.
+    qp : qubit pair object
+        Used to resolve qubit roles and label the plot.
+    """
+    fr = ds_fit.sel(qubit_pair=qp_name)
+    n_ops = fr.number_of_operations.values if "number_of_operations" in fr.dims else None
+
+    roles = qubit_role_obj
+    lq = roles.leakage if roles is not None else None
+    mq = roles.moving if roles is not None else None
+    leakage_key = "moving" if (roles is not None and roles.leakage is roles.moving) else "stationary"
+
+    try:
+        data_g = (
+            ds_fit[f"g_state_{leakage_key}"]
+            .sel(qubit_pair=qp_name, control_axis=1)
+            .sel(amp=fr.optimal_amplitude, method="nearest")
+            .mean(dim="frame")
+        )
+        data_e = (
+            ds_fit[f"e_state_{leakage_key}"]
+            .sel(qubit_pair=qp_name, control_axis=1)
+            .sel(amp=fr.optimal_amplitude, method="nearest")
+            .mean(dim="frame")
+        )
+        data_f = ds_fit[f"f_state_{leakage_key}"].sel(qubit_pair=qp_name, control_axis=1).sel(amp=fr.optimal_amplitude, method="nearest").mean(dim="frame")
+        ax.plot(n_ops, data_g, label="g", color="steelblue")
+        ax.plot(n_ops, data_e, label="e", color="tomato")
+        ax.plot(n_ops, data_f, label="f (leakage)", color="seagreen")
+        ax.legend(fontsize=8)
+    except Exception as e:
+        ax.text(0.5, 0.5, f"Plot failed:\n{e}", ha="center", va="center", transform=ax.transAxes, fontsize=8)
+
+    if lq is not None and mq is not None:
+        ax.set_title(f"{qp_name} \n leakage qubit: {lq.name}")
+    else:
+        ax.set_title(qp_name)
+    ax.set_xlabel("# CZ operations")
+    ax.set_ylabel("Leakage qubit state fractions")

--- a/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase_error_amp/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/cz_conditional_phase_error_amp/plotting.py
@@ -31,11 +31,10 @@ def plot_raw_data_with_fit(
     grid_names, pair_names = grid_pair_names(qubit_pairs)
     grid = QubitPairGrid(grid_names, pair_names)
 
-    qp_map = {qp.name: qp for qp in qubit_pairs}
     for ax, qubit in grid_iter(grid):
         qp_name = qubit["qubit"]
         qubit_role_obj = qubit_roles_map.get(qp_name) if qubit_roles_map else None
-        plot_individual_data_with_fit(ax, ds_fit, qp_name, qp_map[qp_name], qubit_role_obj=qubit_role_obj)
+        plot_individual_data_with_fit(ax, ds_fit, qp_name, qubit_role_obj=qubit_role_obj)
 
     grid.fig.suptitle("CZ conditional phase error amplification - phase difference")
     grid.fig.tight_layout()
@@ -46,7 +45,6 @@ def plot_individual_data_with_fit(
     ax: Axes,
     ds_fit: xr.Dataset,
     qp_name: str,
-    qp,
     qubit_role_obj=None,
 ):
     """Plot phase-diff heatmap for one qubit pair.
@@ -59,8 +57,8 @@ def plot_individual_data_with_fit(
         Fit dataset containing ``phase_diff`` and ``optimal_amplitude``.
     qp_name : str
         Qubit pair name used to select data.
-    qp : qubit pair object
-        Used to compute the secondary detuning axis via the moving qubit.
+    qubit_role_obj : optional
+        Resolved ``QubitRoles`` for this pair; used for the secondary detuning axis.
     """
     fr = ds_fit.sel(qubit_pair=qp_name)
     phase = fr.phase_diff  # dims: number_of_operations, amp
@@ -118,11 +116,10 @@ def plot_leakage_qubit_populations(
     grid_names, pair_names = grid_pair_names(qubit_pairs)
     grid = QubitPairGrid(grid_names, pair_names)
 
-    qp_map = {qp.name: qp for qp in qubit_pairs}
     for ax, qubit in grid_iter(grid):
         qp_name = qubit["qubit"]
         qubit_role_obj = qubit_roles_map.get(qp_name) if qubit_roles_map else None
-        plot_individual_leakage_qubit_populations(ax, ds_fit, qp_name, qp_map[qp_name], qubit_role_obj=qubit_role_obj)
+        plot_individual_leakage_qubit_populations(ax, ds_fit, qp_name, qubit_role_obj=qubit_role_obj)
 
     grid.fig.suptitle("CZ conditional phase error amplification — leakage qubit populations")
     grid.fig.tight_layout()
@@ -133,7 +130,6 @@ def plot_individual_leakage_qubit_populations(
     ax: Axes,
     ds_fit: xr.Dataset,
     qp_name: str,
-    qp,
     qubit_role_obj=None,
 ):
     """Plot leakage-qubit g/f populations vs # operations for one pair at its optimal amplitude.
@@ -150,8 +146,8 @@ def plot_individual_leakage_qubit_populations(
         and ``optimal_amplitude``.
     qp_name : str
         Qubit pair name used to select data.
-    qp : qubit pair object
-        Used to resolve qubit roles and label the plot.
+    qubit_role_obj : optional
+        Resolved ``QubitRoles`` for this pair; selects leakage populations and plot labels.
     """
     fr = ds_fit.sel(qubit_pair=qp_name)
     n_ops = fr.number_of_operations.values if "number_of_operations" in fr.dims else None

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32a_cz_conditional_phase.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32a_cz_conditional_phase.py
@@ -1,24 +1,22 @@
 # %% {Imports}
 from dataclasses import asdict
-
 import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
 from calibration_utils.cz_conditional_phase import (
-    FitResults,
     Parameters,
     fit_raw_data,
     log_fitted_results,
+    QubitRoles,
+    verify_moving_qubit,
+    plot_leakage_qubit_populations,
     plot_raw_data_with_fit,
     process_raw_dataset,
 )
-from qm import SimulationConfig
 from qm.qua import *
-from qualang_tools.bakery import baking
 from qualang_tools.loops import from_array
 from qualang_tools.multi_user import qm_session
-from qualang_tools.results import fetching_tool, progress_counter
-from qualang_tools.units import unit
+from qualang_tools.results import progress_counter
 from qualibrate import QualibrationNode
 from qualibration_libs.core import tracked_updates
 from qualibration_libs.data import XarrayDataFetcher
@@ -28,35 +26,37 @@ from quam_config import Quam
 
 # %% {Initialisation}
 description = """
-CALIBRATION OF THE CONTROLLED-PHASE (CPHASE) OF THE CZ GATE
+CZ controlled-phase (CPhase) calibration
 
-This sequence calibrates the CPhase of the CZ gate by scanning the pulse amplitude and measuring the
-resulting phase of the target qubit. The calibration compares two scenarios:
+Calibrates the CZ gate phase by scanning the flux-pulse amplitude scale on the moving qubit
+(the qubit flux-pulsed toward the |11⟩↔|20⟩ avoided crossing) and measuring the conditional
+phase acquired by the stationary qubit.
 
-1. Control qubit in the ground state
-2. Control qubit in the excited state
+Protocol
+--------
+1. Prepare the stationary qubit in a superposition (x90).
+2. Prepare the moving qubit in |g⟩ or |e⟩ (two ``control_axis`` points).
+3. Apply ``macros[operation]`` at scaled amplitude.
+4. Perform frame tomography on the stationary qubit (frame rotation + x90).
+5. Fit the stationary-qubit |e⟩-state oscillation vs. frame for each moving-qubit state.
 
-For each amplitude, we measure:
-1. The phase difference of the target qubit between the two scenarios
-2. The amount of leakage to the |f> state when the control qubit is in the excited state
+The conditional phase difference is
+``phase(moving=|g⟩) − phase(moving=|e⟩)`` on the stationary qubit. The optimal amplitude is
+where this difference crosses π (0.5 in normalised units), found by a tanh fit to
+``phase_diff`` vs. amplitude.
 
-The calibration process involves:
-1. Applying a CZ gate with varying amplitudes
-2. Measuring the phase of the target qubit for both control qubit states
-3. Calculating the phase difference
-4. Measuring the population in the |f> state to quantify leakage
-
-The optimal CZ gate amplitude is determined by finding the point where:
-1. The phase difference is closest to π (0.5 in normalized units)
-2. The leakage to the |f> state is minimized
+Leakage populations (|g⟩, |e⟩, |f⟩) of the leakage qubit (always the higher-frequency qubit)
+are recorded and plotted for visual inspection when GEF readout is enabled; they are not used
+in the fit criterion for this node (see node 32b for error-amplified refinement).
 
 Prerequisites:
-- Calibrated single-qubit gates for both qubits in the pair
-- Calibrated readout for both qubits
-- Initial estimate of the CZ gate amplitude
+- Calibrated single-qubit gates for both qubits in the pair.
+- Calibrated GEF readout for both qubits (if ``use_state_discrimination=True``).
+- ``macros[operation]`` defined with an initial CZ amplitude (from node 30 for tunable couplers,
+  node 31 for fixed couplers, or manual entry).
 
 State update:
-- The optimal CZ gate amplitude: qubit_pair.gates["Cz"].flux_pulse_control.amplitude
+- ``qubit_pair.macros[operation].flux_pulse_qubit.amplitude`` → optimal CZ amplitude.
 """
 
 # Be sure to include [Parameters, Quam] so the node has proper type hinting
@@ -81,11 +81,18 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
 def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     """Create the sweep axes and generate the QUA program from the pulse sequence and the node parameters."""
 
-    # Class containing tools to help handle units and conversions.
-    u = unit(coerce_to_integer=True)
     # Get the active qubit pairs from the node and organize them by batches
     node.namespace["qubit_pairs"] = qubit_pairs = get_qubit_pairs(node)
     num_qubit_pairs = len(qubit_pairs)
+
+    # Verify qp.moving_qubit against recalculation and precompute roles for QUA program loops.
+    # Logs a warning and corrects qp.moving_qubit in-memory if they disagree; state is persisted
+    # at the end of the node.
+    qubit_roles_map = {}
+    for qp in qubit_pairs:
+        verify_moving_qubit(qp, log_callable=node.log)
+        qubit_roles_map[qp.name] = QubitRoles.resolve(qp)
+    node.namespace["qubit_roles_map"] = qubit_roles_map
 
     # Extract the sweep parameters and axes from the node parameters
     n_avg = node.parameters.num_averages
@@ -113,24 +120,28 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     node.namespace["tracked_qubit_pairs"] = tracked_qp_list
     # The QUA program stored in the node namespace to be transfer to the simulation and execution run_actions
     with program() as node.namespace["qua_program"]:
-        I_c, I_c_st, Q_c, Q_c_st, n, n_st = node.machine.declare_qua_variables()
-        I_t, I_t_st, Q_t, Q_t_st, _, _ = node.machine.declare_qua_variables()
+        I_m, I_m_st, Q_m, Q_m_st, n, n_st = node.machine.declare_qua_variables()
+        I_s, I_s_st, Q_s, Q_s_st, _, _ = node.machine.declare_qua_variables()
         amp = declare(fixed)
         frame = declare(fixed)
-        control_initial = declare(int)
+        moving_initial = declare(int)
         if node.parameters.use_state_discrimination:
-            state_c = [declare(int) for _ in range(num_qubit_pairs)]
-            state_t = [declare(int) for _ in range(num_qubit_pairs)]
-            state_ce_st = [declare_stream() for _ in range(num_qubit_pairs)]
-            state_cg_st = [declare_stream() for _ in range(num_qubit_pairs)]
-            state_cf_st = [declare_stream() for _ in range(num_qubit_pairs)]
-            state_t_st = [declare_stream() for _ in range(num_qubit_pairs)]
+            state_mq = [declare(int) for _ in range(num_qubit_pairs)]
+            state_sq = [declare(int) for _ in range(num_qubit_pairs)]
+            state_mg_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_me_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_mf_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_sg_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_se_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_sf_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
 
         for multiplexed_qubit_pairs in qubit_pairs.batch():
             # Initialize the qubits
             for qp in multiplexed_qubit_pairs.values():
-                node.machine.initialize_qpu(target=qp.qubit_control)
-                node.machine.initialize_qpu(target=qp.qubit_target)
+                qubit_role = qubit_roles_map[qp.name]
+                mq, sq = qubit_role.moving, qubit_role.stationary
+                node.machine.initialize_qpu(target=mq)
+                node.machine.initialize_qpu(target=sq)
             # Loop for averaging
             with for_(n, 0, n < n_avg, n + 1):
                 save(n, n_st)
@@ -139,57 +150,73 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
                     # Loop over the frame rotations
                     with for_(*from_array(frame, frames)):
                         # Loop over the initial state of the control qubit
-                        with for_(*from_array(control_initial, [0, 1])):
+                        with for_(*from_array(moving_initial, [0, 1])):
                             for ii, qp in multiplexed_qubit_pairs.items():
+                                qubit_role = qubit_roles_map[qp.name]
+                                mq, sq = qubit_role.moving, qubit_role.stationary
                                 # Reset the qubits
-                                qp.qubit_control.reset(node.parameters.reset_type, node.parameters.simulate)
-                                qp.qubit_target.reset(node.parameters.reset_type, node.parameters.simulate)
+                                mq.reset(node.parameters.reset_type, node.parameters.simulate)
+                                sq.reset(node.parameters.reset_type, node.parameters.simulate)
                                 qp.align()
                                 # Reset the frames of both qubits
-                                reset_frame(qp.qubit_target.xy.name)
-                                reset_frame(qp.qubit_control.xy.name)
+                                reset_frame(sq.xy.name)
+                                reset_frame(mq.xy.name)
                                 # setting both qubits to the initial state
-                                qp.qubit_control.xy.play("x180", condition=control_initial == 1)
-                                qp.qubit_target.xy.play("x90")
+                                mq.xy.play("x180", condition=moving_initial == 1)
+                                sq.xy.play("x90")
                                 qp.align()
                                 # play the CZ gate
                                 qp.macros[operation].apply(amplitude_scale_qubit=amp)
                                 # rotate the frame
-                                qp.qubit_target.xy.frame_rotation_2pi(frame)
-                                # Tomographic rotation on the target qubit
-                                qp.qubit_target.xy.play("x90")
+                                sq.xy.frame_rotation_2pi(frame)
+                                # Tomographic rotation on the other qubit
+                                sq.xy.play("x90")
                                 qp.align()
 
                                 if node.parameters.use_state_discrimination:
-                                    # measure both qubits
-                                    qp.qubit_control.readout_state_gef(state_c[ii])
-                                    qp.qubit_target.readout_state(state_t[ii])
-                                    # save each state outcome in its respective stream
-                                    with switch_(state_c[ii]):
+                                    # measure g/e/f populations for both qubits
+                                    mq.readout_state_gef(state_mq[ii])
+                                    sq.readout_state_gef(state_sq[ii])
+                                    with switch_(state_mq[ii]):
                                         with case_(0):
                                             wait(4)
-                                            save(1, state_cg_st[ii])
-                                            save(0, state_ce_st[ii])
-                                            save(0, state_cf_st[ii])
+                                            save(1, state_mg_st[ii])
+                                            save(0, state_me_st[ii])
+                                            save(0, state_mf_st[ii])
                                         with case_(1):
                                             wait(4)
-                                            save(0, state_cg_st[ii])
-                                            save(1, state_ce_st[ii])
-                                            save(0, state_cf_st[ii])
+                                            save(0, state_mg_st[ii])
+                                            save(1, state_me_st[ii])
+                                            save(0, state_mf_st[ii])
                                         with default_():
                                             wait(4)
-                                            save(0, state_cg_st[ii])
-                                            save(0, state_ce_st[ii])
-                                            save(1, state_cf_st[ii])
-                                    save(state_t[ii], state_t_st[ii])
+                                            save(0, state_mg_st[ii])
+                                            save(0, state_me_st[ii])
+                                            save(1, state_mf_st[ii])
+                                    with switch_(state_sq[ii]):
+                                        with case_(0):
+                                            wait(4)
+                                            save(1, state_sg_st[ii])
+                                            save(0, state_se_st[ii])
+                                            save(0, state_sf_st[ii])
+                                        with case_(1):
+                                            wait(4)
+                                            save(0, state_sg_st[ii])
+                                            save(1, state_se_st[ii])
+                                            save(0, state_sf_st[ii])
+                                        with default_():
+                                            wait(4)
+                                            save(0, state_sg_st[ii])
+                                            save(0, state_se_st[ii])
+                                            save(1, state_sf_st[ii])
 
                                 else:
-                                    qp.qubit_control.resonator.measure("readout", qua_vars=(I_c[ii], Q_c[ii]))
-                                    qp.qubit_target.resonator.measure("readout", qua_vars=(I_t[ii], Q_t[ii]))
-                                    save(I_c[ii], I_c_st[ii])
-                                    save(Q_c[ii], Q_c_st[ii])
-                                    save(I_t[ii], I_t_st[ii])
-                                    save(Q_t[ii], Q_t_st[ii])
+                                    mq.resonator.measure("readout", qua_vars=(I_m[ii], Q_m[ii]))
+                                    sq.resonator.measure("readout", qua_vars=(I_s[ii], Q_s[ii]))
+                                    save(I_m[ii], I_m_st[ii])
+                                    save(Q_m[ii], Q_m_st[ii])
+                                    save(I_s[ii], I_s_st[ii])
+                                    save(Q_s[ii], Q_s_st[ii])
 
             align()
 
@@ -197,23 +224,33 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
             n_st.save("n")
             for i in range(num_qubit_pairs):
                 if node.parameters.use_state_discrimination:
-                    state_cg_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
-                        f"g_state_control{i + 1}"
+                    state_mg_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
+                        f"g_state_moving{i + 1}"
                     )
-                    state_ce_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
-                        f"e_state_control{i + 1}"
+                    state_me_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
+                        f"e_state_moving{i + 1}"
                     )
-                    state_cf_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
-                        f"f_state_control{i + 1}"
+                    state_mf_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
+                        f"f_state_moving{i + 1}"
                     )
-                    state_t_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
-                        f"state_target{i + 1}"
+                    state_sg_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
+                        f"g_state_stationary{i + 1}"
+                    )
+                    state_se_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
+                        f"e_state_stationary{i + 1}"
+                    )
+                    state_sf_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
+                        f"f_state_stationary{i + 1}"
                     )
                 else:
-                    I_c_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(f"I_control{i + 1}")
-                    Q_c_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(f"Q_control{i + 1}")
-                    I_t_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(f"I_target{i + 1}")
-                    Q_t_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(f"Q_target{i + 1}")
+                    I_m_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(f"I_moving{i + 1}")
+                    Q_m_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(f"Q_moving{i + 1}")
+                    I_s_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
+                        f"I_stationary{i + 1}"
+                    )
+                    Q_s_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).average().save(
+                        f"Q_stationary{i + 1}"
+                    )
 
 
 # %% {Simulate}
@@ -246,14 +283,18 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_averages,
                 start_time=data_fetcher.t_start,
             )
         # Display the execution report to expose possible runtime errors
         node.log(job.execution_report())
-    # Register the raw dataset
+    # Register the raw dataset and role data needed for reproducible re-analysis
     node.results["ds_raw"] = dataset
+    qubit_roles_map = node.namespace["qubit_roles_map"]
+    node.results["qubit_roles"] = {
+        name: {field: getattr(role, field).name for field in role._fields} for name, role in qubit_roles_map.items()
+    }
 
 
 # %% {Load_data}
@@ -266,6 +307,10 @@ def load_data(node: QualibrationNode[Parameters, Quam]):
     node.parameters.load_data_id = load_data_id
     # Get the active qubit pairs from the loaded node parameters
     node.namespace["qubit_pairs"] = get_qubit_pairs(node)
+    node.namespace["qubit_roles_map"] = {
+        name: QubitRoles(**{field: node.machine.qubits[qname] for field, qname in roles.items()})
+        for name, roles in node.results["qubit_roles"].items()
+    }
 
 
 # %% {Analyse_data}
@@ -294,14 +339,21 @@ def plot_data(node: QualibrationNode[Parameters, Quam]):
     """Plot the raw and fitted data in a specific figure whose shape is given by qubit pair grid locations."""
     qubit_pairs = node.namespace["qubit_pairs"]
 
-    # Plot phase calibration data
-    fig_phase = plot_raw_data_with_fit(
-        node.results["ds_fit"],
-        qubit_pairs,
-    )
+    ds_fit = node.results["ds_fit"]
+
+    fig_phase = plot_raw_data_with_fit(ds_fit, qubit_pairs, qubit_roles_map=node.namespace.get("qubit_roles_map"))
     plt.show()
 
     node.results["phase_figure"] = fig_phase
+
+    if "f_state_moving" in ds_fit.data_vars or "f_state_stationary" in ds_fit.data_vars:
+        fig_populations = plot_leakage_qubit_populations(
+            ds_fit, qubit_pairs, qubit_roles_map=node.namespace.get("qubit_roles_map")
+        )
+        plt.show()
+        node.results["populations_figure"] = fig_populations
+    else:
+        node.log("No leakage (f-state) populations data found in the fit dataset.")
 
 
 # %% {Update_state}
@@ -314,6 +366,7 @@ def update_state(node: QualibrationNode[Parameters, Quam]):
         fit_results = node.results["fit_results"]
         for qp in node.namespace["qubit_pairs"]:
             if node.outcomes[qp.name] == "failed":
+                node.log(f"Skipping state update for {qp.name}: fit flagged unsuccessful.")
                 continue
             qp.macros[operation].flux_pulse_qubit.amplitude = fit_results[qp.name]["optimal_amplitude"]
 
@@ -326,3 +379,6 @@ def save_results(node: QualibrationNode[Parameters, Quam]):
         qp.revert_changes()
 
     node.save()
+
+
+# %%

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32a_cz_conditional_phase.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32a_cz_conditional_phase.py
@@ -90,7 +90,7 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     # at the end of the node.
     qubit_roles_map = {}
     for qp in qubit_pairs:
-        verify_moving_qubit(qp, log_callable=node.log)
+        verify_moving_qubit(qp, operation=node.parameters.operation, log_callable=node.log)
         qubit_roles_map[qp.name] = QubitRoles.resolve(qp)
     node.namespace["qubit_roles_map"] = qubit_roles_map
 

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32b_cz_conditional_phase_error_amp.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32b_cz_conditional_phase_error_amp.py
@@ -1,5 +1,6 @@
 # %% {Imports}
 from dataclasses import asdict
+from multiprocessing.process import parent_process
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -8,6 +9,9 @@ from calibration_utils.cz_conditional_phase_error_amp import (
     Parameters,
     fit_raw_data,
     log_fitted_results,
+    QubitRoles,
+    verify_moving_qubit,
+    plot_leakage_qubit_populations,
     plot_raw_data_with_fit,
     process_raw_dataset,
 )
@@ -15,7 +19,6 @@ from qm.qua import *
 from qualang_tools.loops import from_array
 from qualang_tools.multi_user import qm_session
 from qualang_tools.results import progress_counter
-from qualang_tools.units import unit
 from qualibrate import QualibrationNode
 from qualibration_libs.core import tracked_updates
 from qualibration_libs.data import XarrayDataFetcher
@@ -25,39 +28,38 @@ from quam_config import Quam
 
 # %% {Initialisation}
 description = """
-CALIBRATION OF THE CONTROLLED-PHASE (CPHASE) OF THE CZ GATE with error amplification
+CZ controlled-phase (CPhase) calibration with error amplification
 
-This sequence calibrates the CPhase of the CZ gate by scanning the pulse amplitude and measuring the
-resulting phase of the target qubit. The calibration compares two scenarios:
+Refines the CZ gate amplitude by scanning the flux-pulse amplitude scale on the moving qubit
+and measuring the conditional phase on the stationary qubit. The CZ gate is applied
+``number_of_operations`` times (1 … N) per shot to amplify small phase errors and improve
+sensitivity near the π crossing.
 
-1. Control qubit in the ground state
-2. Control qubit in the excited state
+Protocol
+--------
+Same as node 32a, with these additions:
+1. Apply ``macros[operation]`` repeatedly (``number_of_operations`` sweep).
+2. Compensate the tomography frame for odd repetition counts when the moving qubit starts
+   excited (π/2 frame shift before the final x90 on the stationary qubit).
+3. Fit the stationary-qubit |e⟩-state oscillation vs. frame at each amplitude and repetition
+   count.
 
-For each amplitude, we measure:
-1. The phase difference of the target qubit between the two scenarios
-2. The average population in the |g>, |e>, and |f> states of the control qubit when the control qubit is in the excited state.
+The conditional phase difference is
+``phase(moving=|g⟩) − phase(moving=|e⟩)`` on the stationary qubit. The optimal amplitude
+minimises the trimmed-mean circular distance to π (0.5 in normalised units) across all
+repetition counts in the ``phase_diff`` map (amplitude × ``number_of_operations``).
 
-**Error amplification:**
-To improve sensitivity to small phase errors, the CZ gate is applied repeatedly (multiple times in sequence) for each measurement. This introduces an extra dimension to the experiment: the number of repeated CZ operations. By increasing the number of repetitions, small phase errors accumulate, making them easier to detect and fit.
-
-The calibration process involves:
-1. Applying a CZ gate with varying amplitudes
-2. Repeating the CZ operation a variable number of times (error amplification dimension)
-3. Measuring the phase of the target qubit for both control qubit states
-4. Calculating the phase difference
-5. Measuring the population fractions of the |g>, |e>, and |f> states on the control qubit to quantify leakage
-
-The optimal CZ gate amplitude is determined by finding the point where:
-1. The phase difference (after error amplification) is closest to π (0.5 in normalized units)
-2. The leakage to the |f> state is minimized
+Leakage populations (|g⟩, |e⟩, |f⟩) of the leakage qubit (always the higher-frequency qubit)
+are recorded and plotted for visual inspection when GEF readout is enabled; they are not used
+in the fit criterion.
 
 Prerequisites:
-- Calibrated single-qubit gates for both qubits in the pair
-- Calibrated readout for both qubits
-- Initial estimate of the CZ gate amplitude
+- Calibrated single-qubit gates for both qubits in the pair.
+- Calibrated GEF readout for both qubits (if ``use_state_discrimination=True``).
+- ``macros[operation]`` with an initial CZ amplitude from node 32a (or manual entry).
 
 State update:
-- The optimal CZ gate amplitude: qubit_pair.macros[operation].flux_pulse_qubit.amplitude
+- ``qubit_pair.macros[operation].flux_pulse_qubit.amplitude`` → optimal CZ amplitude.
 """
 
 # Be sure to include [Parameters, Quam] so the node has proper type hinting
@@ -82,11 +84,18 @@ def custom_param(node: QualibrationNode[Parameters, Quam]):
 def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     """Create the sweep axes and generate the QUA program from the pulse sequence and the node parameters."""
 
-    # Class containing tools to help handle units and conversions.
-    u = unit(coerce_to_integer=True)
     # Get the active qubit pairs from the node and organize them by batches
     node.namespace["qubit_pairs"] = qubit_pairs = get_qubit_pairs(node)
     num_qubit_pairs = len(qubit_pairs)
+
+    # Verify qp.moving_qubit against recalculation and precompute roles for QUA program loops.
+    # Logs a warning and corrects qp.moving_qubit in-memory if they disagree; state is persisted
+    # at the end of the node.
+    qubit_roles_map = {}
+    for qp in qubit_pairs:
+        verify_moving_qubit(qp, log_callable=node.log)
+        qubit_roles_map[qp.name] = QubitRoles.resolve(qp)
+    node.namespace["qubit_roles_map"] = qubit_roles_map
 
     # Extract the sweep parameters and axes from the node parameters
     n_avg = node.parameters.num_averages
@@ -119,28 +128,30 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     # The QUA program stored in the node namespace to be transfer to the simulation and execution run_actions
     with program() as node.namespace["qua_program"]:
         amp = declare(fixed)  # amplitude scaling factor for the CZ gate
-        frame = declare(fixed)  # frame rotation of the target qubit (even number of operations)
-        frame_odd = declare(fixed)  # frame rotation of the target qubit (odd number of operations)
-        control_initial = declare(int)  # initial state of the control qubit
-        n = declare(int)
+        frame = declare(fixed)  # frame rotation of the other qubit (even number of operations)
+        frame_odd = declare(fixed)  # frame rotation of the other qubit (odd number of operations)
+        moving_initial = declare(int)  # initial state of the moving qubit
         n_op = declare(int)  # number of CZ operations
         count = declare(int)  # loop counter
-        n_st = declare_stream()
-        I_c, I_c_st, Q_c, Q_c_st, n, n_st = node.machine.declare_qua_variables()
-        I_t, I_t_st, Q_t, Q_t_st, _, _ = node.machine.declare_qua_variables()
+        I_m, I_m_st, Q_m, Q_m_st, n, n_st = node.machine.declare_qua_variables()
+        I_s, I_s_st, Q_s, Q_s_st, _, _ = node.machine.declare_qua_variables()
         if node.parameters.use_state_discrimination:
-            state_c = [declare(int) for _ in range(num_qubit_pairs)]
-            state_t = [declare(int) for _ in range(num_qubit_pairs)]
-            state_cg_st = [declare_stream() for _ in range(num_qubit_pairs)]
-            state_ce_st = [declare_stream() for _ in range(num_qubit_pairs)]
-            state_cf_st = [declare_stream() for _ in range(num_qubit_pairs)]
-            state_t_st = [declare_stream() for _ in range(num_qubit_pairs)]
+            state_mq = [declare(int) for _ in range(num_qubit_pairs)]
+            state_sq = [declare(int) for _ in range(num_qubit_pairs)]
+            state_mg_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_me_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_mf_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_sg_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_se_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
+            state_sf_st = [declare_output_stream() for _ in range(num_qubit_pairs)]
 
         for multiplexed_qubit_pairs in qubit_pairs.batch():
             # Initialize the qubits
             for qp in multiplexed_qubit_pairs.values():
-                node.machine.initialize_qpu(target=qp.qubit_control)
-                node.machine.initialize_qpu(target=qp.qubit_target)
+                qubit_role = qubit_roles_map[qp.name]
+                mq, sq = qubit_role.moving, qubit_role.stationary
+                node.machine.initialize_qpu(target=mq)
+                node.machine.initialize_qpu(target=sq)
             # Loop for averaging
             with for_(n, 0, n < n_avg, n + 1):
                 save(n, n_st)
@@ -151,92 +162,114 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
                         # Loop over the frame rotations
                         with for_(*from_array(frame, frames)):
                             # Loop over the initial state of the control qubit
-                            with for_(*from_array(control_initial, [0, 1])):
+                            with for_(*from_array(moving_initial, [0, 1])):
                                 for ii, qp in multiplexed_qubit_pairs.items():
+                                    qubit_role = qubit_roles_map[qp.name]
+                                    mq, sq = qubit_role.moving, qubit_role.stationary
                                     # Reset the qubits
-                                    qp.qubit_control.reset(node.parameters.reset_type, node.parameters.simulate)
-                                    qp.qubit_target.reset(node.parameters.reset_type, node.parameters.simulate)
+                                    mq.reset(node.parameters.reset_type, node.parameters.simulate)
+                                    sq.reset(node.parameters.reset_type, node.parameters.simulate)
                                     qp.align()
                                     # Reset the frames of both qubits
-                                    reset_frame(qp.qubit_target.xy.name)
-                                    reset_frame(qp.qubit_control.xy.name)
+                                    reset_frame(sq.xy.name)
+                                    reset_frame(mq.xy.name)
                                     # setting both qubits to the initial state
-                                    qp.qubit_control.xy.play("x180", condition=control_initial == 1)
-                                    qp.qubit_target.xy.play("x90")
+                                    mq.xy.play("x180", condition=moving_initial == 1)
+                                    sq.xy.play("x90")
                                     qp.align()
                                     # Loop over the number of CZ operations
                                     with for_(count, 0, count < n_op, count + 1):
                                         # play the CZ gate
                                         qp.macros[operation].apply(amplitude_scale_qubit=amp)
                                     # rotate the frame by 𝜋/2 for odd number of operations
-                                    with if_(((n_op & 1) == 0) & (control_initial == 1)):
+                                    with if_(((n_op & 1) == 0) & (moving_initial == 1)):
                                         assign(frame_odd, frame - 0.5)
-                                        qp.qubit_target.xy.frame_rotation_2pi(frame_odd)
+                                        sq.xy.frame_rotation_2pi(frame_odd)
                                     with else_():
-                                        qp.qubit_target.xy.frame_rotation_2pi(frame)
-                                    # return the target qubit before measurement
-                                    qp.qubit_target.xy.play("x90")
+                                        sq.xy.frame_rotation_2pi(frame)
+                                    # return the other qubit before measurement
+                                    sq.xy.play("x90")
                                     qp.align()
 
                                     if node.parameters.use_state_discrimination:
-                                        # measure both qubits
-                                        qp.qubit_control.readout_state_gef(state_c[ii])
-                                        qp.qubit_target.readout_state(state_t[ii])
-                                        # save each state outcome to its corresponding stream
-                                        with switch_(state_c[ii]):
+                                        # measure g/e/f populations for both qubits
+                                        mq.readout_state_gef(state_mq[ii])
+                                        sq.readout_state_gef(state_sq[ii])
+                                        with switch_(state_mq[ii]):
                                             with case_(0):
                                                 wait(4)
-                                                save(1, state_cg_st[ii])
-                                                save(0, state_ce_st[ii])
-                                                save(0, state_cf_st[ii])
+                                                save(1, state_mg_st[ii])
+                                                save(0, state_me_st[ii])
+                                                save(0, state_mf_st[ii])
                                             with case_(1):
                                                 wait(4)
-                                                save(0, state_cg_st[ii])
-                                                save(1, state_ce_st[ii])
-                                                save(0, state_cf_st[ii])
+                                                save(0, state_mg_st[ii])
+                                                save(1, state_me_st[ii])
+                                                save(0, state_mf_st[ii])
                                             with default_():
                                                 wait(4)
-                                                save(0, state_cg_st[ii])
-                                                save(0, state_ce_st[ii])
-                                                save(1, state_cf_st[ii])
-                                        save(state_t[ii], state_t_st[ii])
+                                                save(0, state_mg_st[ii])
+                                                save(0, state_me_st[ii])
+                                                save(1, state_mf_st[ii])
+                                        with switch_(state_sq[ii]):
+                                            with case_(0):
+                                                wait(4)
+                                                save(1, state_sg_st[ii])
+                                                save(0, state_se_st[ii])
+                                                save(0, state_sf_st[ii])
+                                            with case_(1):
+                                                wait(4)
+                                                save(0, state_sg_st[ii])
+                                                save(1, state_se_st[ii])
+                                                save(0, state_sf_st[ii])
+                                            with default_():
+                                                wait(4)
+                                                save(0, state_sg_st[ii])
+                                                save(0, state_se_st[ii])
+                                                save(1, state_sf_st[ii])
                                     else:
-                                        qp.qubit_control.resonator.measure("readout", qua_vars=(I_c[ii], Q_c[ii]))
-                                        qp.qubit_target.resonator.measure("readout", qua_vars=(I_t[ii], Q_t[ii]))
-                                        save(I_c[ii], I_c_st[ii])
-                                        save(Q_c[ii], Q_c_st[ii])
-                                        save(I_t[ii], I_t_st[ii])
-                                        save(Q_t[ii], Q_t_st[ii])
+                                        mq.resonator.measure("readout", qua_vars=(I_m[ii], Q_m[ii]))
+                                        sq.resonator.measure("readout", qua_vars=(I_s[ii], Q_s[ii]))
+                                        save(I_m[ii], I_m_st[ii])
+                                        save(Q_m[ii], Q_m_st[ii])
+                                        save(I_s[ii], I_s_st[ii])
+                                        save(Q_s[ii], Q_s_st[ii])
 
         with stream_processing():
             n_st.save("n")
             for i in range(num_qubit_pairs):
                 if node.parameters.use_state_discrimination:
-                    state_cg_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
+                    state_mg_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
                         num_operations
-                    ).average().save(f"g_state_control{i + 1}")
-                    state_ce_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
+                    ).average().save(f"g_state_moving{i + 1}")
+                    state_me_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
                         num_operations
-                    ).average().save(f"e_state_control{i + 1}")
-                    state_cf_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
+                    ).average().save(f"e_state_moving{i + 1}")
+                    state_mf_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
                         num_operations
-                    ).average().save(f"f_state_control{i + 1}")
-                    state_t_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
+                    ).average().save(f"f_state_moving{i + 1}")
+                    state_sg_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
                         num_operations
-                    ).average().save(f"state_target{i + 1}")
+                    ).average().save(f"g_state_stationary{i + 1}")
+                    state_se_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
+                        num_operations
+                    ).average().save(f"e_state_stationary{i + 1}")
+                    state_sf_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
+                        num_operations
+                    ).average().save(f"f_state_stationary{i + 1}")
                 else:
-                    I_c_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
+                    I_m_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
                         num_operations
-                    ).average().save(f"I_control{i + 1}")
-                    Q_c_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
+                    ).average().save(f"I_moving{i + 1}")
+                    Q_m_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
                         num_operations
-                    ).average().save(f"Q_control{i + 1}")
-                    I_t_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
+                    ).average().save(f"Q_moving{i + 1}")
+                    I_s_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
                         num_operations
-                    ).average().save(f"I_target{i + 1}")
-                    Q_t_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
+                    ).average().save(f"I_stationary{i + 1}")
+                    Q_s_st[i].buffer(2).buffer(len(frames)).buffer(len(amplitudes)).buffer(
                         num_operations
-                    ).average().save(f"Q_target{i + 1}")
+                    ).average().save(f"Q_stationary{i + 1}")
 
 
 # %% {Simulate}
@@ -269,14 +302,18 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
         data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
         for dataset in data_fetcher:
             progress_counter(
-                data_fetcher["n"],
+                data_fetcher.get("n", 0),
                 node.parameters.num_averages,
                 start_time=data_fetcher.t_start,
             )
         # Display the execution report to expose possible runtime errors
         node.log(job.execution_report())
-    # Register the raw dataset
+    # Register the raw dataset and role data needed for reproducible re-analysis
     node.results["ds_raw"] = dataset
+    qubit_roles_map = node.namespace["qubit_roles_map"]
+    node.results["qubit_roles"] = {
+        name: {field: getattr(role, field).name for field in role._fields} for name, role in qubit_roles_map.items()
+    }
 
 
 # %% {Load_data}
@@ -289,6 +326,10 @@ def load_data(node: QualibrationNode[Parameters, Quam]):
     node.parameters.load_data_id = load_data_id
     # Get the active qubit pairs from the loaded node parameters
     node.namespace["qubit_pairs"] = get_qubit_pairs(node)
+    node.namespace["qubit_roles_map"] = {
+        name: QubitRoles(**{field: node.machine.qubits[qname] for field, qname in roles.items()})
+        for name, roles in node.results["qubit_roles"].items()
+    }
 
 
 # %% {Analyse_data}
@@ -311,14 +352,21 @@ def plot_data(node: QualibrationNode[Parameters, Quam]):
     """Plot the raw and fitted data in a specific figure whose shape is given by qubit pair grid locations."""
     qubit_pairs = node.namespace["qubit_pairs"]
 
-    # Plot phase calibration data
-    fig_phase = plot_raw_data_with_fit(
-        node.results["ds_fit"],
-        qubit_pairs,
-    )
+    ds_fit = node.results["ds_fit"]
+
+    fig_phase = plot_raw_data_with_fit(ds_fit, qubit_pairs, qubit_roles_map=node.namespace.get("qubit_roles_map"))
     plt.show()
 
     node.results["phase_figure"] = fig_phase
+
+    if "f_state_moving" in ds_fit.data_vars or "f_state_stationary" in ds_fit.data_vars:
+        fig_populations = plot_leakage_qubit_populations(
+            ds_fit, qubit_pairs, qubit_roles_map=node.namespace.get("qubit_roles_map")
+        )
+        plt.show()
+        node.results["populations_figure"] = fig_populations
+    else:
+        node.log("No leakage (f-state) populations data found in the fit dataset.")
 
 
 # %% {Update_state}
@@ -331,6 +379,7 @@ def update_state(node: QualibrationNode[Parameters, Quam]):
         fit_results = node.results["fit_results"]
         for qp in node.namespace["qubit_pairs"]:
             if node.outcomes[qp.name] == "failed":
+                node.log(f"Skipping state update for {qp.name}: fit flagged unsuccessful.")
                 continue
             qp.macros[operation].flux_pulse_qubit.amplitude = fit_results[qp.name]["optimal_amplitude"]
 

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32b_cz_conditional_phase_error_amp.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32b_cz_conditional_phase_error_amp.py
@@ -92,7 +92,7 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     # at the end of the node.
     qubit_roles_map = {}
     for qp in qubit_pairs:
-        verify_moving_qubit(qp, log_callable=node.log)
+        verify_moving_qubit(qp, operation=node.parameters.operation, log_callable=node.log)
         qubit_roles_map[qp.name] = QubitRoles.resolve(qp)
     node.namespace["qubit_roles_map"] = qubit_roles_map
 

--- a/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32b_cz_conditional_phase_error_amp.py
+++ b/qualibration_graphs/superconducting/calibrations/CZ_calibrations/32b_cz_conditional_phase_error_amp.py
@@ -1,6 +1,5 @@
 # %% {Imports}
 from dataclasses import asdict
-from multiprocessing.process import parent_process
 
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
## Summary
Refactors the CZ controlled-phase calibrations (nodes **32a** and **32b**) to use physics-driven **moving/stationary/leakage** qubit roles instead of hardcoded control/target, and updates analysis, plotting, and node documentation accordingly.
## What
### Nodes 32a & 32b
- Resolve qubit roles via `QubitRoles` / `verify_moving_qubit` before building the QUA program.
- Flux pulse and CZ macro applied on the **moving** qubit; frame tomography and phase extraction on the **stationary** qubit.
- Rename data streams: `state_control`/`state_target` → `state_moving`/`state_stationary` (and matching `I_*`/`Q_*`, GEF g/e/f streams).
- Both qubits use GEF readout (`readout_state_gef`) when state discrimination is enabled.
- Save `qubit_roles` in results for reproducible re-analysis via `load_data_id`.
- Rewrite node descriptions to match the actual protocol and fit criteria.
### Analysis (`cz_conditional_phase`, `cz_conditional_phase_error_amp`)
- Detuning computed from the **moving** qubit's `freq_vs_flux_01_quad_term`.
- **32a**: fit stationary-qubit oscillations; find optimal amplitude via tanh fit to `phase_diff` at π (0.5).
- **32b**: fit at each `number_of_operations`; select amplitude via trimmed-mean circular distance to π across the 2D `phase_diff` map (`_fit_full_amp`).
- Leakage populations recorded but **not** used in the fit criterion (visual only).
### Plotting
- Replace ad-hoc subplot grids with `QubitPairGrid` / `grid_iter` chip-topology layout.
- **32a**: phase-diff vs amplitude (+ tanh fit) and leakage-qubit g/e/f populations vs amplitude.
- **32b**: phase-diff heatmap (amplitude × # CZ ops) and leakage-qubit populations at optimal amplitude vs # ops.
- Leakage plots use `QubitRoles.leakage` (always the higher-frequency qubit), not hardcoded control.
## Why
After #526 introduced `QubitRoles`, nodes 32a/32b still assumed control = flux qubit and target = phase qubit. That breaks for pairs where the moving qubit is not `qubit_control` (determined by δ vs anharmonicity for |11⟩↔|20⟩ CZ). The old descriptions also incorrectly stated that |f⟩ leakage is minimised in the fit, and used outdated control/target language.
This PR aligns the phase-calibration pipeline with the same role model used in nodes 30/31, fixes the physics labelling, and gives clearer chip-layout plots for multi-pair runs.