### PR TITLE
Add tests/qualibration_graphs directory from final-eval-state

### DIFF
--- a/tests/qualibration_graphs/quantum_dots/calibrations/loss_divincenzo/test_05d_charge_stability_demo.py
+++ b/tests/qualibration_graphs/quantum_dots/calibrations/loss_divincenzo/test_05d_charge_stability_demo.py
@@ -1,0 +1,54 @@
+"""Regression tests for the simulated video-mode charge-stability setup."""
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+
+pytest.importorskip("qarray")
+
+ROOT = Path(__file__).resolve().parents[5]
+QUANTUM_DOTS_DIR = ROOT / "qualibration_graphs" / "quantum_dots"
+if str(QUANTUM_DOTS_DIR) not in sys.path:
+    sys.path.insert(0, str(QUANTUM_DOTS_DIR))
+
+from calibration_utils.run_video_mode.simulated_video_mode import (  # noqa: E402
+    generate_simulated_video_mode_quam,
+    get_simulated_video_mode_base_point,
+    setup_simulation,
+)
+
+
+def test_simulated_video_mode_base_point_resolves_virtual_offsets():
+    machine = generate_simulated_video_mode_quam()
+    gate_set = machine.virtual_gate_sets["main_qpu"]
+    base_point = get_simulated_video_mode_base_point(
+        {
+            "virtual_dot_1": -0.02,
+            "virtual_dot_2": -0.01,
+        }
+    )
+
+    simulator = setup_simulation(
+        base_point=base_point,
+        gate_set=gate_set,
+        dc_set=None,
+        sensor_gate_names=["virtual_sensor_1", "virtual_sensor_2"],
+    )
+    grids = simulator.get_physical_grid(
+        "virtual_dot_1",
+        "virtual_dot_2",
+        np.array([0.0]),
+        np.array([0.0]),
+    )
+
+    expected = gate_set.resolve_voltages(base_point, allow_extra_entries=True)
+    observed = {
+        gate_name: float(grid[0, 0])
+        for gate_name, grid in zip(simulator.qarray_gate_order, grids)
+    }
+
+    for gate_name in simulator.qarray_gate_order:
+        assert observed[gate_name] == pytest.approx(float(expected.get(gate_name, 0.0)))

--- a/tests/qualibration_graphs/quantum_dots/calibrations/loss_divincenzo/test_10b_time_rabi_chevron.py
+++ b/tests/qualibration_graphs/quantum_dots/calibrations/loss_divincenzo/test_10b_time_rabi_chevron.py
@@ -1,0 +1,10 @@
+"""Unit tests for 10b_time_rabi_chevron node.
+
+These are placeholders; we'll design real tests together next.
+"""
+
+import pytest
+
+
+def test_placeholder():
+    pytest.skip("Placeholder: test plan pending")

--- a/tests/qualibration_graphs/quantum_dots/calibrations/loss_divincenzo/test_simulated_video_mode_quam_factory.py
+++ b/tests/qualibration_graphs/quantum_dots/calibrations/loss_divincenzo/test_simulated_video_mode_quam_factory.py
@@ -1,0 +1,142 @@
+"""Regression tests for the simulated video-mode QuAM factory."""
+
+from pathlib import Path
+import sys
+
+from qm.qua import Cast, align, assign, declare, fixed, program, wait
+
+ROOT = Path(__file__).resolve().parents[5]
+QUANTUM_DOTS_DIR = ROOT / "qualibration_graphs" / "quantum_dots"
+if str(QUANTUM_DOTS_DIR) not in sys.path:
+    sys.path.insert(0, str(QUANTUM_DOTS_DIR))
+
+from calibration_utils.run_video_mode.simulated_video_mode import (  # noqa: E402
+    save_simulated_video_mode_quam,
+)
+from quam_config import Quam  # noqa: E402
+
+
+def _compile_power_rabi_sequence(machine: Quam) -> None:
+    qubit = machine.qubits["Q1"]
+    with program():
+        amplitude = declare(fixed)
+        p1 = declare(int)
+        p2 = declare(int)
+
+        align()
+        qubit.empty()
+        align()
+        assign(p1, Cast.to_int(qubit.measure()))
+        align()
+        qubit.initialize()
+        align()
+        qubit.x180(amplitude_scale=amplitude)
+        align()
+        assign(p2, Cast.to_int(qubit.measure()))
+        align()
+        qubit.voltage_sequence.apply_compensation_pulse()
+
+
+def _compile_time_rabi_sequence(machine: Quam) -> None:
+    qubit = machine.qubits["Q1"]
+    with program():
+        duration = declare(int)
+        p1 = declare(int)
+        p2 = declare(int)
+
+        align()
+        qubit.empty()
+        align()
+        assign(p1, Cast.to_int(qubit.measure()))
+        align()
+        qubit.initialize()
+        align()
+        qubit.x180(duration=duration)
+        align()
+        assign(p2, Cast.to_int(qubit.measure()))
+        align()
+        qubit.voltage_sequence.apply_compensation_pulse()
+
+
+def _compile_ramsey_sequence(machine: Quam) -> None:
+    qubit = machine.qubits["Q1"]
+    with program():
+        duration = declare(int)
+        detuning = declare(int)
+        p1 = declare(int)
+        p2 = declare(int)
+
+        qubit.xy.update_frequency(qubit.xy.intermediate_frequency + detuning)
+        align()
+        qubit.empty()
+        align()
+        assign(p1, Cast.to_int(qubit.measure()))
+        align()
+        qubit.initialize()
+        align()
+        qubit.x90()
+        align()
+        wait(duration)
+        qubit.voltage_sequence.step_to_voltages({}, duration=duration * 4)
+        align()
+        qubit.x90()
+        align()
+        assign(p2, Cast.to_int(qubit.measure()))
+        align()
+        qubit.voltage_sequence.apply_compensation_pulse()
+
+
+def _compile_hahn_sequence(machine: Quam) -> None:
+    qubit = machine.qubits["Q1"]
+    with program():
+        duration = declare(int)
+        p1 = declare(int)
+        p2 = declare(int)
+
+        align()
+        qubit.empty()
+        align()
+        assign(p1, Cast.to_int(qubit.measure()))
+        align()
+        qubit.initialize()
+        align()
+        qubit.x90()
+        align()
+        wait(duration)
+        qubit.voltage_sequence.step_to_voltages({}, duration=duration * 4)
+        align()
+        qubit.x180()
+        align()
+        wait(duration)
+        qubit.voltage_sequence.step_to_voltages({}, duration=duration * 4)
+        align()
+        qubit.x90()
+        align()
+        assign(p2, Cast.to_int(qubit.measure()))
+        align()
+        qubit.voltage_sequence.apply_compensation_pulse()
+
+
+import pytest
+
+
+@pytest.mark.skip(
+    reason="Simulated video mode factory needs pair voltage point registration for current architecture"
+)
+def test_simulated_video_mode_quam_supports_single_qubit_nodes(tmp_path):
+    state_path = save_simulated_video_mode_quam(tmp_path / "quam_state")
+    machine = Quam.load(str(state_path))
+
+    assert list(machine.qubits.keys()) == ["Q1", "Q2"]
+    assert machine.active_qubit_names == ["Q1", "Q2"]
+
+    q1 = machine.qubits["Q1"]
+    assert {"x180", "x90", "-x90", "y90", "-y90"}.issubset(q1.xy.operations.keys())
+    assert {"x180", "x90", "measure"}.issubset(q1.macros.keys())
+
+    _compile_power_rabi_sequence(machine)
+    _compile_time_rabi_sequence(machine)
+    _compile_ramsey_sequence(machine)
+    _compile_hahn_sequence(machine)
+
+    machine.generate_config()

