### PR TITLE
feat(superconducting): port 09a_ramsey_vs_flux_calibration updates from CS_installations

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/__init__.py
@@ -1,12 +1,18 @@
+"""Utilities for Ramsey versus flux calibration."""
+
 from .parameters import Parameters
-from .analysis import process_raw_dataset, fit_raw_data, log_fitted_results
-from .plotting import plot_raw_data_with_fit, plot_parabolas_with_fit
+from .analysis import process_raw_dataset, fit_raw_data, log_fitted_results, unfold_aliased_frequencies
+from .plotting import plot_raw_data_with_fit, plot_parabolas_with_fit, plot_qubit_freq_vs_flux_fig
+from .analysis import add_qubit_freq_vs_flux
 
 __all__ = [
     "Parameters",
     "process_raw_dataset",
     "fit_raw_data",
     "log_fitted_results",
+    "unfold_aliased_frequencies",
+    "add_qubit_freq_vs_flux",
     "plot_raw_data_with_fit",
     "plot_parabolas_with_fit",
+    "plot_qubit_freq_vs_flux_fig",
 ]

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
@@ -290,8 +290,6 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
     return ds_fit, fit_results
 
 
-
-
 def add_qubit_freq_vs_flux(
     ds_fit,
     rf_frequencies_hz: dict,
@@ -305,6 +303,7 @@ def add_qubit_freq_vs_flux(
     """
     import numpy as np
     import xarray as xr
+
     artificial_ghz = artificial_detuning_mhz * 1e-3
     qubits = ds_fit.qubit.values
     n_flux = len(ds_fit.flux_bias)
@@ -312,11 +311,7 @@ def add_qubit_freq_vs_flux(
     for qi, q in enumerate(qubits):
         if q not in rf_frequencies_hz:
             continue
-        f_qubit_data[qi] = (
-            rf_frequencies_hz[q] / 1e9
-            + artificial_ghz
-            - ds_fit.unfolded_frequency.sel(qubit=q).values
-        )
+        f_qubit_data[qi] = rf_frequencies_hz[q] / 1e9 + artificial_ghz - ds_fit.unfolded_frequency.sel(qubit=q).values
     ds_fit["f_qubit_vs_flux"] = xr.DataArray(
         f_qubit_data,
         dims=["qubit", "flux_bias"],
@@ -324,6 +319,7 @@ def add_qubit_freq_vs_flux(
         attrs={"long_name": "Qubit RF frequency", "units": "GHz"},
     )
     return ds_fit
+
 
 def _extract_relevant_fit_parameters(fit: xr.Dataset, node: QualibrationNode):
     """Add metadata to the dataset and fit results."""

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
@@ -1,3 +1,5 @@
+"""Data analysis for Ramsey versus flux calibration."""
+
 import logging
 from dataclasses import dataclass
 from typing import Dict, Tuple
@@ -5,9 +7,9 @@ from typing import Dict, Tuple
 import numpy as np
 import xarray as xr
 from qualibrate import QualibrationNode
-from qualibration_libs.data import add_amplitude_and_phase, convert_IQ_to_V
 from quam_config.instrument_limits import instrument_limits
 from qualibration_libs.analysis import fit_oscillation_decay_exp, oscillation_decay_exp, peaks_dips
+from qualibration_libs.data import add_amplitude_and_phase, convert_IQ_to_V
 
 
 @dataclass
@@ -40,7 +42,157 @@ def log_fitted_results(fit_results: Dict, log_callable=None):
 
 
 def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
+    """Process raw dataset (placeholder)."""
     return ds
+
+
+def unfold_aliased_frequencies(frequency: xr.DataArray, f_nyquist: float) -> Tuple[xr.DataArray, xr.DataArray]:
+    """Unfold aliased frequencies using Nyquist zone tracking (extended zone scheme).
+
+    Analogous to Brillouin zone unfolding in solid-state physics: the fitted
+    oscillation frequency folds into [0, f_nyquist] due to discrete time sampling,
+    and this function recovers the true frequency by tracking which Nyquist zone
+    each flux point belongs to.
+
+    Assumes the true frequency is approximately parabolic, centered near
+    flux_bias=0 (first Nyquist zone), generally increasing with |flux_bias|.
+    The curve need not be globally monotonic — the algorithm only triggers a
+    zone transition when the measured frequency has demonstrably reached the
+    zone boundary (f_nyquist for even zones, 0 for odd zones).
+
+    The unfolding formula per zone *n*:
+      - n even: f_real = n * f_nyq + f_measured
+      - n odd:  f_real = (n+1) * f_nyq - f_measured
+
+    Parameters
+    ----------
+    frequency : xr.DataArray
+        Fitted oscillation frequencies, dims (qubit, flux_bias), in GHz.
+    f_nyquist : float
+        Nyquist frequency in GHz: 1 / (2 * wait_time_step_in_ns).
+
+    Returns
+    -------
+    unfolded : xr.DataArray
+        Unfolded frequencies (GHz), same shape as input.
+    zones : xr.DataArray
+        Nyquist zone index per point, same shape as input.
+    """
+    flux = frequency.flux_bias.values
+    center_idx = int(np.argmin(np.abs(flux)))
+
+    unfolded_data = np.full(frequency.shape, np.nan)
+    zone_data = np.zeros(frequency.shape)
+
+    for qi, q in enumerate(frequency.qubit.values):
+        freq = np.abs(frequency.isel(qubit=qi).values)
+        result = np.full(len(flux), np.nan)
+        zone_arr = np.zeros(len(flux))
+
+        if not np.isnan(freq[center_idx]):
+            result[center_idx] = freq[center_idx]
+
+        for step, rng in [
+            (+1, range(center_idx + 1, len(flux))),
+            (-1, range(center_idx - 1, -1, -1)),
+        ]:
+            zone = 0
+            # Track the extremum of the measured frequency since the last
+            # zone transition.  A real zone crossing requires the measured
+            # frequency to have reached the boundary: ≈ f_nyquist for even
+            # zones (upper boundary) or ≈ 0 for odd zones (lower boundary).
+            extremum = freq[center_idx] if not np.isnan(freq[center_idx]) else 0.0
+            for i in rng:
+                f_m = freq[i]
+                if np.isnan(f_m):
+                    result[i] = np.nan
+                    zone_arr[i] = zone
+                    continue
+
+                if not int(zone) % 2:
+                    extremum = max(extremum, f_m)
+                else:
+                    extremum = min(extremum, f_m)
+
+                f_candidate = _unfold_single(f_m, zone, f_nyquist)
+
+                prev = _find_prev_valid(result, i, -step)
+                if prev is not None and f_candidate < prev and _boundary_was_reached(extremum, zone, f_nyquist):
+                    zone += 1
+                    f_candidate = _unfold_single(f_m, zone, f_nyquist)
+                    extremum = f_m
+
+                result[i] = f_candidate
+                zone_arr[i] = zone
+
+        unfolded_data[qi] = result
+        zone_data[qi] = zone_arr
+
+    unfolded = xr.DataArray(
+        unfolded_data,
+        dims=frequency.dims,
+        coords=frequency.coords,
+        attrs={"long_name": "unfolded frequency", "units": "GHz"},
+    )
+    zones = xr.DataArray(
+        zone_data,
+        dims=frequency.dims,
+        coords=frequency.coords,
+        attrs={"long_name": "Nyquist zone"},
+    )
+    return unfolded, zones
+
+
+def _unfold_single(f_measured: float, zone: int, f_nyquist: float) -> float:
+    """Compute unfolded frequency from measured frequency and zone index."""
+    zone = int(zone)
+    if not zone % 2:
+        return zone * f_nyquist + f_measured
+    return (zone + 1) * f_nyquist - f_measured
+
+
+def _boundary_was_reached(
+    extremum_since_zone_change: float,
+    zone: int,
+    f_nyquist: float,
+    threshold: float = 0.9,
+) -> bool:
+    """Check whether the measured frequency reached the zone boundary since the
+    last zone transition.
+
+    At a genuine aliasing fold the measured frequency must have touched the
+    boundary — f_nyquist for even zones (upper) or 0 for odd zones (lower).
+    If the extremum since the last zone change never got close to the boundary,
+    the monotonicity violation is caused by the real frequency curve turning
+    over, not by aliasing.
+
+    Parameters
+    ----------
+    extremum_since_zone_change : float
+        Running max (even zone) or running min (odd zone) of the measured
+        frequency since the last zone transition.
+    zone : int
+        Current Nyquist zone index.
+    f_nyquist : float
+        Nyquist frequency (GHz).
+    threshold : float
+        Fraction of f_nyquist the extremum must exceed (even zone) or stay
+        below (odd zone).  Default 0.9.
+    """
+    zone = int(zone)
+    if not zone % 2:
+        return extremum_since_zone_change > threshold * f_nyquist
+    return extremum_since_zone_change < (1 - threshold) * f_nyquist
+
+
+def _find_prev_valid(arr: np.ndarray, idx: int, direction: int):
+    """Find the nearest non-NaN value from *idx* in the given direction."""
+    i = idx + direction
+    while 0 <= i < len(arr):
+        if not np.isnan(arr[i]):
+            return arr[i]
+        i += direction
+    return None
 
 
 def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, dict[str, FitParameters]]:
@@ -72,7 +224,10 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
     )
 
     frequency = fit_data.sel(fit_vals="f")
-    frequency.attrs = {"long_name": "frequency", "units": "MHz"}
+
+    # Unfold aliased frequencies (Nyquist zone unfolding / extended zone scheme)
+    f_nyquist = 1.0 / (2.0 * node.parameters.wait_time_step_in_ns)  # GHz
+    frequency_unfolded, nyquist_zones = unfold_aliased_frequencies(frequency, f_nyquist)
 
     decay = fit_data.sel(fit_vals="decay")
     decay.attrs = {"long_name": "decay", "units": "nSec"}
@@ -80,7 +235,7 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
     tau = 1 / fit_data.sel(fit_vals="decay")
     tau.attrs = {"long_name": "T2*", "units": "uSec"}
 
-    frequency = frequency.where(frequency > 0, drop=True)
+    frequency = frequency_unfolded.where(frequency_unfolded > 0, drop=True)
 
     fitvals = frequency.polyfit(dim="flux_bias", deg=2)
     flux = frequency.flux_bias
@@ -117,6 +272,9 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
     ds_fit["artifitial_detuning"] = xr.DataArray(
         node.parameters.frequency_detuning_in_mhz, dims=["qubit"], coords={"qubit": qubits}
     )
+    ds_fit["unfolded_frequency"] = frequency_unfolded
+    ds_fit["nyquist_zones"] = nyquist_zones
+    ds_fit["f_nyquist"] = f_nyquist
 
     fit_results = {
         q: FitParameters(
@@ -131,6 +289,41 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
 
     return ds_fit, fit_results
 
+
+
+
+def add_qubit_freq_vs_flux(
+    ds_fit,
+    rf_frequencies_hz: dict,
+    artificial_detuning_mhz: float,
+):
+    """Compute absolute qubit RF frequency vs flux and add to ds_fit.
+
+    f_qubit(Phi) [GHz] = RF_frequency/1e9 + artificial_detuning*1e-3 - unfolded_frequency
+
+    Qubits absent from rf_frequencies_hz (fitting failed) receive NaN rows.
+    """
+    import numpy as np
+    import xarray as xr
+    artificial_ghz = artificial_detuning_mhz * 1e-3
+    qubits = ds_fit.qubit.values
+    n_flux = len(ds_fit.flux_bias)
+    f_qubit_data = np.full((len(qubits), n_flux), np.nan)
+    for qi, q in enumerate(qubits):
+        if q not in rf_frequencies_hz:
+            continue
+        f_qubit_data[qi] = (
+            rf_frequencies_hz[q] / 1e9
+            + artificial_ghz
+            - ds_fit.unfolded_frequency.sel(qubit=q).values
+        )
+    ds_fit["f_qubit_vs_flux"] = xr.DataArray(
+        f_qubit_data,
+        dims=["qubit", "flux_bias"],
+        coords={"qubit": qubits, "flux_bias": ds_fit.flux_bias},
+        attrs={"long_name": "Qubit RF frequency", "units": "GHz"},
+    )
+    return ds_fit
 
 def _extract_relevant_fit_parameters(fit: xr.Dataset, node: QualibrationNode):
     """Add metadata to the dataset and fit results."""

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
@@ -230,7 +230,7 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
     decay.attrs = {"long_name": "decay", "units": "nSec"}
 
     tau = 1 / fit_data.sel(fit_vals="decay")
-    tau.attrs = {"long_name": "T2*", "units": "uSec"}
+    tau.attrs = {"long_name": "T2*", "units": "nSec"}
 
     frequency = frequency_unfolded.where(frequency_unfolded > 0, drop=True)
 

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
@@ -266,7 +266,7 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
     ds_fit["quad_term"] = xr.DataArray([a[q] for q in qubits], dims=["qubit"], coords={"qubit": qubits})
     ds_fit["flux_offset"] = xr.DataArray([flux_offset[q] for q in qubits], dims=["qubit"], coords={"qubit": qubits})
     ds_fit["freq_offset"] = xr.DataArray([freq_offset[q] for q in qubits], dims=["qubit"], coords={"qubit": qubits})
-    ds_fit["artifitial_detuning"] = xr.DataArray(
+    ds_fit["artificial_detuning"] = xr.DataArray(
         node.parameters.frequency_detuning_in_mhz, dims=["qubit"], coords={"qubit": qubits}
     )
     ds_fit["unfolded_frequency"] = frequency_unfolded

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
@@ -241,8 +241,10 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
     flux_offset = {}
     freq_offset = {}
     t2_star = {}
+    success = {}
 
     qubits = ds.qubit.values
+    flux_min, flux_max = flux.min().values, flux.max().values
 
     for q in qubits:
         a[q] = float(-1e6 * fitvals.sel(qubit=q, degree=2).polyfit_coefficients.values)
@@ -260,6 +262,14 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
         )
         t2_star[q] = tau.sel(qubit=q).values
 
+        # Success criterion: fit parameters are finite and flux offset is within swept range
+        success[q] = (
+            np.isfinite(a[q])
+            and np.isfinite(flux_offset[q])
+            and np.isfinite(freq_offset[q])
+            and flux_min <= flux_offset[q] <= flux_max
+        )
+
     ds_fit = ds.merge(fit_data.rename("fit_results"))
 
     # Add a, flux_offset, and freq_offset as data variables in the dataset
@@ -275,7 +285,7 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
 
     fit_results = {
         q: FitParameters(
-            success=True,
+            success=success[q],
             quad_term=a[q],
             flux_offset=flux_offset[q],
             freq_offset=freq_offset[q],

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
@@ -7,9 +7,7 @@ from typing import Dict, Tuple
 import numpy as np
 import xarray as xr
 from qualibrate import QualibrationNode
-from quam_config.instrument_limits import instrument_limits
-from qualibration_libs.analysis import fit_oscillation_decay_exp, oscillation_decay_exp, peaks_dips
-from qualibration_libs.data import add_amplitude_and_phase, convert_IQ_to_V
+from qualibration_libs.analysis import fit_oscillation_decay_exp, oscillation_decay_exp
 
 
 @dataclass

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
@@ -18,7 +18,6 @@ class FitParameters:
     quad_term: float
     flux_offset: float
     freq_offset: float
-    flux_offset: float
     t2_star: np.ndarray
 
 

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/parameters.py
@@ -1,9 +1,13 @@
+"""Parameters for Ramsey versus flux calibration."""
+
 from qualibrate import NodeParameters
 from qualibrate.core.parameters import RunnableParameters
 from qualibration_libs.parameters import QubitsExperimentNodeParameters, CommonNodeParameters
 
 
 class NodeSpecificParameters(RunnableParameters):
+    """Node-specific parameters for Ramsey vs flux experiment."""
+
     num_shots: int = 100
     """Number of averages to perform. Default is 100."""
     frequency_detuning_in_mhz: float = 1.0
@@ -18,6 +22,8 @@ class NodeSpecificParameters(RunnableParameters):
     """Span of flux values to sweep in volts. Default is 0.01 V."""
     flux_num: int = 21
     """Number of flux points to sample. Default is 21."""
+    save_load_id: bool = False
+    """Whether to save the load id. Default is False."""
 
 
 class Parameters(
@@ -26,4 +32,6 @@ class Parameters(
     NodeSpecificParameters,
     QubitsExperimentNodeParameters,
 ):
+    """Combined parameters for the Ramsey vs flux calibration node."""
+
     pass

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/plotting.py
@@ -1,20 +1,23 @@
+"""Plotting functions for Ramsey versus flux calibration."""
+
 from typing import List
 
+import numpy as np
 import matplotlib.pyplot as plt
 import xarray as xr
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from qualang_tools.units import unit
-from qualibration_libs.plotting import QubitGrid, grid_iter
 from quam_builder.architecture.superconducting.qubit import AnyTransmon
 from qualibration_libs.analysis import lorentzian_peak
+from qualibration_libs.plotting import QubitGrid, grid_iter
 
 u = unit(coerce_to_integer=True)
 
 
 def plot_raw_data_with_fit(ds: xr.Dataset, qubits: List[AnyTransmon], fits: xr.Dataset):
     """
-    Plots the resonator spectroscopy amplitude IQ_abs with fitted curves for the given qubits.
+    Plots Ramsey vs flux with the fitted dataset.
 
     Parameters
     ----------
@@ -47,7 +50,7 @@ def plot_raw_data_with_fit(ds: xr.Dataset, qubits: List[AnyTransmon], fits: xr.D
 
 def plot_parabolas_with_fit(ds: xr.Dataset, qubits: List[AnyTransmon], fits: xr.Dataset):
     """
-    Plots the resonator spectroscopy amplitude IQ_abs with fitted curves for the given qubits.
+    Plots Ramsey vs flux frequency with the fitted dataset.
 
     Parameters
     ----------
@@ -72,7 +75,7 @@ def plot_parabolas_with_fit(ds: xr.Dataset, qubits: List[AnyTransmon], fits: xr.
     for ax, qubit in grid_iter(grid):
         plot_individual_parabolas_with_fit(ax, ds, qubit, fits.sel(qubit=qubit["qubit"]))
 
-    grid.fig.suptitle("Ramsey vs flux frequency ")
+    grid.fig.suptitle("Ramsey vs flux frequency")
     grid.fig.set_size_inches(15, 9)
     grid.fig.tight_layout()
     return grid.fig
@@ -129,17 +132,130 @@ def plot_individual_parabolas_with_fit(ax: Axes, ds: xr.Dataset, qubit: dict[str
     """
     detuning = fit.artifitial_detuning
 
-    (fit.sel(fit_vals="f").fit_results * 1e3 - detuning).plot(ax=ax, linestyle="--", marker=".")
+    (fit.unfolded_frequency * 1e3 - detuning).plot(ax=ax, linestyle="--", marker=".", label="Unfolded freq")
+
+    # Show aliased (raw) fitted frequency for comparison
+    (np.abs(fit.sel(fit_vals="f").fit_results) * 1e3 - detuning).plot(
+        ax=ax, linestyle=":", marker=".", alpha=0.35, color="gray", label="Aliased freq"
+    )
+
     ax.set_title(qubit["qubit"])
     ax.set_xlabel("Flux offset (V)")
     ax.set_ylabel("Qubit SweetSpot detuning (MHz)")
 
-    flux_offset = fit.flux_offset
+    # Parabola fit: f(V) = c2*(V - V0)² + f0, converted to MHz minus detuning
+    flux = fit.unfolded_frequency.flux_bias.values
+    c2_mhz = -float(fit.quad_term) / 1e3  # MHz/V²
+    v0 = float(fit.flux_offset)
+    f0_mhz = float(fit.freq_offset) * 1e-3  # MHz at vertex
+    parabola_mhz = c2_mhz * (flux - v0) ** 2 + f0_mhz - float(detuning)
+    ax.plot(flux, parabola_mhz, color="tab:orange", linewidth=2, alpha=0.8, label="Parabola fit")
 
+    flux_offset = fit.flux_offset
     ax.axvline(flux_offset, color="red", linestyle="--", label="Flux offset")
 
     freq_offset = fit.freq_offset.values * 1e-3 - detuning
-
     ax.axhline(freq_offset, color="green", linestyle="--", label="Detuning from SweetSpot")
 
-    ax.legend()
+    # Nyquist zone boundary lines
+    max_zone = int(fit.nyquist_zones.max())
+    f_nyq = float(fit.f_nyquist)
+    for n in range(1, max_zone + 1):
+        boundary_mhz = n * f_nyq * 1e3 - detuning
+        ax.axhline(
+            boundary_mhz,
+            color="gray",
+            linestyle=":",
+            alpha=0.5,
+            label="Nyquist boundary" if n == 1 else None,
+        )
+
+    ax.legend(fontsize="small")
+
+
+def plot_qubit_freq_vs_flux_fig(ds: xr.Dataset, qubits) -> "Figure":
+    """Plot absolute qubit RF frequency vs flux for all qubits.
+
+    The curve is derived from the unfolded Ramsey frequency and the corrected
+    RF_frequency stored in ds["f_qubit_vs_flux"] (GHz).  Qubits whose
+    fitting failed have an all-NaN row and are labelled accordingly.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Fit dataset containing f_qubit_vs_flux (GHz), flux_offset,
+        freq_offset, and quad_term.
+    qubits : list of AnyTransmon
+        Active qubits (used for grid layout).
+
+    Returns
+    -------
+    Figure
+        Matplotlib figure.
+    """
+    grid = QubitGrid(ds, [q.grid_location for q in qubits])
+    for ax, qubit in grid_iter(grid):
+        plot_individual_qubit_freq_vs_flux(ax, ds, qubit)
+
+    grid.fig.suptitle("Qubit RF frequency vs flux")
+    grid.fig.set_size_inches(15, 9)
+    grid.fig.tight_layout()
+    return grid.fig
+
+
+def plot_individual_qubit_freq_vs_flux(ax, ds: xr.Dataset, qubit: dict) -> None:
+    """Plot absolute qubit RF frequency vs flux on a single axis.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        Target axis.
+    ds : xr.Dataset
+        Fit dataset (must contain f_qubit_vs_flux in GHz).
+    qubit : dict
+        Mapping with key "qubit" giving the qubit name.
+    """
+    import numpy as np
+
+    q_name = qubit["qubit"]
+    f_ghz = ds["f_qubit_vs_flux"].sel(qubit=q_name).values
+    flux = ds.flux_bias.values
+
+    if np.all(np.isnan(f_ghz)):
+        ax.set_title(q_name)
+        ax.text(
+            0.5, 0.5, "fitting failed",
+            transform=ax.transAxes,
+            ha="center", va="center", color="red",
+        )
+        ax.set_xlabel("Flux offset (V)")
+        ax.set_ylabel("RF frequency (GHz)")
+        return
+
+    ax.plot(flux, f_ghz, linestyle="-", marker=".", label="f_qubit (Ramsey)")
+
+    # Parabola fit overlay (same curve, smooth)
+    c2_ghz = -float(ds.quad_term.sel(qubit=q_name).values) / 1e9  # Hz/V2 -> GHz/V2... actually quad_term unit check
+    # quad_term stored as MHz/V^2 (= -1e6 * GHz/V^2 polyfit coeff * 1e3... see analysis)
+    # safe approach: just use the fitted f_qubit_vs_flux data itself for the parabola
+    # Fit a smooth parabola through the valid (non-NaN) points for visual overlay
+    valid = ~np.isnan(f_ghz)
+    if valid.sum() >= 3:
+        coeffs = np.polyfit(flux[valid], f_ghz[valid], 2)
+        flux_smooth = np.linspace(flux[valid].min(), flux[valid].max(), 300)
+        ax.plot(flux_smooth, np.polyval(coeffs, flux_smooth),
+                color="tab:orange", linewidth=2, alpha=0.8, label="Parabola fit")
+
+    # Sweet-spot vertical line
+    flux_offset = float(ds.flux_offset.sel(qubit=q_name).values)
+    ax.axvline(flux_offset, color="red", linestyle="--", label="Flux offset")
+
+    # Operating frequency horizontal line (value at flux_offset)
+    f_at_sweetspot = float(np.interp(flux_offset, flux[valid], f_ghz[valid])) if valid.sum() > 0 else np.nan
+    if not np.isnan(f_at_sweetspot):
+        ax.axhline(f_at_sweetspot, color="green", linestyle="--", label=f"Sweet-spot freq ({f_at_sweetspot:.4f} GHz)")
+
+    ax.set_title(q_name)
+    ax.set_xlabel("Flux offset (V)")
+    ax.set_ylabel("RF frequency (GHz)")
+    ax.legend(fontsize="small")

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/plotting.py
@@ -224,9 +224,13 @@ def plot_individual_qubit_freq_vs_flux(ax, ds: xr.Dataset, qubit: dict) -> None:
     if np.all(np.isnan(f_ghz)):
         ax.set_title(q_name)
         ax.text(
-            0.5, 0.5, "fitting failed",
+            0.5,
+            0.5,
+            "fitting failed",
             transform=ax.transAxes,
-            ha="center", va="center", color="red",
+            ha="center",
+            va="center",
+            color="red",
         )
         ax.set_xlabel("Flux offset (V)")
         ax.set_ylabel("RF frequency (GHz)")
@@ -243,8 +247,14 @@ def plot_individual_qubit_freq_vs_flux(ax, ds: xr.Dataset, qubit: dict) -> None:
     if valid.sum() >= 3:
         coeffs = np.polyfit(flux[valid], f_ghz[valid], 2)
         flux_smooth = np.linspace(flux[valid].min(), flux[valid].max(), 300)
-        ax.plot(flux_smooth, np.polyval(coeffs, flux_smooth),
-                color="tab:orange", linewidth=2, alpha=0.8, label="Parabola fit")
+        ax.plot(
+            flux_smooth,
+            np.polyval(coeffs, flux_smooth),
+            color="tab:orange",
+            linewidth=2,
+            alpha=0.8,
+            label="Parabola fit",
+        )
 
     # Sweet-spot vertical line
     flux_offset = float(ds.flux_offset.sel(qubit=q_name).values)

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/plotting.py
@@ -130,7 +130,7 @@ def plot_individual_parabolas_with_fit(ax: Axes, ds: xr.Dataset, qubit: dict[str
     -----
     - If the fit dataset is provided, the fitted curve is plotted along with the raw data.
     """
-    detuning = fit.artifitial_detuning
+    detuning = fit.artificial_detuning
 
     (fit.unfolded_frequency * 1e3 - detuning).plot(ax=ax, linestyle="--", marker=".", label="Unfolded freq")
 

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/plotting.py
@@ -103,8 +103,8 @@ def plot_individual_data_with_fit(ax: Axes, ds: xr.Dataset, qubit: dict[str, str
 
     ds.sel(qubit=qubit["qubit"]).state.plot(ax=ax)
     ax.set_title(qubit["qubit"])
-    ax.set_xlabel("Idle_time (uS)")
-    ax.set_ylabel(" Flux (V)")
+    ax.set_xlabel("Idle time (ns)")
+    ax.set_ylabel("Flux (V)")
 
     flux_offset = fit.flux_offset
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/09a_ramsey_vs_flux_calibration.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/09a_ramsey_vs_flux_calibration.py
@@ -1,3 +1,5 @@
+"""Ramsey versus flux calibration for qubit frequency vs flux characterization."""
+
 # %% {Imports}
 from dataclasses import asdict
 
@@ -14,10 +16,12 @@ from qualibration_libs.data import XarrayDataFetcher
 from quam_config import Quam
 from calibration_utils.ramsey_versus_flux_calibration import (
     Parameters,
+    add_qubit_freq_vs_flux,
     fit_raw_data,
     log_fitted_results,
-    plot_raw_data_with_fit,
     plot_parabolas_with_fit,
+    plot_qubit_freq_vs_flux_fig,
+    plot_raw_data_with_fit,
     process_raw_dataset,
 )
 from qualibration_libs.parameters import get_qubits
@@ -60,8 +64,8 @@ node = QualibrationNode[Parameters, Quam](
 # These parameters are ignored when run through the GUI or as part of a graph
 @node.run_action(skip_if=node.modes.external)
 def custom_param(node: QualibrationNode[Parameters, Quam]):
+    """Allow the user to locally set the node parameters."""
     # You can get type hinting in your IDE by typing node.parameters.
-    # node.parameters.qubits = ["q1", "q3"]
     pass
 
 
@@ -130,7 +134,7 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
                                 qubit.xy.play("x90")
                                 qubit.xy.frame_rotation_2pi(phi)
                                 qubit.xy.wait(t + 1)
-                                qubit.z.wait(qubit.xy.operations["x90"].length * u.ns)
+                                qubit.z.wait(qubit.xy.operations["x90"].length * u.ns // 4)
                                 qubit.z.play(
                                     "const", amplitude_scale=flux / qubit.z.operations["const"].amplitude, duration=t
                                 )
@@ -170,7 +174,7 @@ def simulate_qua_program(node: QualibrationNode[Parameters, Quam]):
 # %% {Execute}
 @node.run_action(skip_if=node.parameters.load_data_id is not None or node.parameters.simulate)
 def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
-    """Connect to the QOP, execute the QUA program and fetch the raw data and store it in a xarray dataset called "ds_raw"."""
+    """Connect, execute QUA program, fetch raw data and store as dataset 'ds_raw'."""
     # Connect to the QOP
     qmm = node.machine.connect()
     # Get the config from the machine
@@ -208,7 +212,7 @@ def load_data(node: QualibrationNode[Parameters, Quam]):
 # %% {Analyse_data}
 @node.run_action(skip_if=node.parameters.simulate)
 def analyse_data(node: QualibrationNode[Parameters, Quam]):
-    """Analyse the raw data and store the fitted data in another xarray dataset "ds_fit" and the fitted results in the "fit_results" dictionary."""
+    """Analyse raw data -> store fitted dataset 'ds_fit' and dict 'fit_results'."""
     node.results["ds_raw"] = process_raw_dataset(node.results["ds_raw"], node)
     node.results["ds_fit"], fit_results = fit_raw_data(node.results["ds_raw"], node)
     node.results["fit_results"] = {k: asdict(v) for k, v in fit_results.items()}
@@ -220,6 +224,24 @@ def analyse_data(node: QualibrationNode[Parameters, Quam]):
         for qubit_name, fit_result in node.results["fit_results"].items()
     }
 
+    # Compute absolute qubit RF frequency vs flux.
+    # Uses the corrected RF frequency (current value + freq_offset from the fit),
+    # which equals the value update_state will write to the state.
+    rf_hz = {}
+    for q in node.namespace["qubits"]:
+        if node.outcomes[q.name] != "successful":
+            continue
+        freq_offset = (
+            node.parameters.frequency_detuning_in_mhz * 1e6
+            - float(node.results["ds_fit"].freq_offset.sel(qubit=q.name).values) * 1e3
+        )
+        rf_hz[q.name] = q.xy.RF_frequency + freq_offset
+    node.results["ds_fit"] = add_qubit_freq_vs_flux(
+        node.results["ds_fit"],
+        rf_hz,
+        node.parameters.frequency_detuning_in_mhz,
+    )
+
 
 # %% {Plot_data}
 @node.run_action(skip_if=node.parameters.simulate)
@@ -227,11 +249,13 @@ def plot_data(node: QualibrationNode[Parameters, Quam]):
     """Plot the raw and fitted data in specific figures whose shape is given by qubit.grid_location."""
     fig_raw_fit = plot_raw_data_with_fit(node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"])
     fig_parabola_fit = plot_parabolas_with_fit(node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"])
+    fig_freq_vs_flux = plot_qubit_freq_vs_flux_fig(node.results["ds_fit"], node.namespace["qubits"])
     plt.show()
     # Store the generated figures
     node.results["figures"] = {
         "raw_data": fig_raw_fit,
         "parabola_fit": fig_parabola_fit,
+        "qubit_freq_vs_flux": fig_freq_vs_flux,
     }
 
 
@@ -241,6 +265,8 @@ def update_state(node: QualibrationNode[Parameters, Quam]):
     """Update the relevant parameters if the qubit data analysis was successful."""
     with node.record_state_updates():
         for q in node.namespace["qubits"]:
+            if node.parameters.save_load_id:
+                node.machine.qubits[q.name].extras["ramsey_vs_flux_calibration_load_id"] = node.snapshot_idx
             if node.outcomes[q.name] == "failed":
                 continue
             flux_point = node.machine.qubits[q.name].z.flux_point
@@ -263,4 +289,8 @@ def update_state(node: QualibrationNode[Parameters, Quam]):
 # %% {Save_results}
 @node.run_action()
 def save_results(node: QualibrationNode[Parameters, Quam]):
+    """Save all node results and state updates."""
     node.save()
+
+
+# %%

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/09a_ramsey_vs_flux_calibration.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/09a_ramsey_vs_flux_calibration.py
@@ -29,14 +29,15 @@ from qualibration_libs.runtime import simulate_and_plot
 
 # %% {Node initialisation}
 description = """
-        RAMSEY WITH VIRTUAL Z ROTATIONS
-This program consists in playing a Ramsey sequence (x90 - idle_time - x90 - measurement)
-for different idle times. Instead of detuning the qubit gates, the frame of the second
-x90 pulse is rotated (de-phased) to mimic an accumulated phase acquired for a given
-detuning after the idle time. This method has the advantage of playing resonant gates.
+        RAMSEY VERSUS FLUX CALIBRATION
+This program sweeps qubit flux bias during Ramsey idle time to characterize the qubit
+frequency dependence on flux. A Ramsey sequence (x90 - idle_time_with_flux_sweep - x90 - measurement)
+is played for different idle times and flux points. Frame rotations (virtual Z-rotations) on the
+second x90 pulse implement frequency detuning to observe Ramsey oscillations.
 
-From the results, one can fit the Ramsey oscillations and precisely measure the qubit
-resonance frequency and T2*.
+From the results, one fits the Ramsey oscillations to extract the frequency vs flux parabola,
+finding the flux sweet spot (flux_offset), frequency offset at the sweet spot, and the
+quadratic coefficient (frequency sensitivity to flux).
 
 Prerequisites:
     - Having found the resonance frequency of the resonator coupled to the qubit under
@@ -47,7 +48,10 @@ Prerequisites:
       duration_optimization IQ_blobs) for better SNR.
 
 Next steps before going to the next node:
-    - Update the qubits frequency (f_01) in the state.
+    - Update the qubit flux offset (z.independent_offset or z.joint_offset) to the
+      calibrated sweet spot.
+    - Update the qubit frequency (f_01 and RF_frequency) with the fitted offset.
+    - Store freq_vs_flux_01_quad_term for use in flux-tuning applications.
     - Save the current state by calling machine.save()
 """
 


### PR DESCRIPTION
## Summary
- Port CS `23_ramsey_vs_flux_calibration` updates into qua-libs `09a_ramsey_vs_flux_calibration`
- Add Nyquist-zone frequency unfolding, qubit RF frequency vs flux analysis/plotting, and `save_load_id` extras support
- Fix QUA `z.wait` timing to use clock cycles (`// 4`)

## Compatibility
- [x] Install-only telemetry code removed
- [x] `machine=Quam.load()` normalized
- [x] Utils import check passed

## Test plan
- [x] `cd qualibration_graphs/superconducting && .venv/bin/python -c "import calibration_utils.ramsey_versus_flux_calibration"`
- [x] Manual node run with `simulate=True` or on hardware


Made with [Cursor](https://cursor.com)