### PR TITLE
feat(superconducting): port 09c_t2star_vs_flux from CS_installations

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/T2star_vs_flux/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/T2star_vs_flux/__init__.py
@@ -1,0 +1,14 @@
+"""T2*-versus-flux (Ramsey dephasing) characterization utilities."""
+
+from .parameters import Parameters
+from .analysis import process_raw_dataset, fit_raw_data, log_fitted_results
+from .plotting import plot_raw_data_with_fit, plot_t2_star_vs_flux
+
+__all__ = [
+    "Parameters",
+    "process_raw_dataset",
+    "fit_raw_data",
+    "log_fitted_results",
+    "plot_raw_data_with_fit",
+    "plot_t2_star_vs_flux",
+]

--- a/qualibration_graphs/superconducting/calibration_utils/T2star_vs_flux/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/T2star_vs_flux/analysis.py
@@ -1,0 +1,209 @@
+"""Analysis for the T2*-versus-flux (Ramsey dephasing) node.
+
+A decaying-oscillation ``a*exp(-t*decay)*cos(2*pi*f*t + phi) + offset`` is fitted along
+the idle-time axis for every flux-bias point, and T2*(flux) = 1/decay is extracted from
+the envelope. The frequency ``f`` (the artificial detuning) is not used here -- only the
+decay envelope matters for T2*.
+
+Each (qubit, flux_bias) curve is fitted with a local, guarded ``curve_fit`` wrapped in
+``xr.apply_ufunc(vectorize=True)`` (see ``_fit_oscillation_vs_flux``). We deliberately do
+NOT call the shared ``fit_oscillation_decay_exp``: on a ``curve_fit`` RuntimeError it pops a
+BLOCKING ``plt.show()``, and a flux sweep routinely produces unfittable far-detuned /
+low-contrast slices that would hang a headless/batch node run. The local fitter returns an
+all-NaN row instead, which the R^2 and relative-error valid-gates then discard.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Tuple, Dict
+
+import numpy as np
+import xarray as xr
+from scipy.optimize import curve_fit
+
+from qualibrate import QualibrationNode
+from qualibration_libs.data import convert_IQ_to_V
+from qualibration_libs.analysis import oscillation_decay_exp, guess
+
+# Minimum goodness-of-fit (R^2) for a flux point's Ramsey fit to count as valid.
+# Clean fringes give R^2 ~ 0.99; noise-only points give R^2 ~ 0, so this cleanly
+# rejects flux points where the decaying-oscillation fit latched onto noise.
+_R2_MIN = 0.5
+
+
+@dataclass
+class T2StarVsFluxFit:
+    """Stores the T2*-versus-flux summary for a single qubit."""
+
+    t2_star_max: float
+    """Longest fitted T2* over the flux sweep, in seconds."""
+    t2_star_max_error: float
+    """Uncertainty on ``t2_star_max``, in seconds."""
+    flux_at_max: float
+    """Flux bias (V) at which the longest T2* is observed."""
+    num_valid_flux: int
+    """Number of flux points that produced a physical (finite, positive) T2*."""
+    success: bool
+    """Whether enough flux points were successfully fitted."""
+
+
+def log_fitted_results(fit_results: Dict, log_callable=None):
+    """Log the per-qubit T2*-versus-flux summary."""
+    if log_callable is None:
+        log_callable = logging.getLogger(__name__).info
+    for q, r in fit_results.items():
+        status = "SUCCESS" if r["success"] else "FAIL"
+        log_callable(
+            f"T2* vs flux for {q} : max T2* = {1e6 * r['t2_star_max']:.2f} +/- "
+            f"{1e6 * r['t2_star_max_error']:.2f} us at flux = {r['flux_at_max']:.4f} V "
+            f"({r['num_valid_flux']} valid flux points) --> {status}!"
+        )
+
+
+def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode) -> xr.Dataset:
+    """Convert IQ data to voltage if state discrimination is not used."""
+    if not node.parameters.use_state_discrimination:
+        ds = convert_IQ_to_V(ds, node.namespace["qubits"])
+    return ds
+
+
+def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, Dict[str, T2StarVsFluxFit]]:
+    """Fit the Ramsey decay for every flux-bias point and extract the per-qubit summary."""
+    signal_name = "state" if node.parameters.use_state_discrimination else "I"
+    data = ds[signal_name]
+    # Fit each (qubit, flux_bias) Ramsey curve with a local guarded curve_fit (see
+    # _fit_oscillation_vs_flux). We do NOT call the shared fit_oscillation_decay_exp because its
+    # internal apply_fit pops a BLOCKING plt.show() on any curve_fit RuntimeError -- a flux sweep
+    # routinely produces unfittable far-detuned/low-contrast slices, which would hang a headless run.
+    fit_data = _fit_oscillation_vs_flux(data, "idle_time")
+    # Goodness-of-fit (R^2) per (qubit, flux_bias). A decaying oscillation can spuriously
+    # fit pure noise, so we additionally reject flux points whose reconstructed fit poorly
+    # matches the data (the rel-error gate alone is insufficient for the oscillation case).
+    fitted = oscillation_decay_exp(
+        data.idle_time,
+        fit_data.sel(fit_vals="a"),
+        fit_data.sel(fit_vals="f"),
+        fit_data.sel(fit_vals="phi"),
+        fit_data.sel(fit_vals="offset"),
+        fit_data.sel(fit_vals="decay"),
+    )
+    ss_res = ((data - fitted) ** 2).sum("idle_time")
+    ss_tot = ((data - data.mean("idle_time")) ** 2).sum("idle_time")
+    r2 = 1.0 - ss_res / ss_tot
+    ds_fit = xr.merge([ds, fit_data])
+    ds_fit["fit_r2"] = r2
+    ds_fit, fit_results = _extract_relevant_fit_parameters(ds_fit)
+    return ds_fit, fit_results
+
+
+def _fit_oscillation_vs_flux(da: xr.DataArray, time_dim: str = "idle_time") -> xr.DataArray:
+    """Fit ``a*exp(-t*decay)*cos(2*pi*f*t + phi) + offset`` along ``time_dim`` for each
+    (qubit, flux_bias), vectorised and robust.
+
+    Returns a DataArray named ``fit_data`` with a ``fit_vals`` dim holding
+    ``[a, f, phi, offset, decay, decay_var]`` (decay_var = variance of the fitted decay).
+    Any curve that cannot be fitted yields an all-NaN row instead of raising or, crucially,
+    reaching the shared fitter's blocking ``plt.show()`` path."""
+    t = da[time_dim]
+
+    def _fit_one(x, y):
+        x = np.asarray(x, dtype=float)
+        y = np.asarray(y, dtype=float)
+        finite = np.isfinite(x) & np.isfinite(y)
+        if finite.sum() < 6:
+            return np.array([np.nan] * 6)
+        x, y = x[finite], y[finite]
+        span = max(x.max() - x.min(), 1.0)
+        # Initial guesses (reuse the shared guess helpers used by fit_oscillation_decay_exp).
+        a0 = float((np.max(y) - np.min(y)) / 2) or 1.0
+        offset0 = float(np.mean(y))
+        try:
+            f0 = float(guess.frequency(x, y))
+        except Exception:
+            f0 = 1.0 / span
+        try:
+            decay0 = float(guess.oscillation_exp_decay(x, y))
+        except Exception:
+            decay0 = 1.0 / span
+        if not np.isfinite(f0) or f0 <= 0:
+            f0 = 1.0 / span
+        if not np.isfinite(decay0) or decay0 == 0:
+            decay0 = 1.0 / span
+        try:
+            popt, pcov = curve_fit(
+                oscillation_decay_exp, x, y, p0=[a0, f0, 0.0, offset0, decay0], maxfev=10000
+            )
+            decay_var = float(np.abs(np.diag(pcov)[4]))
+            return np.array([popt[0], popt[1], popt[2], popt[3], popt[4], decay_var])
+        except Exception:
+            return np.array([np.nan] * 6)
+
+    fit = xr.apply_ufunc(
+        _fit_one,
+        t,
+        da,
+        input_core_dims=[[time_dim], [time_dim]],
+        output_core_dims=[["fit_vals"]],
+        vectorize=True,
+    )
+    fit = fit.assign_coords(fit_vals=("fit_vals", ["a", "f", "phi", "offset", "decay", "decay_var"]))
+    return fit.rename("fit_data")
+
+
+def _extract_relevant_fit_parameters(ds_fit: xr.Dataset) -> Tuple[xr.Dataset, Dict[str, T2StarVsFluxFit]]:
+    """Turn fitted decay rates into T2*(flux) and per-qubit summaries."""
+    # Model is a*exp(-t*decay)*cos(...)+offset, so decay > 0 for a real decay and T2* = 1/decay.
+    decay = ds_fit.fit_data.sel(fit_vals="decay")
+    decay_var = ds_fit.fit_data.sel(fit_vals="decay_var")
+
+    tau = 1.0 / decay
+    tau_error = np.abs(tau) * (np.sqrt(np.abs(decay_var)) / np.abs(decay))
+    # Keep only physical, well-constrained dephasing times: finite & positive, above the
+    # ~1-clock-cycle (16 ns) floor, and with a relative error < 1. This discards noise-only
+    # / unconverged fits (decay <= 0 or ~0 -> runaway / negative tau) so they are never
+    # counted valid nor written to qubit.extras.
+    rel_err = np.abs(tau_error / tau)
+    r2 = ds_fit["fit_r2"] if "fit_r2" in ds_fit else xr.ones_like(decay)
+    valid = (
+        np.isfinite(tau)
+        & (tau > 16)
+        & np.isfinite(tau_error)
+        & (rel_err < 1)
+        & (r2 >= _R2_MIN)
+    )
+    tau = tau.where(valid)
+    tau_error = tau_error.where(valid)
+
+    ds_fit["T2_star"] = tau
+    ds_fit["T2_star"].attrs = {"long_name": "T2*", "units": "ns"}
+    ds_fit["T2_star_error"] = tau_error
+    ds_fit["T2_star_error"].attrs = {"long_name": "T2* error", "units": "ns"}
+
+    n_flux = ds_fit.sizes.get("flux_bias", 0)
+    min_valid = max(3, n_flux // 2)
+
+    fit_results = {}
+    for q in ds_fit.qubit.values:
+        tau_q = ds_fit["T2_star"].sel(qubit=q)
+        err_q = ds_fit["T2_star_error"].sel(qubit=q)
+        num_valid = int(np.isfinite(tau_q).sum())
+        if num_valid == 0:
+            fit_results[str(q)] = T2StarVsFluxFit(
+                t2_star_max=float("nan"),
+                t2_star_max_error=float("nan"),
+                flux_at_max=float("nan"),
+                num_valid_flux=0,
+                success=False,
+            )
+            continue
+        flux_at_max = float(tau_q.idxmax(dim="flux_bias", skipna=True).values)
+        t2_max_ns = float(tau_q.max(skipna=True).values)
+        t2_max_err_ns = float(err_q.sel(flux_bias=flux_at_max).values)
+        fit_results[str(q)] = T2StarVsFluxFit(
+            t2_star_max=1e-9 * t2_max_ns,
+            t2_star_max_error=1e-9 * t2_max_err_ns,
+            flux_at_max=flux_at_max,
+            num_valid_flux=num_valid,
+            success=bool(num_valid >= min_valid),
+        )
+    return ds_fit, fit_results

--- a/qualibration_graphs/superconducting/calibration_utils/T2star_vs_flux/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/T2star_vs_flux/parameters.py
@@ -1,0 +1,56 @@
+"""Parameters for T2*-versus-flux (Ramsey dephasing) characterization."""
+
+from typing import Literal
+
+from qualibrate import NodeParameters
+from qualibrate.core.parameters import RunnableParameters
+from qualibration_libs.parameters import (
+    QubitsExperimentNodeParameters,
+    CommonNodeParameters,
+)
+
+
+class NodeSpecificParameters(RunnableParameters):
+    """Node-specific parameters for the T2*-versus-flux sweep."""
+
+    num_shots: int = 100
+    """Number of averages to perform per (flux, idle-time) point. Default is 100."""
+    frequency_detuning_in_mhz: float = 2.0
+    """Artificial detuning applied via a virtual-Z (frame) rotation so the Ramsey
+    fringes oscillate; the oscillation envelope gives T2*. The extracted T2* does
+    not depend on this value (it only needs to be large enough to resolve a few
+    fringes within the idle-time window). Default is 2.0 MHz."""
+
+    # --- idle-time sweep ---
+    # NOTE: unlike T1/echo (monotonic decays, which use a log sweep), Ramsey fringes
+    # must be sampled roughly uniformly (>= ~2 points per fringe), so the default sweep
+    # is LINEAR. These fields are owned here (not inherited from IdleTimeNodeParameters)
+    # so the linear default is unambiguous; get_idle_times_in_clock_cycles only needs
+    # these four attributes to be present.
+    min_wait_time_in_ns: int = 16
+    """Minimum idle (free-evolution) time in ns. Default is 16."""
+    max_wait_time_in_ns: int = 15000
+    """Maximum idle (free-evolution) time in ns. Default is 15000."""
+    wait_time_num_points: int = 150
+    """Number of idle-time points. Default is 150."""
+    log_or_linear_sweep: Literal["log", "linear"] = "linear"
+    """Idle-time sweep spacing. Default 'linear' (required to sample Ramsey fringes
+    without aliasing); 'log' is available but only sensible for very low detuning."""
+
+    # --- flux sweep ---
+    flux_span: float = 0.02
+    """Full span of the flux-bias sweep in volts, centered on the qubit flux
+    point. The sweep runs over ``[-flux_span/2, +flux_span/2]``. Default is 0.02 V."""
+    flux_num: int = 11
+    """Number of flux-bias points to sample. Default is 11."""
+
+
+class Parameters(
+    NodeParameters,
+    CommonNodeParameters,
+    NodeSpecificParameters,
+    QubitsExperimentNodeParameters,
+):
+    """Combined parameters for the T2*-versus-flux characterization node."""
+
+    pass

--- a/qualibration_graphs/superconducting/calibration_utils/T2star_vs_flux/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/T2star_vs_flux/plotting.py
@@ -1,0 +1,103 @@
+"""Plotting for the T2*-versus-flux (Ramsey dephasing) node."""
+
+from typing import List
+
+import numpy as np
+import xarray as xr
+from matplotlib.axes import Axes
+
+from qualibration_libs.plotting import QubitGrid, grid_iter
+from quam_builder.architecture.superconducting.qubit import AnyTransmon
+
+
+def _signal_name(ds: xr.Dataset) -> str:
+    if hasattr(ds, "state"):
+        return "state"
+    if hasattr(ds, "I"):
+        return "I"
+    raise RuntimeError("The dataset must contain either 'I' or 'state' for the plotting function to work.")
+
+
+def plot_raw_data_with_fit(ds: xr.Dataset, qubits: List[AnyTransmon], fits: xr.Dataset):
+    """Plot the 2-D Ramsey-fringe map (idle time vs flux bias) for each qubit.
+
+    A horizontal dashed line marks the flux bias giving the longest T2*.
+    """
+    grid = QubitGrid(ds, [q.grid_location for q in qubits])
+    for ax, qubit in grid_iter(grid):
+        _plot_individual_map(ax, ds, qubit, fits.sel(qubit=qubit["qubit"]))
+
+    grid.fig.suptitle("T2* vs flux (Ramsey-fringe map)")
+    grid.fig.set_size_inches(15, 9)
+    grid.fig.tight_layout()
+    return grid.fig
+
+
+def plot_t2_star_vs_flux(ds: xr.Dataset, qubits: List[AnyTransmon], fits: xr.Dataset):
+    """Plot the extracted T2* versus flux bias (with error bars) for each qubit."""
+    grid = QubitGrid(ds, [q.grid_location for q in qubits])
+    for ax, qubit in grid_iter(grid):
+        _plot_individual_curve(ax, fits.sel(qubit=qubit["qubit"]), qubit)
+
+    grid.fig.suptitle("T2* vs flux")
+    grid.fig.set_size_inches(15, 9)
+    grid.fig.tight_layout()
+    return grid.fig
+
+
+def _plot_individual_map(ax: Axes, ds: xr.Dataset, qubit: dict, fit: xr.Dataset = None):
+    signal = _signal_name(ds)
+    da = ds.sel(qubit=qubit["qubit"])[signal]
+    if signal == "I":
+        da = da * 1e3
+        cbar_label = "Trans. amp. I [mV]"
+    else:
+        cbar_label = "State"
+
+    # A 2-D map needs both axes to have >1 point; otherwise (e.g. a single flux point)
+    # degrade gracefully to a 1-D line of signal vs idle time instead of crashing.
+    two_d = da.sizes.get("flux_bias", 1) > 1 and da.sizes.get("idle_time", 1) > 1
+    if two_d:
+        da.plot(ax=ax, x="idle_time", y="flux_bias", add_colorbar=True, cbar_kwargs={"label": cbar_label})
+        if fit is not None:
+            valid = np.isfinite(fit["T2_star"].values)
+            if valid.any():
+                idx = int(np.nanargmax(np.where(valid, fit["T2_star"].values, -np.inf)))
+                best_flux = float(fit.flux_bias.values[idx])
+                ax.axhline(best_flux, color="red", linestyle="--", linewidth=1, label="max T2*")
+    else:
+        da.squeeze().plot(ax=ax)
+
+    # Set labels AFTER plotting so they override xarray's auto-generated labels
+    ax.set_title(qubit["qubit"])
+    ax.set_xlabel("Idle time [ns]")
+    ax.set_ylabel("Flux bias [V]" if two_d else cbar_label)
+
+
+def _plot_individual_curve(ax: Axes, fit: xr.Dataset, qubit: dict):
+    flux = fit.flux_bias.values
+    tau_us = fit["T2_star"].values * 1e-3  # ns -> us
+    err_us = fit["T2_star_error"].values * 1e-3
+
+    ax.errorbar(flux, tau_us, yerr=err_us, fmt="o-", capsize=3, markersize=4)
+
+    valid = np.isfinite(tau_us)
+    if valid.any():
+        idx = int(np.nanargmax(np.where(valid, tau_us, -np.inf)))
+        best_flux = float(flux[idx])
+        best_t2 = float(tau_us[idx])
+        ax.axvline(best_flux, color="red", linestyle="--", linewidth=1)
+        ax.text(
+            0.05,
+            0.95,
+            f"max T2* = {best_t2:.1f} us\n@ flux = {best_flux:.4f} V",
+            transform=ax.transAxes,
+            fontsize=9,
+            verticalalignment="top",
+            bbox={"facecolor": "white", "alpha": 0.5},
+        )
+
+    ax.set_title(qubit["qubit"])
+    ax.set_xlabel("Flux bias [V]")
+    ax.set_ylabel("T2* [us]")
+    ax.set_ylim(bottom=0)  # T2* is non-negative; pin the y-axis floor to 0

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/09c_t2star_vs_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/09c_t2star_vs_flux.py
@@ -1,0 +1,291 @@
+# pylint: disable=duplicate-code
+"""T2* (Ramsey dephasing) coherence time versus flux-bias characterization."""
+
+# %% {Imports}
+import warnings
+from dataclasses import asdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+
+from qm.qua import *
+
+from qualang_tools.loops import from_array
+from qualang_tools.multi_user import qm_session
+from qualang_tools.results import progress_counter
+from qualang_tools.units import unit
+
+from qualibrate import QualibrationNode
+from quam_config import Quam
+from calibration_utils.T2star_vs_flux import (
+    Parameters,
+    process_raw_dataset,
+    fit_raw_data,
+    log_fitted_results,
+    plot_raw_data_with_fit,
+    plot_t2_star_vs_flux,
+)
+from qualibration_libs.parameters import get_qubits, get_idle_times_in_clock_cycles
+from qualibration_libs.runtime import simulate_and_plot
+from qualibration_libs.data import XarrayDataFetcher
+
+
+
+# %% {Description}
+description = """
+        T2* (RAMSEY) VERSUS FLUX
+The sequence plays a Ramsey sequence (x90 - idle - x90 - measurement) for several idle
+times while a constant flux pulse biases the qubit during the free-evolution window.
+A virtual-Z (frame) rotation applies an artificial detuning so the fringes oscillate;
+the oscillation envelope gives T2*. The single-qubit gates are played at the operating
+point (flux baseline) so they stay calibrated; only the free-evolution window is
+flux-biased. Repeating the scan over several flux biases maps how T2* depends on the
+qubit flux point.
+
+For each flux bias a decaying oscillation is fitted along the idle time to extract
+T2*(flux) = 1/decay; the flux giving the longest T2* is reported.
+
+Prerequisites:
+    - Having calibrated the qubit frequency precisely (node 12_ramsey.py).
+    - Having calibrated the x90 pulse, and specified the flux point (qubit.z.flux_point).
+    - A working z-line on every active qubit.
+
+State update:
+    - The flux giving the longest T2* and the corresponding T2* are stored in qubit.extras.
+"""
+
+
+node = QualibrationNode[Parameters, Quam](
+    name="09c_t2star_vs_flux",
+    description=description,
+    parameters=Parameters(),
+    machine=Quam.load(),
+)
+
+
+# Any parameters that should change for debugging purposes only should go in here
+# These parameters are ignored when run through the GUI or as part of a graph
+@node.run_action(skip_if=node.modes.external)
+def custom_param(node: QualibrationNode[Parameters, Quam]):
+    """Allow the user to locally set the node parameters."""
+    # You can get type hinting in your IDE by typing node.parameters.
+    # node.parameters.qubits = ["q1", "q2"]
+    pass
+
+
+# Instantiate the QUAM class from the state file
+# node.machine = Quam.load()
+
+
+# %% {Create_QUA_program}
+@node.run_action(skip_if=node.parameters.load_data_id is not None)
+def create_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Create the sweep axes and generate the QUA program from the pulse sequence and the node parameters."""
+    # Class containing tools to help handle units and conversions.
+    u = unit(coerce_to_integer=True)
+    # Get the active qubits from the node and organize them by batches
+    node.namespace["qubits"] = qubits = get_qubits(node)
+    num_qubits = len(qubits)
+    # Check if the qubits have a z-line attached
+    if any(q.z is None for q in qubits):
+        warnings.warn("Found qubits without a flux line. T2* vs flux requires a z-line.")
+
+    n_avg = node.parameters.num_shots  # The number of averages
+    # Idle-time sweep (clock cycles; may be log-spaced and non-uniform).
+    idle_times = get_idle_times_in_clock_cycles(node.parameters)
+    # Artificial detuning (Hz) implemented as a virtual-Z rotation of the second x90.
+    detuning = int(1e6 * node.parameters.frequency_detuning_in_mhz)
+    # Flux-bias sweep in V, centered on the qubit flux point
+    fluxes = np.linspace(
+        -node.parameters.flux_span / 2,
+        +node.parameters.flux_span / 2,
+        node.parameters.flux_num,
+    )
+    # Register the sweep axes to be added to the dataset when fetching data.
+    node.namespace["sweep_axes"] = {
+        "qubit": xr.DataArray(qubits.get_names()),
+        "flux_bias": xr.DataArray(fluxes, attrs={"long_name": "flux bias", "units": "V"}),
+        "idle_time": xr.DataArray(4 * idle_times, attrs={"long_name": "idle time", "units": "ns"}),
+    }
+
+    with program() as node.namespace["qua_program"]:
+        I, I_st, Q, Q_st, n, n_st = node.machine.declare_qua_variables()
+        if node.parameters.use_state_discrimination:
+            state = [declare(int) for _ in range(num_qubits)]
+            state_st = [declare_stream() for _ in range(num_qubits)]
+
+        t = declare(int)  # QUA variable for the idle time
+        flux = declare(fixed)  # QUA variable for the flux dc level
+        phi = declare(fixed)  # QUA variable for the virtual-Z (artificial detuning) phase
+
+        for multiplexed_qubits in qubits.batch():
+            # Initialize the QPU in terms of flux points (flux tunable transmons and/or tunable couplers)
+            for qubit in multiplexed_qubits.values():
+                node.machine.initialize_qpu(target=qubit)
+            align()
+
+            with for_(n, 0, n < n_avg, n + 1):
+                save(n, n_st)
+                with for_(*from_array(flux, fluxes)):
+                    with for_each_(t, idle_times):
+                        # Qubit initialization
+                        for i, qubit in multiplexed_qubits.items():
+                            reset_frame(qubit.xy.name)
+                            qubit.reset(node.parameters.reset_type, node.parameters.simulate)
+                        align()
+
+                        # Qubit manipulation: Ramsey with the flux applied during the idle window.
+                        # The z waits for the first x90 so the flux pulse aligns with the free-evolution
+                        # window and the gates themselves are played at the operating point (z baseline).
+                        for i, qubit in multiplexed_qubits.items():
+                            x90_len = qubit.xy.operations["x90"].length * u.ns // 4
+                            # Virtual-Z phase accumulated over the idle time (4*t ns).
+                            assign(phi, Cast.mul_fixed_by_int(detuning * 1e-9, 4 * t))
+                            with strict_timing_():
+                                qubit.xy.play("x90")
+                                qubit.xy.frame_rotation_2pi(phi)
+                                qubit.xy.wait(t + 1)
+                                # Flux on z, offset by the gate length to overlap the idle window
+                                qubit.z.wait(x90_len)
+                                qubit.z.play(
+                                    "const",
+                                    amplitude_scale=flux / qubit.z.operations["const"].amplitude,
+                                    duration=t,
+                                )
+                                qubit.xy.play("x90")
+                        align()
+
+                        # Qubit readout
+                        for i, qubit in multiplexed_qubits.items():
+                            if node.parameters.use_state_discrimination:
+                                qubit.readout_state(state[i])
+                                save(state[i], state_st[i])
+                            else:
+                                qubit.resonator.measure("readout", qua_vars=(I[i], Q[i]))
+                                save(I[i], I_st[i])
+                                save(Q[i], Q_st[i])
+
+            # Measure sequentially
+            if not node.parameters.multiplexed:
+                align()
+
+        with stream_processing():
+            n_st.save("n")
+            for i in range(num_qubits):
+                if node.parameters.use_state_discrimination:
+                    state_st[i].buffer(len(idle_times)).buffer(len(fluxes)).average().save(f"state{i + 1}")
+                else:
+                    I_st[i].buffer(len(idle_times)).buffer(len(fluxes)).average().save(f"I{i + 1}")
+                    Q_st[i].buffer(len(idle_times)).buffer(len(fluxes)).average().save(f"Q{i + 1}")
+
+
+# %% {Simulate}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or not node.parameters.simulate)
+def simulate_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Connect to the QOP and simulate the QUA program"""
+    # Connect to the QOP
+    qmm = node.machine.connect()
+    # Get the config from the machine
+    config = node.machine.generate_config()
+    debug = False
+    if debug:
+        from pathlib import Path
+        from qm import generate_qua_script
+        file_name = Path(__file__).stem
+        with open(Path(__file__).parent.parent / f"{file_name}_debug.py", 'w') as sourceFile:
+            print(generate_qua_script(node.namespace["qua_program"], config), file=sourceFile)
+    # Simulate the QUA program, generate the waveform report and plot the simulated samples
+    samples, fig, wf_report = simulate_and_plot(qmm, config, node.namespace["qua_program"], node.parameters)
+    # Store the figure, waveform report and simulated samples
+    node.results["simulation"] = {"figure": fig, "wf_report": wf_report, "samples": samples}
+
+
+# %% {Execute}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or node.parameters.simulate)
+def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Connect to the QOP, execute the QUA program and fetch the raw data and store it in
+    a xarray dataset called "ds_raw"."""
+    # Connect to the QOP
+    qmm = node.machine.connect()
+    # Get the config from the machine
+    config = node.machine.generate_config()
+    # Execute the QUA program only if the quantum machine is available (this is to avoid interrupting running jobs).
+    with qm_session(qmm, config, timeout=node.parameters.timeout) as qm:
+        # The job is stored in the node namespace to be reused in the fetching_data run_action
+        node.namespace["job"] = job = qm.execute(node.namespace["qua_program"])
+        # Display the progress bar
+        data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
+        for dataset in data_fetcher:
+            progress_counter(
+                data_fetcher.get("n", 0),
+                node.parameters.num_shots,
+                start_time=data_fetcher.t_start,
+            )
+        # Display the execution report to expose possible runtime errors
+        node.log(job.execution_report())
+    # Register the raw dataset
+    node.results["ds_raw"] = dataset
+
+
+# %% {Load_historical_data}
+@node.run_action(skip_if=node.parameters.load_data_id is None)
+def load_data(node: QualibrationNode[Parameters, Quam]):
+    """Load a previously acquired dataset."""
+    load_data_id = node.parameters.load_data_id
+    # Load the specified dataset
+    node.load_from_id(node.parameters.load_data_id)
+    node.parameters.load_data_id = load_data_id
+    # Get the active qubits from the loaded node parameters
+    node.namespace["qubits"] = get_qubits(node)
+
+
+# %% {Analyse_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def analyse_data(node: QualibrationNode[Parameters, Quam]):
+    """Analyse the raw data and store the fitted data in another xarray dataset "ds_fit"
+    and the fitted results in the "fit_results" dictionary."""
+    node.results["ds_raw"] = process_raw_dataset(node.results["ds_raw"], node)
+    node.results["ds_fit"], fit_results = fit_raw_data(node.results["ds_raw"], node)
+    node.results["fit_results"] = {k: asdict(v) for k, v in fit_results.items()}
+
+    # Log the relevant information extracted from the data analysis
+    log_fitted_results(node.results["fit_results"], log_callable=node.log)
+    node.outcomes = {
+        qubit_name: ("successful" if fit_result["success"] else "failed")
+        for qubit_name, fit_result in node.results["fit_results"].items()
+    }
+
+
+# %% {Plot_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def plot_data(node: QualibrationNode[Parameters, Quam]):
+    """Plot the raw and fitted data in specific figures whose shape is given by qubit.grid_location."""
+    fig_map = plot_raw_data_with_fit(node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"])
+    fig_curve = plot_t2_star_vs_flux(node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"])
+    plt.show()
+    # Store the generated figures
+    node.results["figures"] = {
+        "ramsey_fringe_map": fig_map,
+        "t2_star_vs_flux": fig_curve,
+    }
+
+
+# %% {Update_state}
+@node.run_action(skip_if=node.parameters.simulate)
+def update_state(node: QualibrationNode[Parameters, Quam]):
+    """Store the best flux point and the corresponding T2* in qubit.extras if successful."""
+    with node.record_state_updates():
+        for q in node.namespace["qubits"]:
+            if node.outcomes[q.name] == "failed":
+                continue
+            fit_results = node.results["fit_results"][q.name]
+            q.extras["T2star_vs_flux_best_flux_V"] = float(fit_results["flux_at_max"])
+            q.extras["T2star_vs_flux_best_T2star_s"] = float(fit_results["t2_star_max"])
+
+
+# %% {Save_results}
+@node.run_action()
+def save_results(node: QualibrationNode[Parameters, Quam]):
+    """Save all node results and state updates."""
+    node.save()


### PR DESCRIPTION
## Summary
- Port `26c_T2star_vs_flux` from CS_installations as `09c_t2star_vs_flux`, a new node
- Renumbered to slot after `09a_ramsey_vs_flux_calibration` / `09b_ramsey_vs_coupler_flux` (same Ramsey-vs-flux family; CS numbering doesn't map to qua-libs' scheme)
- Sweeps a Ramsey (T2*) sequence over idle time and flux bias to find the flux point giving the longest T2*; stores the best flux/T2* in `qubit.extras`

## Compatibility
- [x] No install-only telemetry / `sys.path` code present
- [x] `machine=Quam.load()` normalized
- [x] Import check passed (resolves through to `QualibrationNode` construction; the only error hit there is a pre-existing local `qualibrate-config` version mismatch that reproduces identically on already-merged nodes, e.g. `06b_echo`)
- [x] No new dependencies — reuses existing `qualibration_libs.data`/`analysis`/`parameters`/`plotting` helpers already used by other nodes (e.g. `T2echo`)
- [ ] No unit/simulation/interop tests exist for this node in CS_installations (none ported)

## Test plan
- [ ] Run the node against a real/simulated QOP to confirm the Ramsey-fringe map and T2*-vs-flux plots render correctly
- [ ] Confirm `qubit.extras["T2star_vs_flux_best_flux_V"]` / `["T2star_vs_flux_best_T2star_s"]` are populated on a successful run

🤖 Generated with [Claude Code](https://claude.com/claude-code)