--- a/tests/qualibration_graphs/quantum_dots/calibrations/quam_factory.py
+++ b/tests/qualibration_graphs/quantum_dots/calibrations/quam_factory.py
@@ -1,0 +1,386 @@
+"""Unified wiring-based QuAM factory for quantum dot calibration tests.
+
+Builds machines using the ``quam_builder`` wiring tools and the
+``release/nightly`` default macro engine.  Two entry points are provided:
+
+* :func:`create_qd_quam` -- Stage 1 dot-layer ``BaseQuamQD``
+  (quantum dots 1-2, sensor dot 1, virtual gate set, dot pair 1-2).
+  Used by gate-virtualization / virtual-gate-subgraph tests.
+
+* :func:`create_ld_quam` -- Stage 2 full ``LossDiVincenzoQuam``
+  (adds qubits 1-2, MW-FEM XY drives, default pulses, and default macros).
+  Used by loss-DiVincenzo calibration tests.
+
+Hardware configuration
+----------------------
+Cluster connection (host IP, cluster name) is loaded from
+``tests/.qm_cluster_config.json`` -- copy the ``.example`` file and
+fill in your values.  FEM slot numbers and topology constants live
+as module-level variables at the top of this file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from qualang_tools.wirer import Connectivity, Instruments, allocate_wiring
+
+from qualang_tools.wirer.wirer.wirer import ChannelSpec
+from quam_builder.architecture.quantum_dots.qpu import BaseQuamQD
+from quam_builder.builder.qop_connectivity import build_quam_wiring
+from quam_builder.architecture.quantum_dots.operations.names import (
+    DrivePulseName,
+    SingleQubitMacroName,
+    VoltagePointName,
+)
+from quam_builder.builder.quantum_dots import (
+    build_base_quam,
+    build_loss_divincenzo_quam,
+)
+
+# ── Hardware Configuration ──────────────────────────────────────────────
+# Cluster connection details are loaded at import time from
+# ``tests/.qm_cluster_config.json`` (not tracked by git).
+# Copy ``.qm_cluster_config.json.example`` and fill in your values.
+
+_WIRING_STATE_DIR = Path(tempfile.mkdtemp(prefix="quam_factory_"))
+"""Temp directory for build_quam_wiring's machine.save() call.
+
+Avoids hitting the global ~/.qualibrate/config.toml path resolution.
+"""
+
+os.environ.setdefault("QUAM_STATE_PATH", str(_WIRING_STATE_DIR))
+
+
+def _fake_get_quam_config():
+    return SimpleNamespace(
+        state_path=str(_WIRING_STATE_DIR),
+        raise_error_missing_reference=False,
+    )
+
+
+_quam_config_patches = [
+    patch("quam.config.resolvers.get_quam_config", _fake_get_quam_config),
+    patch("quam.config.get_quam_config", _fake_get_quam_config),
+    patch("quam.core.quam_classes.get_quam_config", _fake_get_quam_config),
+    patch("quam.serialisation.json.get_quam_config", _fake_get_quam_config),
+]
+for _p in _quam_config_patches:
+    _p.start()
+
+
+def _find_repo_root(start: Path) -> Path:
+    current = start
+    while current != current.parent:
+        if (current / "tests").is_dir() and (current / "qualibration_graphs").is_dir():
+            return current
+        current = current.parent
+    raise FileNotFoundError("Could not locate repo root")
+
+
+def _load_cluster_config() -> tuple[str, str]:
+    config_path = (
+        _find_repo_root(Path(__file__).resolve().parent)
+        / "tests"
+        / ".qm_cluster_config.json"
+    )
+    if not config_path.exists():
+        raise FileNotFoundError(
+            f"Cluster config not found at {config_path}. "
+            "Copy tests/.qm_cluster_config.json.example and fill in your values."
+        )
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    return data["host"], data["cluster_name"]
+
+
+HOST_IP, CLUSTER_NAME = _load_cluster_config()
+
+CONTROLLER_ID: int = 1
+"""Controller number passed to ``Instruments.add_*_fem(controller=...)``."""
+
+MW_FEM_SLOT: int = 1
+"""MW-FEM slot for qubit XY drive lines (Stage 2 only)."""
+
+LF_FEM_SLOT: int = 5
+"""LF-FEM slot for plungers 1-2, sensor 1, and resonator 1."""
+
+LF_FEM_DELAY_NS: int = 161  # 161
+"""Delay (ns) applied to all LF-FEM analog output ports to compensate for MW-FEM path skew."""
+
+MW_FEM_DELAY_NS: int = 0
+"""Delay (ns) applied to all MW-FEM output ports (Band 2: 161 ns)."""
+
+DEFAULT_LARMOR_FREQUENCIES: dict[str, float] = {
+    "q1": 5.1e9,
+    "q2": 5.3e9,
+}
+"""Per-qubit Larmor (RF) frequencies in Hz.
+
+Different g-factors give distinct Larmor frequencies in the same
+magnetic field, enabling frequency-selective single-qubit addressing.
+The MW-FEM upconverter is at 5 GHz, so IFs of 100–300 MHz are
+well within the MW-FEM NCO limit of ±500 MHz.
+"""
+
+DEFAULT_LARMOR_FREQUENCY: float = 5.1e9
+"""Fallback Larmor frequency for qubits not in DEFAULT_LARMOR_FREQUENCIES."""
+
+# ── Quantum-dot topology ───────────────────────────────────────────────
+
+SENSOR_DOTS: list[int] = [1]
+"""Sensor dot indices passed to ``Connectivity.add_sensor_dots``."""
+
+QUANTUM_DOTS: list[int] = [1, 2]
+"""Quantum dot (plunger) indices passed to ``Connectivity.add_quantum_dots``."""
+
+QUANTUM_DOT_PAIRS: list[tuple[int, int]] = [(1, 2)]
+"""Quantum dot pair tuples passed to ``Connectivity.add_quantum_dot_pairs``."""
+
+QUBIT_PAIR_SENSOR_MAP: dict[str, list[str]] = {
+    "q1_q2": ["sensor_1"],
+}
+"""Maps qubit-pair IDs to their readout sensor(s) for Stage 2."""
+
+
+# ── Factory functions ──────────────────────────────────────────────────
+
+
+def create_qd_quam() -> BaseQuamQD:
+    """Build a Stage-1 ``BaseQuamQD`` with the dot layer only.
+
+    Creates quantum dots 1-2, sensor dot 1 with readout resonator, a virtual
+    gate set with an identity compensation matrix, and dot pair (1, 2).
+    No qubits, XY drives, or macros are added.
+
+    The returned machine is suitable for gate-virtualization and
+    virtual-gate-subgraph calibration tests that operate on the dot layer.
+    """
+    connectivity = Connectivity()
+    connectivity.add_sensor_dots(
+        sensor_dots=SENSOR_DOTS,
+        shared_resonator_line=False,
+        use_mw_fem=False,
+    )
+    connectivity.add_quantum_dots(
+        quantum_dots=QUANTUM_DOTS,
+        add_drive_lines=False,
+    )
+    connectivity.add_quantum_dot_pairs(quantum_dot_pairs=QUANTUM_DOT_PAIRS)
+
+    instruments = Instruments()
+    instruments.add_lf_fem(
+        controller=CONTROLLER_ID,
+        slots=[LF_FEM_SLOT],
+    )
+
+    allocate_wiring(connectivity, instruments)
+
+    machine = BaseQuamQD()
+    machine = build_quam_wiring(
+        connectivity, HOST_IP, CLUSTER_NAME, machine, path=_WIRING_STATE_DIR
+    )
+    machine = build_base_quam(machine, connect_qdac=False, save=False)
+    return machine
+
+
+def create_ld_quam():
+    """Build a Stage-2 ``LossDiVincenzoQuam`` with qubits and default macros.
+
+    Internally calls :func:`create_qd_quam` for the dot layer, then adds
+    MW-FEM XY drive lines, registers qubits (q1-q2), wires the default
+    single-reference XY pulse and the default macros via
+    ``wire_machine_macros()``.
+
+    Returns a fully configured ``LossDiVincenzoQuam`` ready for
+    loss-DiVincenzo calibration tests.
+    """
+    base_machine = create_qd_quam()
+
+    connectivity = Connectivity()
+    connectivity.add_sensor_dots(
+        sensor_dots=SENSOR_DOTS,
+        shared_resonator_line=False,
+        use_mw_fem=False,
+    )
+    connectivity.add_quantum_dots(
+        quantum_dots=QUANTUM_DOTS,
+        add_drive_lines=True,
+        use_mw_fem=True,
+        shared_drive_line=True,
+    )
+    connectivity.add_quantum_dot_pairs(quantum_dot_pairs=QUANTUM_DOT_PAIRS)
+
+    instruments = Instruments()
+    instruments.add_mw_fem(controller=CONTROLLER_ID, slots=[MW_FEM_SLOT])
+    instruments.add_lf_fem(
+        controller=CONTROLLER_ID,
+        slots=[LF_FEM_SLOT],
+    )
+
+    allocate_wiring(connectivity, instruments)
+
+    machine = build_quam_wiring(
+        connectivity, HOST_IP, CLUSTER_NAME, base_machine, path=_WIRING_STATE_DIR
+    )
+    machine = build_loss_divincenzo_quam(
+        machine,
+        qubit_pair_sensor_map=QUBIT_PAIR_SENSOR_MAP,
+        implicit_mapping=True,
+        save=False,
+    )
+
+    # The builder sets qubit.id to the quantum-dot name (e.g. "virtual_dot_1")
+    # but downstream code expects qubit.name to equal the dict key ("q1").
+    for key, qubit in machine.qubits.items():
+        qubit.id = key
+
+    _set_default_larmor_frequencies(machine)
+    _override_default_pulse_lengths(machine)
+    _add_default_voltage_points(machine)
+    _apply_port_delays(machine)
+    return machine
+
+
+def _set_default_larmor_frequencies(machine) -> None:
+    """Set per-qubit Larmor frequencies reflecting distinct g-factors.
+
+    XYDriveMW.RF_frequency refs qubit.larmor_frequency; without a numeric
+    value the reference string leaks into the QM config as a non-number.
+    Qubits in ``DEFAULT_LARMOR_FREQUENCIES`` get their specific value;
+    others fall back to ``DEFAULT_LARMOR_FREQUENCY``.
+    """
+    for key, qubit in machine.qubits.items():
+        if getattr(qubit, "larmor_frequency", None) is None:
+            qubit.larmor_frequency = DEFAULT_LARMOR_FREQUENCIES.get(
+                key, DEFAULT_LARMOR_FREQUENCY
+            )
+
+
+def _apply_port_delays(machine) -> None:
+    """Set per-FEM output port delays to align LF-FEM and MW-FEM paths."""
+    for controller_ports in machine.ports.analog_outputs.values():
+        for fem_ports in controller_ports.values():
+            for port in fem_ports.values():
+                port.delay = LF_FEM_DELAY_NS
+
+    for controller_ports in machine.ports.mw_outputs.values():
+        for fem_ports in controller_ports.values():
+            for port in fem_ports.values():
+                port.delay = MW_FEM_DELAY_NS
+
+
+def _override_default_pulse_lengths(machine) -> None:
+    """Override quam-builder default pulse lengths for this test configuration."""
+    for qubit in machine.qubits.values():
+        if hasattr(qubit, "xy") and qubit.xy is not None:
+            gaussian_pulse = qubit.xy.operations.get(DrivePulseName.GAUSSIAN)
+            if gaussian_pulse is not None:
+                gaussian_pulse.length = 524
+                gaussian_pulse.amplitude = 0.2
+                if hasattr(gaussian_pulse, "sigma"):
+                    gaussian_pulse.sigma = 524 / 6
+
+    for sd in machine.sensor_dots.values():
+        rr = getattr(sd, "readout_resonator", None)
+        if rr is not None:
+            rr.intermediate_frequency = 50e6
+            if "readout" in getattr(rr, "operations", {}):
+                rr.operations["readout"].length = 1000
+                rr.operations["readout"].amplitude = 0.025
+
+
+def _add_default_voltage_points(machine) -> None:
+    """Register canonical voltage tuning points consumed by state macros.
+
+    ``build_loss_divincenzo_quam()`` already wires the latest default macro
+    instances. The test factory only needs to define the canonical points those
+    macros consume and tune a few runtime defaults on the instantiated macros.
+
+    The voltage values here are nominal placeholders; calibration nodes override
+    them at run time.
+    """
+    for qubit in machine.qubits.values():
+        dot_id = qubit.quantum_dot.id
+        qubit.add_point(VoltagePointName.INITIALIZE, {dot_id: 0.075}, duration=248)
+        qubit.add_point(VoltagePointName.MEASURE, {dot_id: -0.05}, duration=248)
+        qubit.add_point(VoltagePointName.EMPTY, {dot_id: -0.1}, duration=524)
+        qubit.add_point(VoltagePointName.EXCHANGE, {dot_id: 0.025}, duration=248)
+        qubit.macros[VoltagePointName.INITIALIZE].ramp_duration = 16
+
+    # Register canonical points on quantum-dot pairs so the latest pair macros
+    # can dispatch by enum-backed names as well.
+    for qdp in machine.quantum_dot_pairs.values():
+        dot_ids = [d.id for d in qdp.quantum_dots]
+        barrier_id = qdp.barrier_gate.id
+        qdp.add_point(
+            VoltagePointName.INITIALIZE,
+            {**{did: 0.075 for did in dot_ids}, barrier_id: 0.0},
+            duration=248,
+        )
+        qdp.add_point(
+            VoltagePointName.MEASURE,
+            {**{did: -0.05 for did in dot_ids}, barrier_id: 0.0},
+            duration=248,
+        )
+        qdp.add_point(
+            VoltagePointName.EMPTY,
+            {**{did: -0.1 for did in dot_ids}, barrier_id: 0.0},
+            duration=524,
+        )
+        qdp.add_point(
+            VoltagePointName.EXCHANGE,
+            {**{did: 0.025 for did in dot_ids}, barrier_id: 0.05},
+            duration=248,
+        )
+
+    # Register the same canonical points on qubit pairs (LDQubitPair).
+    # Qubit pairs have a different id (e.g. "q1_q2") than their underlying
+    # quantum-dot pair ("virtual_dot_1_virtual_dot_2_pair"), so macros like
+    # qubit_pair.empty() resolve to a different prefixed name ("q1_q2_empty").
+    for qp in machine.qubit_pairs.values():
+        qdp = qp.quantum_dot_pair
+        dot_ids = [d.id for d in qdp.quantum_dots]
+        barrier_id = qdp.barrier_gate.id
+        qp.add_point(
+            VoltagePointName.INITIALIZE,
+            {**{did: 0.075 for did in dot_ids}, barrier_id: 0.0},
+            duration=248,
+        )
+        qp.add_point(
+            VoltagePointName.MEASURE,
+            {**{did: -0.05 for did in dot_ids}, barrier_id: 0.0},
+            duration=248,
+        )
+        qp.add_point(
+            VoltagePointName.EMPTY,
+            {**{did: -0.1 for did in dot_ids}, barrier_id: 0.0},
+            duration=524,
+        )
+        qp.add_point(
+            VoltagePointName.EXCHANGE,
+            {**{did: 0.025 for did in dot_ids}, barrier_id: 0.0},
+            duration=248,
+        )
+        qp.add_point(
+            "CZ",
+            {**{did: 0.075 for did in dot_ids}, barrier_id: 0.2},
+            duration=248,
+        )
+        qp.macros["cz"].wait_duration = 200
+
+    # Populate default readout thresholds / projectors on sensor dots so
+    # the SensorDotMeasureMacro can perform state discrimination.
+    for qdp_name, qdp in machine.quantum_dot_pairs.items():
+        for sd in qdp.sensor_dots:
+            sd._add_readout_params(qdp_name, threshold=0.0)
+
+    for qubit in machine.qubits.values():
+        qubit.macros[VoltagePointName.MEASURE].hold_duration = 248
+        qubit.macros[SingleQubitMacroName.XY_DRIVE].pulse_family = (
+            DrivePulseName.GAUSSIAN.value
+        )

--- a/tests/qualibration_graphs/quantum_dots/calibrations/save_quam_state.py
+++ b/tests/qualibration_graphs/quantum_dots/calibrations/save_quam_state.py
@@ -1,0 +1,83 @@
+"""Save QUAM states from the test factory for sharing.
+
+Generates both the Stage-1 (BaseQuamQD) and Stage-2 (LossDiVincenzoQuam)
+machines and writes their serialised state as JSON files.
+
+Usage::
+
+    python -m tests.qualibration_graphs.quantum_dots.calibrations.save_quam_state
+
+Or run directly::
+
+    python tests/qualibration_graphs/quantum_dots/calibrations/save_quam_state.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+OUTPUT_DIR = Path(__file__).resolve().parent / "quam_state"
+
+# build_quam_wiring / reference resolution internally calls get_quam_config()
+# which triggers a config migration that is broken in the current env
+# (quam 0.4.2 ships v1_v2 but qualibrate-config expects v2_v3).
+# Patching it out at every import site lets the factory run purely in-memory.
+_tmpdir = tempfile.mkdtemp(prefix="quam_state_")
+os.environ["QUAM_STATE_PATH"] = _tmpdir
+
+
+def _fake_get_quam_config():
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        state_path=_tmpdir,
+        raise_error_missing_reference=False,
+    )
+
+
+_patches = [
+    patch("quam.config.resolvers.get_quam_config", _fake_get_quam_config),
+    patch("quam.config.get_quam_config", _fake_get_quam_config),
+    patch("quam.core.quam_classes.get_quam_config", _fake_get_quam_config),
+    patch("quam.serialisation.json.get_quam_config", _fake_get_quam_config),
+]
+for p in _patches:
+    p.start()
+
+from tests.qualibration_graphs.quantum_dots.calibrations.quam_factory import (  # noqa: E402
+    create_ld_quam,
+    create_qd_quam,
+)
+
+
+def _save_machine(machine, output_path: Path) -> None:
+    state = machine.to_dict(follow_references=False, include_defaults=False)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(state, indent=2, default=str), encoding="utf-8")
+
+
+def main() -> None:
+    stage1_path = OUTPUT_DIR / "stage1_base_quam.json"
+    stage2_path = OUTPUT_DIR / "stage2_loss_divincenzo.json"
+
+    print("Building Stage-1 BaseQuamQD …")
+    qd_machine = create_qd_quam()
+    _save_machine(qd_machine, stage1_path)
+    print(f"  Saved to {stage1_path}")
+
+    print("Building Stage-2 LossDiVincenzoQuam …")
+    ld_machine = create_ld_quam()
+    _save_machine(ld_machine, stage2_path)
+    print(f"  Saved to {stage2_path}")
+
+    print(f"\nDone. Share the {OUTPUT_DIR.name}/ directory with your colleague.")
+    for p in _patches:
+        p.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/qualibration_graphs/quantum_dots/calibrations/shared_fixtures.py
+++ b/tests/qualibration_graphs/quantum_dots/calibrations/shared_fixtures.py
@@ -1,0 +1,780 @@
+"""Shared helpers and fixtures for quantum-dot calibration tests.
+
+This module consolidates the utilities that were previously duplicated
+across the four per-suite ``conftest.py`` files:
+
+* Qualibrate configuration and logger patching
+* Calibration-library node loading
+* ActionManager register-only patching (analysis tests)
+* Parameter-override helpers
+* ``qua_dashboards`` import stub (gate-virtualization tests)
+* Machine network configuration (simulation tests)
+* Markdown / artifact generators
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import sys
+import types
+import warnings
+from functools import wraps
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, Iterator, Optional
+from unittest.mock import patch
+
+import matplotlib
+import pytest
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+# ── Repo root discovery ────────────────────────────────────────────────
+
+
+def find_repo_root(start: Path) -> Path:
+    """Find the repository root by locating ``tests/`` and ``qualibration_graphs/``."""
+    current = start
+    while current != current.parent:
+        if (current / "tests").is_dir() and (current / "qualibration_graphs").is_dir():
+            return current
+        current = current.parent
+    raise FileNotFoundError(
+        "Could not locate repo root containing tests/ and qualibration_graphs/."
+    )
+
+
+SHARED_DIR = Path(__file__).resolve().parent
+REPO_ROOT = find_repo_root(SHARED_DIR)
+CLUSTER_CONFIG_PATH = REPO_ROOT / "tests" / ".qm_cluster_config.json"
+
+_LOCAL_QD_ROOT = str(REPO_ROOT / "qualibration_graphs" / "quantum_dots")
+if _LOCAL_QD_ROOT not in sys.path:
+    sys.path.insert(0, _LOCAL_QD_ROOT)
+_local_cu_path = str(
+    REPO_ROOT / "qualibration_graphs" / "quantum_dots" / "calibration_utils"
+)
+_cu_mod = sys.modules.get("calibration_utils")
+if (
+    _cu_mod is not None
+    and hasattr(_cu_mod, "__path__")
+    and _local_cu_path not in list(_cu_mod.__path__)
+):
+    _cu_mod.__path__.insert(0, _local_cu_path)
+
+
+# ── Cache / logger helpers ─────────────────────────────────────────────
+
+
+def setup_test_cache(cache_root: Path) -> None:
+    """Create cache directories and set env vars for matplotlib/qualibrate."""
+    cache_root.mkdir(parents=True, exist_ok=True)
+    os.environ.setdefault("MPLCONFIGDIR", str(cache_root / "matplotlib"))
+    os.environ.setdefault("QUALIBRATE_LOG_DIR", str(cache_root / "qualibrate"))
+
+
+def patch_qualibrate_logger(cache_root: Path) -> None:
+    """Force qualibrate file logging into the repo-local pytest cache."""
+    try:
+        import qualibrate.utils.logger_m as logger_m
+    except Exception:
+        try:
+            import qualibrate.core.utils.logger_m as logger_m
+        except Exception:
+            return
+
+    log_dir = cache_root / "qualibrate" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    def _local_log_filepath() -> Path:
+        return log_dir / "qualibrate.log"
+
+    logger_m.LazyInitLogger.get_log_filepath = staticmethod(_local_log_filepath)
+
+
+# ── Qualibrate configuration ──────────────────────────────────────────
+
+
+def configure_qualibrate(library_root: Path) -> None:
+    """Best-effort configuration of Qualibrate runner settings."""
+    try:
+        from qualibrate.config import config as qualibrate_config
+    except Exception:
+        return
+    try:
+        qualibrate_config.set("runner-calibration-library-folder", str(library_root))
+        qualibrate_config.set(
+            "runner-calibration-library-resolver",
+            "qualibrate.QualibrationLibrary",
+        )
+    except Exception:
+        return
+
+
+# ── Node loading ───────────────────────────────────────────────────────
+
+
+def load_library_node(node_name: str, library_root: Path) -> Any:
+    """Load a calibration node by directly importing its module file.
+
+    Uses register-only patching so that ``@node.run_action`` decorators
+    only *register* the action without eagerly executing it (qualibrate
+    >= 1.1 executes actions at decoration time by default).
+
+    Raises on any error so that test failures are visible rather than
+    silently skipped.
+    """
+    if not library_root.exists():
+        pytest.fail(f"Calibration library not found at {library_root}")
+
+    node_file = library_root / f"{node_name}.py"
+    if not node_file.exists():
+        pytest.fail(f"Node file '{node_name}.py' does not exist in {library_root}")
+
+    parent_dir = str(library_root.parent)
+    if parent_dir not in sys.path:
+        sys.path.insert(0, parent_dir)
+    cal_utils_dir = str(library_root.parents[1])
+    if cal_utils_dir not in sys.path:
+        sys.path.insert(0, cal_utils_dir)
+
+    mod_name = f"_test_node_{node_name}"
+    spec = spec_from_file_location(mod_name, node_file)
+    if spec is None or spec.loader is None:
+        pytest.fail(f"Could not create import spec for {node_file}")
+    mod = module_from_spec(spec)
+
+    with patch_action_manager_register_only():
+        spec.loader.exec_module(mod)
+
+    node = getattr(mod, "node", None)
+    if node is None:
+        pytest.fail(f"Module {node_file} loaded but has no 'node' attribute")
+    if getattr(node, "filepath", None) is None:
+        node.filepath = node_file
+    return node
+
+
+def reimport_node_to_register_actions(node_name: str, library_root: Path) -> Any | None:
+    """Re-import the node module to get run_action handlers registered.
+
+    Library scanning uses inspection mode and stops before decorators run,
+    so the scanned node has no registered actions.
+    """
+    node_file = library_root / f"{node_name}.py"
+    if not node_file.exists():
+        return None
+    mod_name = f"_analysis_node_{node_name}"
+    spec = spec_from_file_location(mod_name, node_file)
+    if spec is None or spec.loader is None:
+        return None
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return getattr(mod, "node", None)
+
+
+# ── ActionManager register-only patching ───────────────────────────────
+
+
+def patch_action_manager_register_only():
+    """Patch ``ActionManager.register_action`` to only register, not execute.
+
+    Returns a context manager that patches all discoverable ActionManager
+    classes (qualibrate exposes the class under both a legacy path and a
+    ``core`` path; they can be distinct classes, so we patch both).
+    """
+    am_classes = []
+    Action = None
+    try:
+        from qualibrate.core.runnables.run_action.action import Action as _A
+        from qualibrate.core.runnables.run_action.action_manager import (
+            ActionManager as _AM,
+        )
+
+        Action = _A
+        am_classes.append(_AM)
+    except ImportError:
+        pass
+    try:
+        from qualibrate.runnables.run_action.action import Action as _A2
+        from qualibrate.runnables.run_action.action_manager import ActionManager as _AM2
+
+        if Action is None:
+            Action = _A2
+        if _AM2 not in am_classes:
+            am_classes.append(_AM2)
+    except ImportError:
+        pass
+
+    if not am_classes or Action is None:
+        raise ImportError("Cannot import ActionManager from qualibrate")
+
+    def _register_only(self, node, func=None, *, skip_if=False):
+        def decorator(f):
+            action = Action(f, self)
+            self.actions[f.__name__] = action
+
+            @wraps(f)
+            def wrapper(*args, **kwargs):
+                return self.run_action(f.__name__, node, *args, **kwargs)
+
+            return wrapper
+
+        return decorator if func is None else decorator(func)
+
+    from contextlib import ExitStack
+
+    class _MultiPatch:
+        def __init__(self):
+            self._stack = ExitStack()
+
+        def __enter__(self):
+            for cls in am_classes:
+                self._stack.enter_context(
+                    patch.object(cls, "register_action", _register_only)
+                )
+            return self
+
+        def __exit__(self, *exc):
+            return self._stack.__exit__(*exc)
+
+    return _MultiPatch()
+
+
+def call_node_action(node: Any, action_name: str) -> None:
+    """Call a registered run_action on *node*."""
+    action_manager = getattr(node, "_action_manager", None)
+    if action_manager is not None:
+        actions = getattr(action_manager, "actions", {})
+        action = actions.get(action_name)
+        if action is not None:
+            try:
+                action.execute_run_action(node)
+            except Exception as exc:
+                warnings.warn(f"Action '{action_name}' raised: {exc}")
+            return
+    pytest.fail(
+        f"Node {getattr(node, 'name', '?')} has no registered "
+        f"run_action '{action_name}'."
+    )
+
+
+# ── Parameter / metadata helpers ───────────────────────────────────────
+
+
+def apply_param_overrides(node: Any, overrides: Optional[Dict[str, Any]]) -> None:
+    """Apply a dict of parameter overrides to a calibration node."""
+    if not overrides:
+        return
+    params = getattr(node, "parameters", None)
+    if params is None:
+        return
+    for key, value in overrides.items():
+        if hasattr(params, key):
+            setattr(params, key, value)
+
+
+def get_parameters_dict(node: Any) -> Dict[str, Any]:
+    """Extract a flat ``{name: value}`` dict from a node's parameters."""
+    params_obj = getattr(node, "parameters", None)
+    params: Dict[str, Any] = {}
+    if params_obj is None:
+        return params
+    if hasattr(type(params_obj), "model_fields"):
+        for name in type(params_obj).model_fields:
+            try:
+                params[name] = getattr(params_obj, name)
+            except Exception:
+                pass
+    else:
+        for name in dir(params_obj):
+            if name.startswith("_"):
+                continue
+            try:
+                val = getattr(params_obj, name)
+                if not callable(val):
+                    params[name] = val
+            except Exception:
+                pass
+    return params
+
+
+# ── Machine network configuration (simulation tests) ──────────────────
+
+
+def configure_machine_network(machine) -> bool:
+    """Populate ``machine.network`` from env vars or cluster config file."""
+    network = getattr(machine, "network", None)
+    if network is None:
+        return False
+
+    host = os.environ.get("QM_HOST")
+    cluster_name = os.environ.get("QM_CLUSTER_NAME")
+
+    if not host and CLUSTER_CONFIG_PATH.exists():
+        try:
+            data = json.loads(CLUSTER_CONFIG_PATH.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                host = host or data.get("host")
+                cluster_name = cluster_name or data.get("cluster_name")
+        except Exception:
+            pass
+
+    if not host:
+        return False
+
+    try:
+        network["host"] = host
+        if cluster_name:
+            network["cluster_name"] = cluster_name
+    except Exception:
+        return False
+    return True
+
+
+# ── Cloud (SaaS) simulator helpers ────────────────────────────────────
+
+_SAAS_CREDENTIALS_CANDIDATES = [
+    REPO_ROOT / ".qm_saas_credentials.json",
+    REPO_ROOT / "quam-builder" / ".qm_saas_credentials.json",
+    Path.home() / ".qm_saas_credentials.json",
+]
+
+
+def find_saas_credentials() -> Optional[Path]:
+    """Return the first existing QM SaaS credentials file, or None."""
+    for path in _SAAS_CREDENTIALS_CANDIDATES:
+        if path.is_file():
+            return path
+    return None
+
+
+def load_saas_credentials(path: Optional[Path] = None) -> Optional[Dict[str, str]]:
+    """Load SaaS credentials from *path* or the first discovered candidate.
+
+    Returns a dict with at least ``email`` and ``password`` keys, or None.
+    """
+    creds_path = path or find_saas_credentials()
+    if creds_path is None:
+        return None
+    try:
+        data = json.loads(creds_path.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and "email" in data and "password" in data:
+            return data
+    except Exception:
+        pass
+    return None
+
+
+@contextlib.contextmanager
+def cloud_simulator_qmm(credentials: Optional[Dict[str, str]] = None) -> Iterator:
+    """Context manager that yields a QMM connected to a QM SaaS cloud simulator.
+
+    Usage::
+
+        with cloud_simulator_qmm() as qmm:
+            job = qmm.simulate(config, program, SimulationConfig(duration=1000))
+            job.wait_until("Done", 300)
+            samples = job.get_simulated_samples()
+
+    Raises ``ImportError`` if ``qm_saas`` is not installed, and ``RuntimeError``
+    if no credentials file can be found.
+    """
+    try:
+        import qm_saas  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise ImportError(
+            "Cloud simulation requires the `qm_saas` package. "
+            "Install it or pass use_cloud=False to fall back to OPX simulation."
+        ) from exc
+
+    from qm import QuantumMachinesManager
+
+    creds = credentials or load_saas_credentials()
+    if creds is None:
+        raise RuntimeError(
+            "No QM SaaS credentials found. Add a .qm_saas_credentials.json file "
+            "to the repo root or pass use_cloud=False to use OPX simulation."
+        )
+
+    email = creds["email"]
+    password = creds["password"]
+    host = creds.get("host", "qm-saas.dev.quantum-machines.co")
+
+    client = qm_saas.QmSaas(email=email, password=password, host=host)
+    client.close_all()
+    with client.simulator(client.latest_version()) as instance:
+        qmm = QuantumMachinesManager(
+            host=instance.host,
+            port=instance.port,
+            connection_headers=instance.default_connection_headers,
+        )
+        yield qmm
+
+
+# ── quam_config stub ───────────────────────────────────────────────────
+
+
+def ensure_quam_config_stub(machine) -> None:
+    """Ensure ``quam_config.Quam.load()`` returns *machine*.
+
+    Injects (or updates) a stub ``quam_config`` module in ``sys.modules``.
+    Can be called multiple times; the most recent *machine* wins.
+    """
+
+    class QuamStub:
+        @staticmethod
+        def load(*args, **kwargs):
+            return machine
+
+    existing = sys.modules.get("quam_config")
+    if existing is not None:
+        existing.Quam = QuamStub
+        if not hasattr(existing, "QubitQuam"):
+            existing.QubitQuam = QuamStub
+        return
+
+    stub = types.ModuleType("quam_config")
+    stub.Quam = QuamStub
+    stub.QubitQuam = QuamStub
+    sys.modules["quam_config"] = stub
+
+
+# ── qua_dashboards import stub ─────────────────────────────────────────
+
+
+def ensure_qua_dashboards_stub() -> None:
+    """Inject a minimal ``qua_dashboards`` stub when optional UI deps are missing."""
+    if "qua_dashboards" in sys.modules:
+        return
+
+    qua_dashboards = ModuleType("qua_dashboards")
+    video_mode = ModuleType("qua_dashboards.video_mode")
+    voltage_control = ModuleType("qua_dashboards.voltage_control")
+    core = ModuleType("qua_dashboards.core")
+    virtual_gates = ModuleType("qua_dashboards.virtual_gates")
+
+    class _Dummy:
+        def __init__(self, *a, **kw):
+            pass
+
+    class _ScanModes:
+        class SwitchRasterScan:
+            pass
+
+        class RasterScan:
+            pass
+
+        class SpiralScan:
+            pass
+
+    video_mode.VideoModeComponent = _Dummy
+    video_mode.OPXDataAcquirer = _Dummy
+    video_mode.scan_modes = _ScanModes
+    voltage_control.VoltageControlComponent = _Dummy
+    core.build_dashboard = lambda *a, **kw: type("_App", (), {"server": None})()
+    virtual_gates.VirtualLayerEditor = _Dummy
+    virtual_gates.ui_update = lambda *a, **kw: None
+
+    qua_dashboards.video_mode = video_mode
+    qua_dashboards.voltage_control = voltage_control
+    qua_dashboards.core = core
+    qua_dashboards.virtual_gates = virtual_gates
+
+    for name, mod in [
+        ("qua_dashboards", qua_dashboards),
+        ("qua_dashboards.video_mode", video_mode),
+        ("qua_dashboards.voltage_control", voltage_control),
+        ("qua_dashboards.core", core),
+        ("qua_dashboards.virtual_gates", virtual_gates),
+    ]:
+        sys.modules[name] = mod
+
+
+# ── QM connectivity error detection ───────────────────────────────────
+
+
+def is_qm_connectivity_error(exc: Exception) -> bool:
+    """Return True when the error looks like an unreachable QM cluster."""
+    msg = str(exc)
+    markers = (
+        "QmServerDetectionError",
+        "Failed to detect to QuantumMachines server",
+        "All connection attempts failed",
+        "Connection refused",
+        "timed out",
+        "Name or service not known",
+    )
+    return any(m in msg for m in markers)
+
+
+# ── Fixture helpers (not actual pytest fixtures — used by conftest) ────
+
+
+def make_markdown_generator_sim():
+    """Return a callable that generates README.md for a simulation node."""
+
+    def _generate(node, parameters_dict, artifacts_dir):
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        params_table = [
+            "| Parameter | Value | Description |",
+            "|-----------|-------|-------------|",
+        ]
+        for name, value in parameters_dict.items():
+            doc = ""
+            node_params = getattr(node, "parameters", None)
+            if node_params is not None and hasattr(node_params, "__class__"):
+                for cls in node_params.__class__.__mro__:
+                    if hasattr(cls, "__annotations__") and name in cls.__annotations__:
+                        if hasattr(cls, "__pydantic_fields__"):
+                            fi = cls.__pydantic_fields__.get(name)
+                            if fi and fi.description:
+                                doc = fi.description
+                                break
+            params_table.append(f"| `{name}` | `{value}` | {doc} |")
+
+        content = (
+            f"# {getattr(node, 'name', 'Unknown Node')}\n\n"
+            f"## Description\n\n"
+            f"{getattr(node, 'description', 'No description available')}\n\n"
+            f"## Parameters\n\n"
+            + "\n".join(params_table)
+            + "\n\n## Simulation Output\n\n"
+            "![Simulation](simulation.png)\n\n"
+            "---\n*Generated by simulation test infrastructure*\n"
+        )
+        output_path = artifacts_dir / "README.md"
+        output_path.write_text(content, encoding="utf-8")
+        return output_path
+
+    return _generate
+
+
+def make_save_simulation_plot():
+    """Return a callable that saves simulated samples to PNG."""
+
+    def _save(simulated_output, artifacts_dir, title="Simulated Samples"):
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+        if isinstance(simulated_output, dict):
+            fig = simulated_output.get("figure")
+            if fig is not None and hasattr(fig, "savefig"):
+                output_path = artifacts_dir / "simulation.png"
+                fig.savefig(output_path, dpi=200)
+                plt.close(fig)
+                return output_path
+            simulated_output = simulated_output.get("samples", simulated_output)
+
+        simulated_samples = simulated_output
+        if hasattr(simulated_output, "get_simulated_samples"):
+            simulated_output.wait_until("Done", 480)
+            simulated_samples = simulated_output.get_simulated_samples()
+
+        con_names = sorted(
+            name for name in dir(simulated_samples) if name.startswith("con")
+        )
+        if not con_names:
+            pytest.skip("No simulated analog connections found to plot.")
+
+        con = getattr(simulated_samples, con_names[0])
+        if not hasattr(con, "plot"):
+            pytest.skip("Simulated connection does not support plotting.")
+
+        con.plot()
+        plt.title(title)
+        plt.tight_layout()
+        output_path = artifacts_dir / "simulation.png"
+        plt.savefig(output_path, dpi=200)
+        plt.close()
+        return output_path
+
+    return _save
+
+
+def make_save_analysis_plot():
+    """Return a callable that saves a matplotlib figure to the artifacts dir."""
+
+    def _save(fig, artifacts_dir, filename="simulation.png"):
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        output_path = artifacts_dir / filename
+        fig.savefig(output_path, dpi=200)
+        fig.savefig(output_path.with_suffix(".svg"))
+        plt.close(fig)
+        return output_path
+
+    return _save
+
+
+# ── Execute-test helpers ───────────────────────────────────────────────
+
+
+def _diff_dicts(
+    before: Dict[str, Any], after: Dict[str, Any], prefix: str = ""
+) -> list:
+    """Recursively compare two nested dicts, returning changed leaf entries.
+
+    Returns a list of ``(dotted_key, before_value, after_value)`` tuples.
+    Keys starting with ``_`` or equal to ``__class__`` are skipped.
+    """
+    changes: list = []
+    all_keys = set(before) | set(after)
+    for key in sorted(all_keys):
+        if isinstance(key, str) and (key.startswith("_") or key == "__class__"):
+            continue
+        path = f"{prefix}.{key}" if prefix else str(key)
+        b_val = before.get(key)
+        a_val = after.get(key)
+        if isinstance(b_val, dict) and isinstance(a_val, dict):
+            changes.extend(_diff_dicts(b_val, a_val, path))
+        elif b_val != a_val:
+            changes.append((path, b_val, a_val))
+    return changes
+
+
+def save_execute_figures(node, artifacts_dir: Path) -> list:
+    """Extract and save all figures from a node's results after execution.
+
+    Returns a list of saved filenames (relative to *artifacts_dir*).
+    """
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    saved: list = []
+    results = getattr(node, "results", None) or {}
+
+    snapshot_idx = getattr(node, "snapshot_idx", None)
+    prefix = f"snapshot{snapshot_idx}_" if snapshot_idx is not None else ""
+
+    single_fig = results.get("figure")
+    if single_fig is not None and hasattr(single_fig, "savefig"):
+        fname = f"{prefix}figure.png"
+        single_fig.savefig(artifacts_dir / fname, dpi=200)
+        plt.close(single_fig)
+        saved.append(fname)
+
+    figures = results.get("figures")
+    if isinstance(figures, dict):
+        for name, fig in figures.items():
+            if fig is not None and hasattr(fig, "savefig"):
+                safe_name = str(name).replace("/", "_").replace(" ", "_")
+                fname = f"{prefix}{safe_name}.png"
+                fig.savefig(artifacts_dir / fname, dpi=200)
+                plt.close(fig)
+                saved.append(fname)
+
+    return saved
+
+
+def make_markdown_generator_exec():
+    """Return a callable that generates README.md for an execute-test node."""
+
+    def _generate(
+        node,
+        parameters_dict: Dict[str, Any],
+        artifacts_dir: Path,
+        figures_saved: list,
+        fit_results: Dict[str, Any],
+        state_diff: list,
+        metadata: Dict[str, Any],
+    ) -> Path:
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+        # -- Parameters table (skip Pydantic internals) --
+        _SKIP_PARAMS = {
+            "model_fields",
+            "model_config",
+            "model_computed_fields",
+            "model_extra",
+            "model_fields_set",
+            "targets",
+            "targets_name",
+        }
+        params_table = [
+            "| Parameter | Value | Description |",
+            "|-----------|-------|-------------|",
+        ]
+        node_params = getattr(node, "parameters", None)
+        for name, value in parameters_dict.items():
+            if name in _SKIP_PARAMS:
+                continue
+            doc = ""
+            if node_params is not None and hasattr(node_params, "__class__"):
+                for cls in node_params.__class__.__mro__:
+                    if hasattr(cls, "__annotations__") and name in cls.__annotations__:
+                        if hasattr(cls, "__pydantic_fields__"):
+                            fi = cls.__pydantic_fields__.get(name)
+                            if fi and fi.description:
+                                doc = fi.description
+                                break
+            params_table.append(f"| `{name}` | `{value}` | {doc} |")
+
+        sections = [
+            f"# {getattr(node, 'name', 'Unknown Node')}",
+            "",
+            "## Description",
+            "",
+            getattr(node, "description", "No description available"),
+            "",
+            "## Parameters",
+            "",
+            *params_table,
+        ]
+
+        # -- Figures --
+        if figures_saved:
+            sections += ["", "## Execution Output", ""]
+            for fname in figures_saved:
+                label = fname.rsplit(".", 1)[0].replace("_", " ").title()
+                sections.append(f"![{label}]({fname})")
+            sections.append("")
+
+        # -- Fit results --
+        if fit_results:
+            sections += ["", "## Fit Results", ""]
+            for target_name, params in fit_results.items():
+                sections.append(f"### {target_name}")
+                sections += [
+                    "| Parameter | Value |",
+                    "|-----------|-------|",
+                ]
+                if isinstance(params, dict):
+                    for k, v in params.items():
+                        sections.append(f"| `{k}` | `{v}` |")
+                sections.append("")
+
+        # -- State updates --
+        if state_diff:
+            sections += ["", "## State Updates", ""]
+            sections += [
+                "| Parameter | Before | After |",
+                "|-----------|--------|-------|",
+            ]
+            for key, before, after in state_diff:
+                sections.append(f"| `{key}` | `{before}` | `{after}` |")
+            sections.append("")
+
+        # -- Metadata --
+        if metadata:
+            sections += ["", "## Metadata", ""]
+            sections += [
+                "| Key | Value |",
+                "|-----|-------|",
+            ]
+            for k, v in metadata.items():
+                sections.append(f"| {k} | {v} |")
+            sections.append("")
+
+        sections += [
+            "---",
+            "*Generated by execute test infrastructure*",
+            "",
+        ]
+
+        content = "\n".join(sections)
+        output_path = artifacts_dir / "README.md"
+        output_path.write_text(content, encoding="utf-8")
+        return output_path
+
+    return _generate


### PR DESCRIPTION
## Summary
- Adds the `tests/qualibration_graphs/quantum_dots/calibrations/` test scaffolding that currently only exists on `final-eval-state`: `quam_factory.py`, `save_quam_state.py`, `shared_fixtures.py`, and three `loss_divincenzo` test cases (`test_05d_charge_stability_demo.py`, `test_10b_time_rabi_chevron.py`, `test_simulated_video_mode_quam_factory.py`).
- This directory does not exist on `release/nightly` yet; content was cherry-picked from `final-eval-state` (which has diverged far more broadly) rather than merging that branch wholesale.

## Test plan
- [ ] Run the new/existing tests under `tests/qualibration_graphs/quantum_dots/calibrations/` against `release/nightly`'s current `quantum_dots` state to confirm they pass here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)