### PR TITLE
Upgrade resonator spectroscopy fitting to be robust for bring-up and modular for routine use

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/__init__.py
@@ -1,4 +1,4 @@
-from .analysis import fit_raw_data, log_fitted_results, process_raw_dataset
+from .analysis import FitParameters, fit_raw_data, log_fitted_results, process_raw_dataset
 from .parameters import Parameters
 from .plotting import (
     plot_raw_amplitude_with_fit,
@@ -9,6 +9,7 @@ from .plotting import (
 
 __all__ = [
     "Parameters",
+    "FitParameters",
     "process_raw_dataset",
     "fit_raw_data",
     "log_fitted_results",

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/__init__.py
@@ -1,6 +1,11 @@
+from .analysis import fit_raw_data, log_fitted_results, process_raw_dataset
 from .parameters import Parameters
-from .analysis import process_raw_dataset, fit_raw_data, log_fitted_results
-from .plotting import plot_raw_phase, plot_raw_amplitude_with_fit
+from .plotting import (
+    plot_raw_amplitude_with_fit,
+    plot_raw_phase,
+    plot_detrended_phase,
+    plot_iq_circle,
+)
 
 __all__ = [
     "Parameters",
@@ -9,4 +14,6 @@ __all__ = [
     "log_fitted_results",
     "plot_raw_phase",
     "plot_raw_amplitude_with_fit",
+    "plot_detrended_phase",
+    "plot_iq_circle",
 ]

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
@@ -344,12 +344,7 @@ def _select_fit_outputs(
     centre_inside_fit_window: bool = fit_win_lo <= f0_out <= fit_win_hi
 
     success_shape: bool = bool(
-        fit_trusted
-        and good_r2
-        and fwhm_in_range
-        and fwhm_not_too_broad
-        and contrast_ok
-        and centre_inside_fit_window
+        fit_trusted and good_r2 and fwhm_in_range and fwhm_not_too_broad and contrast_ok and centre_inside_fit_window
     )
 
     return SelectedFitOutputs(

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
@@ -1,105 +1,622 @@
 import logging
-from dataclasses import dataclass
-from typing import Tuple, Dict
+import warnings
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
 import numpy as np
 import xarray as xr
+from numpy.typing import NDArray
+from scipy.ndimage import median_filter
+from scipy.optimize import curve_fit
+from scipy.signal import find_peaks, peak_widths, savgol_filter
 
 from qualibrate import QualibrationNode
 from qualibration_libs.data import add_amplitude_and_phase, convert_IQ_to_V
-from qualibration_libs.analysis import peaks_dips
+
+
+def lorentzian_dip_linbg(
+    f: NDArray[np.float64],
+    f0: float,
+    fwhm: float,
+    amp: float,
+    bg0: float,
+    bg1: float
+) -> NDArray[np.float64]:
+    """Inverted Lorentzian with linear background.
+
+    R(f) = [bg0 + bg1*(f - fc)] - amp / [1 + ((f - f0)/(fwhm/2))^2]
+
+    fc is the centre of the frequency array so that bg1 has units of V/Hz
+    without absorbing a large offset into bg0.
+    """
+    fc = f.mean()
+    return (bg0 + bg1 * (f - fc)) - amp / (1 + ((f - f0) / (fwhm / 2)) ** 2)
+
+
+def lorentzian_dip_quadbg(
+    f: NDArray[np.float64],
+    f0: float,
+    fwhm: float, amp: float,
+    bg0: float,
+    bg1: float,
+    bg2: float
+) -> NDArray[np.float64]:
+    """Inverted Lorentzian with quadratic background (curved / bowl baselines)."""
+    fc = f.mean()
+    x = f - fc
+    return (bg0 + bg1 * x + bg2 * x * x) - amp / (1 + ((f - f0) / (fwhm / 2)) ** 2)
+
+
+def find_dip_candidates(
+    freqs: NDArray[np.float64],
+    smoothed: NDArray[np.float64],
+    noise_sigma: float,
+    *,
+    min_dip_snr: float = 6.0,
+    max_dip_width_hz: float = 22.5e6,
+    edge_fraction: float = 0.02,
+) -> list[dict[str, int | float]]:
+    """Noise-relative, background-free dip candidates on an arbitrary-width scan.
+
+    1. Remove broad structure (cable ripple, bowl) with a rolling-median
+       baseline (~8 MHz window): resonator dips (<= a few MHz) pass through,
+       ripple minima (>= tens of MHz) are levelled — so their fake prominence
+       disappears BEFORE significance is measured.
+    2. ``find_peaks`` on the inverted baseline-subtracted trace with prominence
+       >= ``min_dip_snr`` x per-point noise sigma (statistical existence, not a
+       range fraction).
+    3. Keep only candidates whose half-prominence width looks like a resonator
+       (<= ``max_dip_width_hz``).
+
+    Returns a list of dicts ``{idx, f, prom_snr, width_hz}`` sorted by
+    descending prominence (may be empty).
+    """
+    freqs = np.asarray(freqs, dtype=float)
+    smoothed = np.asarray(smoothed, dtype=float)
+    N = len(smoothed)
+    step = float(np.median(np.abs(np.diff(freqs)))) if N > 1 else 1e5
+    edge = max(1, int(N * edge_fraction))
+    sigma = max(float(noise_sigma), 1e-15)
+
+    bl_win = max(int(round(8e6 / step)) | 1, 9)
+    bl_win = min(bl_win, max(N // 3 * 2 - 1, 9))
+    baseline = median_filter(smoothed, size=bl_win, mode="nearest")
+    detr = smoothed - baseline
+
+    pk, props = find_peaks(-detr, prominence=min_dip_snr * sigma)
+    if len(pk) == 0:
+        return []
+    widths = peak_widths(-detr, pk, rel_height=0.5)[0] * step
+    out = []
+    for p, prom, w in zip(pk, props["prominences"], widths):
+        if p < edge or p > N - 1 - edge:
+            continue
+        if w > max_dip_width_hz:
+            continue
+        out.append(dict(idx=int(p), f=float(freqs[p]), prom_snr=float(prom / sigma), width_hz=float(w)))
+    out.sort(key=lambda c: -c["prom_snr"])
+    return out
+
+
+def _smooth_and_estimate_noise(
+    amplitude: NDArray[np.float64], smooth_window: int
+) -> tuple[NDArray[np.float64], float]:
+    """Savgol-smooth the trace and estimate the per-point noise sigma from the residual (robust MAD)."""
+    N = len(amplitude)
+    win = min(smooth_window, N // 3 * 2 - 1)
+    win = win if win % 2 == 1 else win - 1
+    win = max(win, 5)
+    try:
+        smoothed = savgol_filter(amplitude, win, 3)
+    except Exception:
+        smoothed = amplitude.copy()
+    resid = amplitude - smoothed
+    noise_sigma = 1.4826 * float(np.median(np.abs(resid - np.median(resid)))) + 1e-15
+    return smoothed, noise_sigma
+
+
+def _estimate_initial_fwhm(
+    freqs: NDArray[np.float64],
+    smoothed: NDArray[np.float64],
+    f0_init: float,
+    fallback_width_hz: float,
+    detrend_window_mhz: float,
+    step: float,
+) -> tuple[float, float]:
+    """Linearly detrend a fixed window around f0_init and measure the half-max width there.
+
+    A fixed-size window (rather than one scaled to a not-yet-known FWHM) keeps
+    this estimate robust on curved/bowl baselines. Falls back to the
+    candidate's width_hz if the half-max crossings run off either edge of the
+    window.
+
+    Returns (fwhm_init, depth_d) where depth_d is the detrended dip depth,
+    kept for the contrast fallback in case the full fit later turns out
+    unusable.
+    """
+    N = len(freqs)
+    detr_half = detrend_window_mhz * 1e6 / 2.0
+    detr_mask = (freqs >= f0_init - detr_half) & (freqs <= f0_init + detr_half)
+    if detr_mask.sum() < 8:
+        detr_mask = np.ones(N, dtype=bool)
+    f_d = freqs[detr_mask]
+    a_d = smoothed[detr_mask]
+    b0d = (a_d[0] + a_d[-1]) / 2.0
+    b1d = (a_d[-1] - a_d[0]) / (f_d[-1] - f_d[0]) if len(f_d) > 1 else 0.0
+    a_detr = a_d - (b0d + b1d * (f_d - f_d.mean()))
+    di2 = int(np.argmin(a_detr))
+    depth_d = -float(a_detr[di2])
+    hd2 = a_detr[di2] + depth_d / 2.0
+    lc2 = np.where(a_detr[: di2 + 1] >= hd2)[0]
+    rc2 = np.where(a_detr[di2:] >= hd2)[0]
+    if len(lc2) and len(rc2):
+        fwhm_init = f_d[di2 + rc2[0]] - f_d[lc2[-1]]
+    else:
+        fwhm_init = max(fallback_width_hz, 4 * step)
+    return max(float(fwhm_init), 2 * step), depth_d
+
+
+def _fit_lorentzian_dip_ladder(
+    freqs: NDArray[np.float64],
+    amplitude: NDArray[np.float64],
+    f0_init: float,
+    fwhm_init: float,
+    A_raw: float,
+    step: float,
+    window_fwhm_factor: float,
+    min_window_mhz: float,
+) -> dict[str, Any] | None:
+    """Try a small ladder of fit windows/models, keep whichever gives the best R².
+
+    Tries, in order: a linear background at the standard window, the same
+    model at a NARROWER window (kills the leverage of curved baselines), and
+    a quadratic background at the standard window (fits the curvature
+    instead). Returns None if every attempt lacked enough points or failed to
+    converge.
+    """
+    tries = (
+        (max(fwhm_init * window_fwhm_factor / 2.0, min_window_mhz * 1e6 / 2.0), lorentzian_dip_linbg, 5),
+        (max(fwhm_init * window_fwhm_factor / 4.0, min_window_mhz * 1e6 / 4.0), lorentzian_dip_linbg, 5),
+        (max(fwhm_init * window_fwhm_factor / 2.0, min_window_mhz * 1e6 / 2.0), lorentzian_dip_quadbg, 6),
+    )
+    best = None
+    for half_win, model, npar in tries:
+        fit_mask = (freqs >= f0_init - half_win) & (freqs <= f0_init + half_win)
+        if fit_mask.sum() < npar + 3:
+            continue
+        f_win = freqs[fit_mask]
+        a_win = amplitude[fit_mask]
+        b0 = (a_win[0] + a_win[-1]) / 2.0
+        b1 = (a_win[-1] - a_win[0]) / (f_win[-1] - f_win[0]) if len(f_win) > 1 else 0.0
+        Ar_win = a_win.max() - a_win.min()
+        p0 = [f0_init, fwhm_init, Ar_win, b0, b1] + ([0.0] if npar == 6 else [])
+        lb = [f_win.min(), 2 * step, 0, -np.inf, -np.inf] + ([-np.inf] if npar == 6 else [])
+        ub = [f_win.max(), f_win.max() - f_win.min(), max(A_raw * 5, Ar_win * 5), np.inf, np.inf] + (
+            [np.inf] if npar == 6 else []
+        )
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                popt_t, _ = curve_fit(model, f_win, a_win, p0=p0, bounds=(lb, ub), maxfev=10000)
+        except Exception:
+            continue
+        y_pred = model(f_win, *popt_t)
+        ss_res = float(np.sum((a_win - y_pred) ** 2))
+        ss_tot = float(np.sum((a_win - a_win.mean()) ** 2)) + 1e-30
+        r2_t = 1.0 - ss_res / ss_tot
+        if best is None or r2_t > best["r2"]:
+            bg_at_f0 = popt_t[3] + popt_t[4] * (popt_t[0] - f_win.mean())
+            best = dict(
+                popt=np.array(popt_t[:5], dtype=float), r2=float(r2_t),
+                f0=float(popt_t[0]), fwhm=float(popt_t[1]), amp=float(popt_t[2]),
+                contrast=float(popt_t[2] / bg_at_f0) if bg_at_f0 > 0 else 0.0,
+                f_win=(float(f_win.min()), float(f_win.max())),
+            )
+    return best
+
+
+def _select_fit_outputs(
+    best: dict[str, Any] | None,
+    f0_init: float,
+    fwhm_init: float,
+    depth_d: float,
+    smoothed: NDArray[np.float64],
+    span_hz: float,
+    r2_threshold: float,
+    max_fwhm_mhz: float,
+    min_contrast: float,
+) -> dict[str, Any]:
+    """Pick between the fit-ladder result and the raw dip estimate, then apply the strict shape gates.
+
+    A fit is only trusted if its centre landed close to the detected dip
+    (``best["f0"]`` within ``2*fwhm_init`` or 1 MHz of ``f0_init``) — otherwise
+    it ran away and the frequency/FWHM fall back to the pre-fit estimates.
+    ``success_shape`` gates on R², FWHM range, and contrast; frequency success
+    never depends on it, since the dip's existence and position were already
+    established before any fit was attempted.
+    """
+    nan5 = np.full(5, np.nan)
+    if best is not None and abs(best["f0"] - f0_init) <= max(2 * fwhm_init, 1e6):
+        f0_out, fwhm_out = best["f0"], best["fwhm"]
+        r2 = best["r2"]
+        fitted_contrast = best["contrast"]
+        popt = best["popt"]
+        fit_win_lo, fit_win_hi = best["f_win"]
+    else:
+        # Fit unusable/ran away: the dip existence and position stand on their own.
+        f0_out, fwhm_out = f0_init, fwhm_init
+        r2 = best["r2"] if best is not None else 0.0
+        fitted_contrast = depth_d / np.median(smoothed) if np.median(smoothed) > 0 else np.nan
+        popt = nan5.copy()
+        fit_win_lo, fit_win_hi = np.nan, np.nan
+
+    success_shape = bool(
+        best is not None
+        and r2 >= r2_threshold
+        and 0 < fwhm_out <= max_fwhm_mhz * 1e6
+        and fwhm_out / span_hz <= 0.50
+        and fitted_contrast >= min_contrast
+        and best["f_win"][0] <= f0_out <= best["f_win"][1]
+    )
+    return dict(
+        f0=f0_out, fwhm=fwhm_out, r2=r2, contrast=fitted_contrast,
+        popt=popt, fit_win_lo=fit_win_lo, fit_win_hi=fit_win_hi,
+        success_shape=success_shape,
+    )
+
+
+def fit_resonator(
+    freqs: NDArray[np.float64],
+    amplitude: NDArray[np.float64],
+    *,
+    override_center_hz: float | None = None,
+    override_span_hz: float | None = None,
+    window_fwhm_factor: float = 4.0,
+    min_window_mhz: float = 5.0,
+    detrend_window_mhz: float = 10.0,
+    max_fwhm_mhz: float = 15.0,
+    r2_threshold: float = 0.85,
+    min_contrast: float = 0.05,
+    edge_fraction: float = 0.02,
+    smooth_window: int = 11,
+    min_dip_snr: float = 6.0,
+    dominance: float = 2.0,
+) -> dict[str, Any]:
+    """Bring-up-grade resonator-dip fitter.
+
+    When override_center_hz and override_span_hz are provided the data is
+    pre-sliced to [center - span/2, center + span/2] before fitting, allowing
+    the user to manually constrain the fit window for problematic qubits.
+
+    Two-tier success:
+
+    * ``success`` — FREQUENCY: a statistically significant, resonator-shaped
+      dip exists (``min_dip_snr`` x noise sigma after broad-background removal)
+      and its position is delivered. Does NOT depend on R².
+    * ``success_shape`` — the fitted Lorentzian lineshape is trustworthy
+      (legacy strict gates, after a fit ladder that also tries a narrower
+      window and a quadratic background for curved baselines).
+
+    Multi-dip transparency: ``candidates`` lists every significant dip
+    (descending prominence); ``ambiguous`` is set when the second candidate is
+    within ``dominance``x of the top one — downstream must disambiguate
+    (expected-frequency prior / punch-out check), the fitter never silently
+    guesses between comparable dips.
+
+    Returns
+    -------
+    dict with keys:
+        f0, fwhm, r2, success, success_shape, ambiguous, dip_snr,
+        candidates (list of {idx, f, prom_snr, width_hz}),
+        popt (array[5] or all-NaN), edge_dip, contrast, dip_idx, reason
+    """
+    _nan5 = np.full(5, np.nan)
+    result = dict(
+        f0=np.nan, fwhm=np.nan, r2=np.nan, success=False, success_shape=False,
+        ambiguous=False, dip_snr=0.0, candidates=[],
+        popt=_nan5.copy(), edge_dip=False, contrast=np.nan, dip_idx=-1, reason="",
+        fit_win_lo=np.nan, fit_win_hi=np.nan,
+    )
+
+    freqs = np.asarray(freqs, dtype=float)
+    amplitude = np.asarray(amplitude, dtype=float)
+
+    # --- Apply manual window override if given ---
+    if override_center_hz is not None and override_span_hz is not None:
+        half = override_span_hz / 2.0
+        mask_ov = (freqs >= override_center_hz - half) & (freqs <= override_center_hz + half)
+        if mask_ov.sum() >= 8:
+            freqs = freqs[mask_ov]
+            amplitude = amplitude[mask_ov]
+
+    span_hz = freqs[-1] - freqs[0]
+    N = len(freqs)
+    if N < 16:
+        result["reason"] = "trace too short"
+        return result
+    step = float(np.median(np.abs(np.diff(freqs)))) if N > 1 else 1e5
+
+    smoothed, noise_sigma = _smooth_and_estimate_noise(amplitude, smooth_window)
+
+    # Significant dip candidates (noise-relative, background-free, width-capped)
+    candidates = find_dip_candidates(
+        freqs, smoothed, noise_sigma,
+        min_dip_snr=min_dip_snr,
+        max_dip_width_hz=1.5 * max_fwhm_mhz * 1e6,
+        edge_fraction=edge_fraction,
+    )
+    result["candidates"] = candidates
+    if not candidates:
+        result["reason"] = "no significant dip"
+        return result
+    top = candidates[0]
+    dip_idx = top["idx"]
+    result["dip_idx"] = dip_idx
+    result["dip_snr"] = top["prom_snr"]
+    result["ambiguous"] = len(candidates) > 1 and candidates[1]["prom_snr"] >= top["prom_snr"] / dominance
+    f0_init = float(freqs[dip_idx])
+    A_raw = smoothed.max() - smoothed.min()
+
+    fwhm_init, depth_d = _estimate_initial_fwhm(
+        freqs, smoothed, f0_init, top["width_hz"], detrend_window_mhz, step
+    )
+
+    best = _fit_lorentzian_dip_ladder(
+        freqs, amplitude, f0_init, fwhm_init, A_raw, step, window_fwhm_factor, min_window_mhz
+    )
+
+    outputs = _select_fit_outputs(
+        best, f0_init, fwhm_init, depth_d, smoothed, span_hz, r2_threshold, max_fwhm_mhz, min_contrast
+    )
+
+    # Refine the reported centre to the true dip minimum (asymmetric-tail
+    # bias correction; see _refine_dip_minimum).
+    f0_out = _refine_dip_minimum(freqs, smoothed, outputs["f0"], max(outputs["fwhm"], 2 * step))
+    popt = outputs["popt"]
+    if not np.any(np.isnan(popt)):
+        popt = np.array(popt, dtype=float)
+        popt[0] = f0_out
+
+    result.update(
+        f0=float(f0_out), fwhm=float(outputs["fwhm"]), r2=float(outputs["r2"]),
+        success=True,  # a significant, resonator-shaped dip exists (candidates non-empty)
+        success_shape=outputs["success_shape"],
+        popt=np.array(popt), contrast=float(outputs["contrast"]),
+        fit_win_lo=float(outputs["fit_win_lo"]), fit_win_hi=float(outputs["fit_win_hi"]),
+    )
+    return result
+
+
+def _refine_dip_minimum(
+    freqs: NDArray[np.float64], smoothed: NDArray[np.float64], f0_guess: float, fwhm_guess: float
+) -> float:
+    """Locate the true dip minimum near *f0_guess* (the visible bottom).
+
+    1. Find the smoothed-amplitude minimum within ±1.5·FWHM of f0_guess (a local
+       window so far-off edge artefacts on poor traces are ignored).
+    2. Refine to sub-step resolution with a 3-point parabolic interpolation
+       around that minimum (uses only the immediate neighbours, so it captures
+       the local bottom curvature and is NOT biased by the asymmetric tails the
+       symmetric Lorentzian was pulled toward).
+
+    Falls back to the local argmin, then to f0_guess, if the data are too sparse.
+    """
+    freqs = np.asarray(freqs, dtype=float)
+    smoothed = np.asarray(smoothed, dtype=float)
+    n = freqs.size
+    if n < 3:
+        return float(f0_guess)
+    step = abs(freqs[1] - freqs[0])
+
+    # 1. Local smoothed argmin within ±1.5*FWHM of the Lorentzian centre
+    search_half = max(1.5 * fwhm_guess, 5 * step)
+    win = (freqs >= f0_guess - search_half) & (freqs <= f0_guess + search_half)
+    if win.sum() < 3:
+        return float(f0_guess)
+    masked = np.where(win, smoothed, np.inf)
+    j = int(np.argmin(masked))
+
+    # 2. 3-point parabolic interpolation around the local minimum
+    if 0 < j < n - 1:
+        y0, y1, y2 = smoothed[j - 1], smoothed[j], smoothed[j + 1]
+        denom = y0 - 2.0 * y1 + y2
+        if denom > 0:  # concave up
+            delta = 0.5 * (y0 - y2) / denom  # offset in units of the freq step
+            if -1.0 <= delta <= 1.0:
+                return float(freqs[j] + delta * (freqs[j + 1] - freqs[j]))
+    return float(freqs[j])
 
 
 @dataclass
 class FitParameters:
-    """Stores the relevant resonator spectroscopy experiment fit parameters for a single qubit"""
+    """Stores the fitted resonator parameters for a single qubit."""
 
     frequency: float
     fwhm: float
-    success: bool
+    r2: float
+    success: bool                    # FREQUENCY success: a significant dip exists, f0 delivered
+    success_shape: bool = False      # Lorentzian lineshape trustworthy (strict gates)
+    ambiguous: bool = False          # >1 comparable dip in the window — needs disambiguation
+    dip_snr: float = 0.0             # top dip prominence / noise sigma
+    candidates: list[dict[str, int | float]] = field(default_factory=list)  # all significant dips (desc prominence)
+    fit_win_lo: float = float("nan")  # lower edge (Hz) of the window popt was actually fit on
+    fit_win_hi: float = float("nan")  # upper edge (Hz) of the window popt was actually fit on
 
 
-def log_fitted_results(fit_results: Dict, log_callable=None):
-    """
-    Logs the node-specific fitted results for all qubits from the fit results
-
-    Parameters:
-    -----------
-    fit_results : dict
-        Dictionary containing the fitted results for all qubits.
-    logger : logging.Logger, optional
-        Logger for logging the fitted results. If None, a default logger is used.
-
-    """
+def log_fitted_results(fit_results: dict[str, dict[str, Any]], log_callable: Callable[[str], None] | None = None) -> None:
+    """Log the fitted results for all qubits (three-state + ambiguity in v2)."""
     if log_callable is None:
         log_callable = logging.getLogger(__name__).info
-    for q in fit_results.keys():
-        s_qubit = f"Results for qubit {q}: "
-        s_freq = f"\tResonator frequency: {1e-9 * fit_results[q]['frequency']:.3f} GHz | "
-        s_fwhm = f"FWHM: {1e-3 * fit_results[q]['fwhm']:.1f} kHz | "
-        if fit_results[q]["success"]:
-            s_qubit += " SUCCESS!\n"
+    for q, res in fit_results.items():
+        if res["success"] and res.get("success_shape", True):
+            status = "SUCCESS!"
+        elif res["success"]:
+            status = "FREQUENCY OK (lineshape poor)"
         else:
-            s_qubit += " FAIL!\n"
-        log_callable(s_qubit + s_freq + s_fwhm)
+            status = "FAIL!"
+        if res.get("ambiguous"):
+            n = len(res.get("candidates") or [])
+            status += f"  [AMBIGUOUS: {n} comparable dips — verify vs expected freq / punch-out]"
+        log_callable(
+            f"Results for qubit {q}:  {status}\n"
+            f"\tResonator frequency: {1e-9 * res['frequency']:.4f} GHz | "
+            f"FWHM: {1e-3 * res['fwhm']:.1f} kHz | "
+            f"R²: {res['r2']:.3f} | dip SNR: {res.get('dip_snr', 0.0):.1f}"
+        )
 
 
-def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode):
+def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode) -> xr.Dataset:
+    """Convert IQ to voltage, add amplitude/phase, and attach full-frequency coordinates."""
     ds = convert_IQ_to_V(ds, node.namespace["qubits"])
     ds = add_amplitude_and_phase(ds, "detuning", subtract_slope_flag=True)
-    full_freq = np.array([ds.detuning + q.resonator.RF_frequency for q in node.namespace["qubits"]])
+    full_freq = np.array([
+        ds.detuning.values + q.resonator.RF_frequency
+        for q in node.namespace["qubits"]
+    ])
     ds = ds.assign_coords(full_freq=(["qubit", "detuning"], full_freq))
     ds.full_freq.attrs = {"long_name": "RF frequency", "units": "Hz"}
     return ds
 
 
-def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, dict[str, FitParameters]]:
+def fit_raw_data(
+    ds: xr.Dataset, node: QualibrationNode
+) -> tuple[xr.Dataset, dict[str, FitParameters]]:
+    """Fit a Lorentzian dip to each qubit's amplitude trace.
+
+    Reads re_fit_resonators / re_fit_centers_ghz / re_fit_span_mhz from
+    node.parameters to apply manual fit-window overrides for selected qubits.
+
+    Returns
+    -------
+    ds_fit : xr.Dataset
+        Per-qubit fit results with variables: f0, fwhm, r2, success, popt.
+    fit_results : dict[str, FitParameters]
     """
-    Fit the T1 relaxation time for each qubit according to ``a * np.exp(t * decay) + offset``.
+    qubits = node.namespace["qubits"]
+    params = node.parameters
 
-    Parameters:
-    -----------
-    ds : xr.Dataset
-        Dataset containing the raw data.
-    node : QualibrationNode
-        The QUAlibrate node.
+    # Build per-qubit override lookup from the three parallel lists
+    overrides: dict[str, dict[str, float]] = {}
+    re_fit_names = params.re_fit_resonators or []
+    re_fit_centers = params.re_fit_centers_ghz or []
+    re_fit_spans = params.re_fit_span_mhz or []
+    for name, center_ghz, span_mhz in zip(re_fit_names, re_fit_centers, re_fit_spans):
+        overrides[name] = {
+            "center_hz": center_ghz * 1e9,
+            "span_hz": span_mhz * 1e6,
+        }
 
-    Returns:
-    --------
-    xr.Dataset
-        Dataset containing the fit results.
-    """
-    # Fit the resonator line
-    fit_results = peaks_dips(ds.IQ_abs, "detuning")
-    # Extract the relevant fitted parameters
-    fit_data, fit_results = _extract_relevant_fit_parameters(fit_results, node)
-    return fit_data, fit_results
+    qubit_names = [q.name for q in qubits]
+    f0_vals, fwhm_vals, r2_vals, success_vals = [], [], [], []
+    shape_vals, amb_vals, snr_vals, cand_vals = [], [], [], []
+    popt_vals = []
+    fit_win_lo_vals, fit_win_hi_vals = [], []
 
+    for i, q in enumerate(qubits):
+        full_freq_q = ds.sel(qubit=q.name).full_freq.values
+        amplitude_q = ds.sel(qubit=q.name).IQ_abs.values
 
-def _extract_relevant_fit_parameters(fit: xr.Dataset, node: QualibrationNode):
-    """Add metadata to the dataset and fit results."""
-    # Add metadata to fit results
-    fit.attrs = {"long_name": "frequency", "units": "Hz"}
-    # Get the fitted resonator frequency
-    full_freq = np.array([q.resonator.RF_frequency for q in node.namespace["qubits"]])
-    res_freq = fit.position + full_freq
-    fit = fit.assign_coords(res_freq=("qubit", res_freq.data))
-    fit.res_freq.attrs = {"long_name": "resonator frequency", "units": "Hz"}
-    # Get the fitted FWHM
-    fwhm = np.abs(fit.width)
-    fit = fit.assign_coords(fwhm=("qubit", fwhm.data))
-    fit.fwhm.attrs = {"long_name": "resonator fwhm", "units": "Hz"}
-    # Assess whether the fit was successful or not
-    freq_success = np.abs(res_freq.data) < node.parameters.frequency_span_in_mhz * 1e6 + full_freq
-    fwhm_success = np.abs(fwhm.data) < node.parameters.frequency_span_in_mhz * 1e6 + full_freq
-    success_criteria = freq_success & fwhm_success
-    fit = fit.assign_coords(success=("qubit", success_criteria))
+        ov = overrides.get(q.name, {})
+        res = fit_resonator(
+            full_freq_q, amplitude_q,
+            override_center_hz=ov.get("center_hz"),
+            override_span_hz=ov.get("span_hz"),
+            min_dip_snr=getattr(params, "min_dip_snr", 6.0),
+            dominance=getattr(params, "dip_dominance", 2.0),
+        )
+
+        f0_vals.append(res["f0"])
+        fwhm_vals.append(res["fwhm"])
+        r2_vals.append(res["r2"] if not np.isnan(res["r2"]) else 0.0)
+        success_vals.append(res["success"])
+        shape_vals.append(res["success_shape"])
+        amb_vals.append(res["ambiguous"])
+        snr_vals.append(res["dip_snr"])
+        cand_vals.append(res["candidates"])
+        popt_vals.append(res["popt"])  # shape (5,) or all-NaN
+        fit_win_lo_vals.append(res["fit_win_lo"])
+        fit_win_hi_vals.append(res["fit_win_hi"])
+
+    popt_array = np.stack(popt_vals, axis=0)  # (n_qubits, 5)
+
+    ds_fit = xr.Dataset(
+        {
+            "f0": xr.DataArray(
+                f0_vals,
+                coords={"qubit": qubit_names},
+                dims="qubit",
+                attrs={"long_name": "resonator frequency", "units": "Hz"}
+            ),
+            "fwhm": xr.DataArray(
+                fwhm_vals,
+                coords={"qubit": qubit_names},
+                dims="qubit",
+                attrs={"long_name": "FWHM", "units": "Hz"}
+            ),
+            "r2": xr.DataArray(
+                r2_vals,
+                coords={"qubit": qubit_names},
+                dims="qubit",
+                attrs={"long_name": "R²"}
+            ),
+            "success": xr.DataArray(
+                success_vals,
+                coords={"qubit": qubit_names},
+                dims="qubit",
+                attrs={"long_name": "frequency success (significant dip found)"}
+            ),
+            "success_shape": xr.DataArray(
+                shape_vals,
+                coords={"qubit": qubit_names},
+                dims="qubit",
+                attrs={"long_name": "lineshape trustworthy (strict gates)"}
+            ),
+            "ambiguous": xr.DataArray(
+                amb_vals,
+                coords={"qubit": qubit_names},
+                dims="qubit",
+                attrs={"long_name": "multiple comparable dips in window"}
+            ),
+            "dip_snr": xr.DataArray(
+                snr_vals,
+                coords={"qubit": qubit_names},
+                dims="qubit",
+                attrs={"long_name": "top dip prominence / noise sigma"}
+            ),
+            "popt": xr.DataArray(
+                popt_array,
+                coords={"qubit": qubit_names, "param": np.arange(5)},
+                dims=["qubit", "param"],
+                attrs={"long_name": "fit parameters [f0, fwhm, amp, bg0, bg1]"},
+            ),
+            "fit_win_lo": xr.DataArray(
+                fit_win_lo_vals,
+                coords={"qubit": qubit_names},
+                dims="qubit",
+                attrs={"long_name": "lower edge of the window popt was fit on", "units": "Hz"}
+            ),
+            "fit_win_hi": xr.DataArray(
+                fit_win_hi_vals,
+                coords={"qubit": qubit_names},
+                dims="qubit",
+                attrs={"long_name": "upper edge of the window popt was fit on", "units": "Hz"}
+            ),
+        }
+    )
 
     fit_results = {
         q: FitParameters(
-            frequency=fit.sel(qubit=q).res_freq.values.__float__(),
-            fwhm=fit.sel(qubit=q).fwhm.values.__float__(),
-            success=fit.sel(qubit=q).success.values.__bool__(),
+            frequency=float(ds_fit.sel(qubit=q).f0.values),
+            fwhm=float(ds_fit.sel(qubit=q).fwhm.values),
+            r2=float(ds_fit.sel(qubit=q).r2.values),
+            success=bool(ds_fit.sel(qubit=q).success.values),
+            success_shape=bool(ds_fit.sel(qubit=q).success_shape.values),
+            ambiguous=bool(ds_fit.sel(qubit=q).ambiguous.values),
+            dip_snr=float(ds_fit.sel(qubit=q).dip_snr.values),
+            candidates=cand_vals[qubit_names.index(q)],
+            fit_win_lo=float(ds_fit.sel(qubit=q).fit_win_lo.values),
+            fit_win_hi=float(ds_fit.sel(qubit=q).fit_win_hi.values),
         )
-        for q in fit.qubit.values
+        for q in qubit_names
     }
-    return fit, fit_results
+    return ds_fit, fit_results

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
@@ -219,15 +219,33 @@ def _select_fit_outputs(
 ) -> dict[str, Any]:
     """Pick between the fit-ladder result and the raw dip estimate, then apply the strict shape gates.
 
-    A fit is only trusted if its centre landed close to the detected dip
+    A fit is only trusted if its center landed close to the detected dip
     (``best["f0"]`` within ``2*fwhm_init`` or 1 MHz of ``f0_init``) — otherwise
     it ran away and the frequency/FWHM fall back to the pre-fit estimates.
     ``success_shape`` gates on R², FWHM range, and contrast; frequency success
     never depends on it, since the dip's existence and position were already
     established before any fit was attempted.
     """
-    nan5 = np.full(5, np.nan)
-    if best is not None and abs(best["f0"] - f0_init) <= max(2 * fwhm_init, 1e6):
+
+    nan5: NDArray[np.float64] = np.full(5, np.nan)
+    max_allowed_drift_hz: float = max(2 * fwhm_init, 1e6)
+
+    fit_trusted: bool = False
+    if best is not None:
+        fit_centre_drift_hz: float = abs(best["f0"] - f0_init)
+
+        if fit_centre_drift_hz <= max_allowed_drift_hz:
+            fit_trusted = True
+
+    f0_out: float
+    fwhm_out: float
+    r2: float
+    fitted_contrast: float
+    popt: NDArray[np.float64]
+    fit_win_lo: float
+    fit_win_hi: float
+
+    if fit_trusted:
         f0_out, fwhm_out = best["f0"], best["fwhm"]
         r2 = best["r2"]
         fitted_contrast = best["contrast"]
@@ -237,18 +255,31 @@ def _select_fit_outputs(
         # Fit unusable/ran away: the dip existence and position stand on their own.
         f0_out, fwhm_out = f0_init, fwhm_init
         r2 = best["r2"] if best is not None else 0.0
-        fitted_contrast = depth_d / np.median(smoothed) if np.median(smoothed) > 0 else np.nan
         popt = nan5.copy()
         fit_win_lo, fit_win_hi = np.nan, np.nan
 
-    success_shape = bool(
-        best is not None
-        and r2 >= r2_threshold
-        and 0 < fwhm_out <= max_fwhm_mhz * 1e6
-        and fwhm_out / span_hz <= 0.50
-        and fitted_contrast >= min_contrast
-        and best["f_win"][0] <= f0_out <= best["f_win"][1]
+        fitted_contrast = np.nan
+        if np.median(smoothed) > 0:
+            fitted_contrast = depth_d / np.median(smoothed)
+
+    # success_shape is gated on fit_trusted (not just "best is not None") so a
+    # discarded/ran-away fit's R² and window can never grade a report that
+    # carries an all-NaN popt.
+    good_r2: bool = r2 >= r2_threshold
+    fwhm_in_range: bool = 0 < fwhm_out <= max_fwhm_mhz * 1e6
+    fwhm_not_too_broad: bool = fwhm_out / span_hz <= 0.50
+    contrast_ok: bool = fitted_contrast >= min_contrast
+    centre_inside_fit_window: bool = fit_win_lo <= f0_out <= fit_win_hi
+
+    success_shape: bool = bool(
+        fit_trusted
+        and good_r2
+        and fwhm_in_range
+        and fwhm_not_too_broad
+        and contrast_ok
+        and centre_inside_fit_window
     )
+
     return dict(
         f0=f0_out,
         fwhm=fwhm_out,

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
@@ -458,8 +458,10 @@ def log_fitted_results(
     fit_results: dict[str, dict[str, Any]], log_callable: Callable[[str], None] | None = None
 ) -> None:
     """Log the fitted results for all qubits (three-state + ambiguity in v2)."""
+
     if log_callable is None:
         log_callable = logging.getLogger(__name__).info
+
     for q, res in fit_results.items():
         if res["success"] and res.get("success_shape", True):
             status = "SUCCESS!"
@@ -467,9 +469,11 @@ def log_fitted_results(
             status = "FREQUENCY OK (lineshape poor)"
         else:
             status = "FAIL!"
+
         if res.get("ambiguous"):
             n = len(res.get("candidates") or [])
             status += f"  [AMBIGUOUS: {n} comparable dips — verify vs expected freq / punch-out]"
+            
         log_callable(
             f"Results for qubit {q}:  {status}\n"
             f"\tResonator frequency: {1e-9 * res['frequency']:.4f} GHz | "

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
@@ -15,12 +15,7 @@ from qualibration_libs.data import add_amplitude_and_phase, convert_IQ_to_V
 
 
 def lorentzian_dip_linbg(
-    f: NDArray[np.float64],
-    f0: float,
-    fwhm: float,
-    amp: float,
-    bg0: float,
-    bg1: float
+    f: NDArray[np.float64], f0: float, fwhm: float, amp: float, bg0: float, bg1: float
 ) -> NDArray[np.float64]:
     """Inverted Lorentzian with linear background.
 
@@ -34,12 +29,7 @@ def lorentzian_dip_linbg(
 
 
 def lorentzian_dip_quadbg(
-    f: NDArray[np.float64],
-    f0: float,
-    fwhm: float, amp: float,
-    bg0: float,
-    bg1: float,
-    bg2: float
+    f: NDArray[np.float64], f0: float, fwhm: float, amp: float, bg0: float, bg1: float, bg2: float
 ) -> NDArray[np.float64]:
     """Inverted Lorentzian with quadratic background (curved / bowl baselines)."""
     fc = f.mean()
@@ -98,9 +88,7 @@ def find_dip_candidates(
     return out
 
 
-def _smooth_and_estimate_noise(
-    amplitude: NDArray[np.float64], smooth_window: int
-) -> tuple[NDArray[np.float64], float]:
+def _smooth_and_estimate_noise(amplitude: NDArray[np.float64], smooth_window: int) -> tuple[NDArray[np.float64], float]:
     """Savgol-smooth the trace and estimate the per-point noise sigma from the residual (robust MAD)."""
     N = len(amplitude)
     win = min(smooth_window, N // 3 * 2 - 1)
@@ -207,8 +195,11 @@ def _fit_lorentzian_dip_ladder(
         if best is None or r2_t > best["r2"]:
             bg_at_f0 = popt_t[3] + popt_t[4] * (popt_t[0] - f_win.mean())
             best = dict(
-                popt=np.array(popt_t[:5], dtype=float), r2=float(r2_t),
-                f0=float(popt_t[0]), fwhm=float(popt_t[1]), amp=float(popt_t[2]),
+                popt=np.array(popt_t[:5], dtype=float),
+                r2=float(r2_t),
+                f0=float(popt_t[0]),
+                fwhm=float(popt_t[1]),
+                amp=float(popt_t[2]),
                 contrast=float(popt_t[2] / bg_at_f0) if bg_at_f0 > 0 else 0.0,
                 f_win=(float(f_win.min()), float(f_win.max())),
             )
@@ -259,8 +250,13 @@ def _select_fit_outputs(
         and best["f_win"][0] <= f0_out <= best["f_win"][1]
     )
     return dict(
-        f0=f0_out, fwhm=fwhm_out, r2=r2, contrast=fitted_contrast,
-        popt=popt, fit_win_lo=fit_win_lo, fit_win_hi=fit_win_hi,
+        f0=f0_out,
+        fwhm=fwhm_out,
+        r2=r2,
+        contrast=fitted_contrast,
+        popt=popt,
+        fit_win_lo=fit_win_lo,
+        fit_win_hi=fit_win_hi,
         success_shape=success_shape,
     )
 
@@ -312,10 +308,21 @@ def fit_resonator(
     """
     _nan5 = np.full(5, np.nan)
     result = dict(
-        f0=np.nan, fwhm=np.nan, r2=np.nan, success=False, success_shape=False,
-        ambiguous=False, dip_snr=0.0, candidates=[],
-        popt=_nan5.copy(), edge_dip=False, contrast=np.nan, dip_idx=-1, reason="",
-        fit_win_lo=np.nan, fit_win_hi=np.nan,
+        f0=np.nan,
+        fwhm=np.nan,
+        r2=np.nan,
+        success=False,
+        success_shape=False,
+        ambiguous=False,
+        dip_snr=0.0,
+        candidates=[],
+        popt=_nan5.copy(),
+        edge_dip=False,
+        contrast=np.nan,
+        dip_idx=-1,
+        reason="",
+        fit_win_lo=np.nan,
+        fit_win_hi=np.nan,
     )
 
     freqs = np.asarray(freqs, dtype=float)
@@ -340,7 +347,9 @@ def fit_resonator(
 
     # Significant dip candidates (noise-relative, background-free, width-capped)
     candidates = find_dip_candidates(
-        freqs, smoothed, noise_sigma,
+        freqs,
+        smoothed,
+        noise_sigma,
         min_dip_snr=min_dip_snr,
         max_dip_width_hz=1.5 * max_fwhm_mhz * 1e6,
         edge_fraction=edge_fraction,
@@ -357,9 +366,7 @@ def fit_resonator(
     f0_init = float(freqs[dip_idx])
     A_raw = smoothed.max() - smoothed.min()
 
-    fwhm_init, depth_d = _estimate_initial_fwhm(
-        freqs, smoothed, f0_init, top["width_hz"], detrend_window_mhz, step
-    )
+    fwhm_init, depth_d = _estimate_initial_fwhm(freqs, smoothed, f0_init, top["width_hz"], detrend_window_mhz, step)
 
     best = _fit_lorentzian_dip_ladder(
         freqs, amplitude, f0_init, fwhm_init, A_raw, step, window_fwhm_factor, min_window_mhz
@@ -378,11 +385,15 @@ def fit_resonator(
         popt[0] = f0_out
 
     result.update(
-        f0=float(f0_out), fwhm=float(outputs["fwhm"]), r2=float(outputs["r2"]),
+        f0=float(f0_out),
+        fwhm=float(outputs["fwhm"]),
+        r2=float(outputs["r2"]),
         success=True,  # a significant, resonator-shaped dip exists (candidates non-empty)
         success_shape=outputs["success_shape"],
-        popt=np.array(popt), contrast=float(outputs["contrast"]),
-        fit_win_lo=float(outputs["fit_win_lo"]), fit_win_hi=float(outputs["fit_win_hi"]),
+        popt=np.array(popt),
+        contrast=float(outputs["contrast"]),
+        fit_win_lo=float(outputs["fit_win_lo"]),
+        fit_win_hi=float(outputs["fit_win_hi"]),
     )
     return result
 
@@ -434,16 +445,18 @@ class FitParameters:
     frequency: float
     fwhm: float
     r2: float
-    success: bool                    # FREQUENCY success: a significant dip exists, f0 delivered
-    success_shape: bool = False      # Lorentzian lineshape trustworthy (strict gates)
-    ambiguous: bool = False          # >1 comparable dip in the window — needs disambiguation
-    dip_snr: float = 0.0             # top dip prominence / noise sigma
+    success: bool  # FREQUENCY success: a significant dip exists, f0 delivered
+    success_shape: bool = False  # Lorentzian lineshape trustworthy (strict gates)
+    ambiguous: bool = False  # >1 comparable dip in the window — needs disambiguation
+    dip_snr: float = 0.0  # top dip prominence / noise sigma
     candidates: list[dict[str, int | float]] = field(default_factory=list)  # all significant dips (desc prominence)
     fit_win_lo: float = float("nan")  # lower edge (Hz) of the window popt was actually fit on
     fit_win_hi: float = float("nan")  # upper edge (Hz) of the window popt was actually fit on
 
 
-def log_fitted_results(fit_results: dict[str, dict[str, Any]], log_callable: Callable[[str], None] | None = None) -> None:
+def log_fitted_results(
+    fit_results: dict[str, dict[str, Any]], log_callable: Callable[[str], None] | None = None
+) -> None:
     """Log the fitted results for all qubits (three-state + ambiguity in v2)."""
     if log_callable is None:
         log_callable = logging.getLogger(__name__).info
@@ -469,18 +482,13 @@ def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode) -> xr.Dataset:
     """Convert IQ to voltage, add amplitude/phase, and attach full-frequency coordinates."""
     ds = convert_IQ_to_V(ds, node.namespace["qubits"])
     ds = add_amplitude_and_phase(ds, "detuning", subtract_slope_flag=True)
-    full_freq = np.array([
-        ds.detuning.values + q.resonator.RF_frequency
-        for q in node.namespace["qubits"]
-    ])
+    full_freq = np.array([ds.detuning.values + q.resonator.RF_frequency for q in node.namespace["qubits"]])
     ds = ds.assign_coords(full_freq=(["qubit", "detuning"], full_freq))
     ds.full_freq.attrs = {"long_name": "RF frequency", "units": "Hz"}
     return ds
 
 
-def fit_raw_data(
-    ds: xr.Dataset, node: QualibrationNode
-) -> tuple[xr.Dataset, dict[str, FitParameters]]:
+def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> tuple[xr.Dataset, dict[str, FitParameters]]:
     """Fit a Lorentzian dip to each qubit's amplitude trace.
 
     Reads re_fit_resonators / re_fit_centers_ghz / re_fit_span_mhz from
@@ -518,7 +526,8 @@ def fit_raw_data(
 
         ov = overrides.get(q.name, {})
         res = fit_resonator(
-            full_freq_q, amplitude_q,
+            full_freq_q,
+            amplitude_q,
             override_center_hz=ov.get("center_hz"),
             override_span_hz=ov.get("span_hz"),
             min_dip_snr=getattr(params, "min_dip_snr", 6.0),
@@ -545,43 +554,35 @@ def fit_raw_data(
                 f0_vals,
                 coords={"qubit": qubit_names},
                 dims="qubit",
-                attrs={"long_name": "resonator frequency", "units": "Hz"}
+                attrs={"long_name": "resonator frequency", "units": "Hz"},
             ),
             "fwhm": xr.DataArray(
-                fwhm_vals,
-                coords={"qubit": qubit_names},
-                dims="qubit",
-                attrs={"long_name": "FWHM", "units": "Hz"}
+                fwhm_vals, coords={"qubit": qubit_names}, dims="qubit", attrs={"long_name": "FWHM", "units": "Hz"}
             ),
-            "r2": xr.DataArray(
-                r2_vals,
-                coords={"qubit": qubit_names},
-                dims="qubit",
-                attrs={"long_name": "R²"}
-            ),
+            "r2": xr.DataArray(r2_vals, coords={"qubit": qubit_names}, dims="qubit", attrs={"long_name": "R²"}),
             "success": xr.DataArray(
                 success_vals,
                 coords={"qubit": qubit_names},
                 dims="qubit",
-                attrs={"long_name": "frequency success (significant dip found)"}
+                attrs={"long_name": "frequency success (significant dip found)"},
             ),
             "success_shape": xr.DataArray(
                 shape_vals,
                 coords={"qubit": qubit_names},
                 dims="qubit",
-                attrs={"long_name": "lineshape trustworthy (strict gates)"}
+                attrs={"long_name": "lineshape trustworthy (strict gates)"},
             ),
             "ambiguous": xr.DataArray(
                 amb_vals,
                 coords={"qubit": qubit_names},
                 dims="qubit",
-                attrs={"long_name": "multiple comparable dips in window"}
+                attrs={"long_name": "multiple comparable dips in window"},
             ),
             "dip_snr": xr.DataArray(
                 snr_vals,
                 coords={"qubit": qubit_names},
                 dims="qubit",
-                attrs={"long_name": "top dip prominence / noise sigma"}
+                attrs={"long_name": "top dip prominence / noise sigma"},
             ),
             "popt": xr.DataArray(
                 popt_array,
@@ -593,13 +594,13 @@ def fit_raw_data(
                 fit_win_lo_vals,
                 coords={"qubit": qubit_names},
                 dims="qubit",
-                attrs={"long_name": "lower edge of the window popt was fit on", "units": "Hz"}
+                attrs={"long_name": "lower edge of the window popt was fit on", "units": "Hz"},
             ),
             "fit_win_hi": xr.DataArray(
                 fit_win_hi_vals,
                 coords={"qubit": qubit_names},
                 dims="qubit",
-                attrs={"long_name": "upper edge of the window popt was fit on", "units": "Hz"}
+                attrs={"long_name": "upper edge of the window popt was fit on", "units": "Hz"},
             ),
         }
     )

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Callable
 
 import numpy as np
 import xarray as xr
@@ -37,6 +37,23 @@ def lorentzian_dip_quadbg(
     return (bg0 + bg1 * x + bg2 * x * x) - amp / (1 + ((f - f0) / (fwhm / 2)) ** 2)
 
 
+@dataclass
+class DipCandidate:
+    """One statistically significant dip found by :func:`find_dip_candidates`."""
+
+    idx: int
+    """Index of the dip minimum within the (smoothed) trace."""
+
+    f: float
+    """Frequency (Hz) of the dip minimum."""
+
+    prom_snr: float
+    """Baseline-subtracted prominence divided by the per-point noise sigma."""
+
+    width_hz: float
+    """Half-prominence width of the dip, in Hz."""
+
+
 def find_dip_candidates(
     freqs: NDArray[np.float64],
     smoothed: NDArray[np.float64],
@@ -45,7 +62,7 @@ def find_dip_candidates(
     min_dip_snr: float = 6.0,
     max_dip_width_hz: float = 22.5e6,
     edge_fraction: float = 0.02,
-) -> list[dict[str, int | float]]:
+) -> list[DipCandidate]:
     """Noise-relative, background-free dip candidates on an arbitrary-width scan.
 
     1. Remove broad structure (cable ripple, bowl) with a rolling-median
@@ -58,8 +75,8 @@ def find_dip_candidates(
     3. Keep only candidates whose half-prominence width looks like a resonator
        (<= ``max_dip_width_hz``).
 
-    Returns a list of dicts ``{idx, f, prom_snr, width_hz}`` sorted by
-    descending prominence (may be empty).
+    Returns a list of :class:`DipCandidate` sorted by descending prominence
+    (may be empty).
     """
     freqs = np.asarray(freqs, dtype=float)
     smoothed = np.asarray(smoothed, dtype=float)
@@ -83,8 +100,8 @@ def find_dip_candidates(
             continue
         if w > max_dip_width_hz:
             continue
-        out.append(dict(idx=int(p), f=float(freqs[p]), prom_snr=float(prom / sigma), width_hz=float(w)))
-    out.sort(key=lambda c: -c["prom_snr"])
+        out.append(DipCandidate(idx=int(p), f=float(freqs[p]), prom_snr=float(prom / sigma), width_hz=float(w)))
+    out.sort(key=lambda c: -c.prom_snr)
     return out
 
 
@@ -144,6 +161,32 @@ def _estimate_initial_fwhm(
     return max(float(fwhm_init), 2 * step), depth_d
 
 
+@dataclass
+class FitLadderResult:
+    """Best fit found by :func:`_fit_lorentzian_dip_ladder` across its window/model ladder."""
+
+    popt: NDArray[np.float64]
+    """Fitted Lorentzian parameters [f0, fwhm, amp, bg0, bg1] (linear-background terms only)."""
+
+    r2: float
+    """Coefficient of determination of the fit over its fit window."""
+
+    f0: float
+    """Fitted dip centre frequency, in Hz."""
+
+    fwhm: float
+    """Fitted full width at half maximum, in Hz."""
+
+    amp: float
+    """Fitted dip depth (Lorentzian amplitude)."""
+
+    contrast: float
+    """Fitted amplitude divided by the background level at f0 (0 when that background is non-positive)."""
+
+    f_win: tuple[float, float]
+    """(lo, hi) frequency bounds, in Hz, of the window this fit was performed on."""
+
+
 def _fit_lorentzian_dip_ladder(
     freqs: NDArray[np.float64],
     amplitude: NDArray[np.float64],
@@ -153,7 +196,7 @@ def _fit_lorentzian_dip_ladder(
     step: float,
     window_fwhm_factor: float,
     min_window_mhz: float,
-) -> dict[str, Any] | None:
+) -> FitLadderResult | None:
     """Try a small ladder of fit windows/models, keep whichever gives the best R².
 
     Tries, in order: a linear background at the standard window, the same
@@ -192,9 +235,9 @@ def _fit_lorentzian_dip_ladder(
         ss_res = float(np.sum((a_win - y_pred) ** 2))
         ss_tot = float(np.sum((a_win - a_win.mean()) ** 2)) + 1e-30
         r2_t = 1.0 - ss_res / ss_tot
-        if best is None or r2_t > best["r2"]:
+        if best is None or r2_t > best.r2:
             bg_at_f0 = popt_t[3] + popt_t[4] * (popt_t[0] - f_win.mean())
-            best = dict(
+            best = FitLadderResult(
                 popt=np.array(popt_t[:5], dtype=float),
                 r2=float(r2_t),
                 f0=float(popt_t[0]),
@@ -206,8 +249,37 @@ def _fit_lorentzian_dip_ladder(
     return best
 
 
+@dataclass
+class SelectedFitOutputs:
+    """Final per-qubit fit outputs chosen by :func:`_select_fit_outputs`."""
+
+    f0: float
+    """Resonance frequency (Hz): the trusted fit's centre, or the pre-fit dip estimate."""
+
+    fwhm: float
+    """Full width at half maximum (Hz): the trusted fit's value, or the pre-fit estimate."""
+
+    r2: float
+    """Coefficient of determination of the fit ladder's best attempt (0.0 if none converged)."""
+
+    contrast: float
+    """Dip depth over background: the fit's value when trusted, else a raw-estimate fallback."""
+
+    popt: NDArray[np.float64]
+    """Lorentzian fit parameters [f0, fwhm, amp, bg0, bg1], or all-NaN when the fit was untrusted."""
+
+    fit_win_lo: float
+    """Lower edge (Hz) of the window the trusted fit was performed on (NaN if untrusted)."""
+
+    fit_win_hi: float
+    """Upper edge (Hz) of the window the trusted fit was performed on (NaN if untrusted)."""
+
+    success_shape: bool
+    """Whether the Lorentzian lineshape passes the strict R²/FWHM/contrast gates."""
+
+
 def _select_fit_outputs(
-    best: dict[str, Any] | None,
+    best: FitLadderResult | None,
     f0_init: float,
     fwhm_init: float,
     depth_d: float,
@@ -216,7 +288,7 @@ def _select_fit_outputs(
     r2_threshold: float,
     max_fwhm_mhz: float,
     min_contrast: float,
-) -> dict[str, Any]:
+) -> SelectedFitOutputs:
     """Pick between the fit-ladder result and the raw dip estimate, then apply the strict shape gates.
 
     A fit is only trusted if its center landed close to the detected dip
@@ -232,7 +304,7 @@ def _select_fit_outputs(
 
     fit_trusted: bool = False
     if best is not None:
-        fit_centre_drift_hz: float = abs(best["f0"] - f0_init)
+        fit_centre_drift_hz: float = abs(best.f0 - f0_init)
 
         if fit_centre_drift_hz <= max_allowed_drift_hz:
             fit_trusted = True
@@ -246,15 +318,15 @@ def _select_fit_outputs(
     fit_win_hi: float
 
     if fit_trusted:
-        f0_out, fwhm_out = best["f0"], best["fwhm"]
-        r2 = best["r2"]
-        fitted_contrast = best["contrast"]
-        popt = best["popt"]
-        fit_win_lo, fit_win_hi = best["f_win"]
+        f0_out, fwhm_out = best.f0, best.fwhm
+        r2 = best.r2
+        fitted_contrast = best.contrast
+        popt = best.popt
+        fit_win_lo, fit_win_hi = best.f_win
     else:
         # Fit unusable/ran away: the dip existence and position stand on their own.
         f0_out, fwhm_out = f0_init, fwhm_init
-        r2 = best["r2"] if best is not None else 0.0
+        r2 = best.r2 if best is not None else 0.0
         popt = nan5.copy()
         fit_win_lo, fit_win_hi = np.nan, np.nan
 
@@ -280,7 +352,7 @@ def _select_fit_outputs(
         and centre_inside_fit_window
     )
 
-    return dict(
+    return SelectedFitOutputs(
         f0=f0_out,
         fwhm=fwhm_out,
         r2=r2,
@@ -290,6 +362,56 @@ def _select_fit_outputs(
         fit_win_hi=fit_win_hi,
         success_shape=success_shape,
     )
+
+
+@dataclass
+class ResonatorFitResult:
+    """Full result of fitting one qubit's resonator trace, as returned by :func:`fit_resonator`."""
+
+    f0: float
+    """Resonance frequency, in Hz (NaN if no significant dip was found)."""
+
+    fwhm: float
+    """Full width at half maximum, in Hz (NaN if no significant dip was found)."""
+
+    r2: float
+    """Coefficient of determination of the Lorentzian fit (NaN if no significant dip was found)."""
+
+    success: bool
+    """FREQUENCY success: a statistically significant, resonator-shaped dip exists and f0 is delivered."""
+
+    success_shape: bool = False
+    """Whether the fitted Lorentzian lineshape passes the strict R²/FWHM/contrast gates."""
+
+    ambiguous: bool = False
+    """Whether a second dip candidate is within `dominance`x of the top one's prominence."""
+
+    dip_snr: float = 0.0
+    """Top dip candidate's prominence divided by the per-point noise sigma."""
+
+    candidates: list[DipCandidate] = field(default_factory=list)
+    """Every statistically significant dip found, sorted by descending prominence."""
+
+    popt: NDArray[np.float64] = field(default_factory=lambda: np.full(5, np.nan))
+    """Lorentzian fit parameters [f0, fwhm, amp, bg0, bg1], or all-NaN when untrusted/no fit."""
+
+    edge_dip: bool = False
+    """Reserved: whether the dip sits at the edge of the swept window (currently always False)."""
+
+    contrast: float = float("nan")
+    """Dip depth over background."""
+
+    dip_idx: int = -1
+    """Index of the top dip candidate within the trace (-1 if none)."""
+
+    reason: str = ""
+    """Human-readable reason for failure when `success` is False."""
+
+    fit_win_lo: float = float("nan")
+    """Lower edge (Hz) of the window the trusted fit was performed on."""
+
+    fit_win_hi: float = float("nan")
+    """Upper edge (Hz) of the window the trusted fit was performed on."""
 
 
 def fit_resonator(
@@ -308,7 +430,7 @@ def fit_resonator(
     smooth_window: int = 11,
     min_dip_snr: float = 6.0,
     dominance: float = 2.0,
-) -> dict[str, Any]:
+) -> ResonatorFitResult:
     """Bring-up-grade resonator-dip fitter.
 
     When override_center_hz and override_span_hz are provided the data is
@@ -332,29 +454,9 @@ def fit_resonator(
 
     Returns
     -------
-    dict with keys:
-        f0, fwhm, r2, success, success_shape, ambiguous, dip_snr,
-        candidates (list of {idx, f, prom_snr, width_hz}),
-        popt (array[5] or all-NaN), edge_dip, contrast, dip_idx, reason
+    ResonatorFitResult
     """
-    _nan5 = np.full(5, np.nan)
-    result = dict(
-        f0=np.nan,
-        fwhm=np.nan,
-        r2=np.nan,
-        success=False,
-        success_shape=False,
-        ambiguous=False,
-        dip_snr=0.0,
-        candidates=[],
-        popt=_nan5.copy(),
-        edge_dip=False,
-        contrast=np.nan,
-        dip_idx=-1,
-        reason="",
-        fit_win_lo=np.nan,
-        fit_win_hi=np.nan,
-    )
+    result = ResonatorFitResult(f0=np.nan, fwhm=np.nan, r2=np.nan, success=False)
 
     freqs = np.asarray(freqs, dtype=float)
     amplitude = np.asarray(amplitude, dtype=float)
@@ -370,7 +472,7 @@ def fit_resonator(
     span_hz = freqs[-1] - freqs[0]
     N = len(freqs)
     if N < 16:
-        result["reason"] = "trace too short"
+        result.reason = "trace too short"
         return result
     step = float(np.median(np.abs(np.diff(freqs)))) if N > 1 else 1e5
 
@@ -385,19 +487,19 @@ def fit_resonator(
         max_dip_width_hz=1.5 * max_fwhm_mhz * 1e6,
         edge_fraction=edge_fraction,
     )
-    result["candidates"] = candidates
+    result.candidates = candidates
     if not candidates:
-        result["reason"] = "no significant dip"
+        result.reason = "no significant dip"
         return result
     top = candidates[0]
-    dip_idx = top["idx"]
-    result["dip_idx"] = dip_idx
-    result["dip_snr"] = top["prom_snr"]
-    result["ambiguous"] = len(candidates) > 1 and candidates[1]["prom_snr"] >= top["prom_snr"] / dominance
+    dip_idx = top.idx
+    result.dip_idx = dip_idx
+    result.dip_snr = top.prom_snr
+    result.ambiguous = len(candidates) > 1 and candidates[1].prom_snr >= top.prom_snr / dominance
     f0_init = float(freqs[dip_idx])
     A_raw = smoothed.max() - smoothed.min()
 
-    fwhm_init, depth_d = _estimate_initial_fwhm(freqs, smoothed, f0_init, top["width_hz"], detrend_window_mhz, step)
+    fwhm_init, depth_d = _estimate_initial_fwhm(freqs, smoothed, f0_init, top.width_hz, detrend_window_mhz, step)
 
     best = _fit_lorentzian_dip_ladder(
         freqs, amplitude, f0_init, fwhm_init, A_raw, step, window_fwhm_factor, min_window_mhz
@@ -409,23 +511,21 @@ def fit_resonator(
 
     # Refine the reported centre to the true dip minimum (asymmetric-tail
     # bias correction; see _refine_dip_minimum).
-    f0_out = _refine_dip_minimum(freqs, smoothed, outputs["f0"], max(outputs["fwhm"], 2 * step))
-    popt = outputs["popt"]
+    f0_out = _refine_dip_minimum(freqs, smoothed, outputs.f0, max(outputs.fwhm, 2 * step))
+    popt = outputs.popt
     if not np.any(np.isnan(popt)):
         popt = np.array(popt, dtype=float)
         popt[0] = f0_out
 
-    result.update(
-        f0=float(f0_out),
-        fwhm=float(outputs["fwhm"]),
-        r2=float(outputs["r2"]),
-        success=True,  # a significant, resonator-shaped dip exists (candidates non-empty)
-        success_shape=outputs["success_shape"],
-        popt=np.array(popt),
-        contrast=float(outputs["contrast"]),
-        fit_win_lo=float(outputs["fit_win_lo"]),
-        fit_win_hi=float(outputs["fit_win_hi"]),
-    )
+    result.f0 = float(f0_out)
+    result.fwhm = float(outputs.fwhm)
+    result.r2 = float(outputs.r2)
+    result.success = True  # a significant, resonator-shaped dip exists (candidates non-empty)
+    result.success_shape = outputs.success_shape
+    result.popt = np.array(popt)
+    result.contrast = float(outputs.contrast)
+    result.fit_win_lo = float(outputs.fit_win_lo)
+    result.fit_win_hi = float(outputs.fit_win_hi)
     return result
 
 
@@ -480,13 +580,13 @@ class FitParameters:
     success_shape: bool = False  # Lorentzian lineshape trustworthy (strict gates)
     ambiguous: bool = False  # >1 comparable dip in the window — needs disambiguation
     dip_snr: float = 0.0  # top dip prominence / noise sigma
-    candidates: list[dict[str, int | float]] = field(default_factory=list)  # all significant dips (desc prominence)
+    candidates: list[DipCandidate] = field(default_factory=list)  # all significant dips (desc prominence)
     fit_win_lo: float = float("nan")  # lower edge (Hz) of the window popt was actually fit on
     fit_win_hi: float = float("nan")  # upper edge (Hz) of the window popt was actually fit on
 
 
 def log_fitted_results(
-    fit_results: dict[str, dict[str, Any]], log_callable: Callable[[str], None] | None = None
+    fit_results: dict[str, FitParameters], log_callable: Callable[[str], None] | None = None
 ) -> None:
     """Log the fitted results for all qubits (three-state + ambiguity in v2)."""
 
@@ -494,22 +594,22 @@ def log_fitted_results(
         log_callable = logging.getLogger(__name__).info
 
     for q, res in fit_results.items():
-        if res["success"] and res.get("success_shape", True):
+        if res.success and res.success_shape:
             status = "SUCCESS!"
-        elif res["success"]:
+        elif res.success:
             status = "FREQUENCY OK (lineshape poor)"
         else:
             status = "FAIL!"
 
-        if res.get("ambiguous"):
-            n = len(res.get("candidates") or [])
+        if res.ambiguous:
+            n = len(res.candidates)
             status += f"  [AMBIGUOUS: {n} comparable dips — verify vs expected freq / punch-out]"
-            
+
         log_callable(
             f"Results for qubit {q}:  {status}\n"
-            f"\tResonator frequency: {1e-9 * res['frequency']:.4f} GHz | "
-            f"FWHM: {1e-3 * res['fwhm']:.1f} kHz | "
-            f"R²: {res['r2']:.3f} | dip SNR: {res.get('dip_snr', 0.0):.1f}"
+            f"\tResonator frequency: {1e-9 * res.frequency:.4f} GHz | "
+            f"FWHM: {1e-3 * res.fwhm:.1f} kHz | "
+            f"R²: {res.r2:.3f} | dip SNR: {res.dip_snr:.1f}"
         )
 
 
@@ -569,17 +669,17 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> tuple[xr.Dataset, di
             dominance=getattr(params, "dip_dominance", 2.0),
         )
 
-        f0_vals.append(res["f0"])
-        fwhm_vals.append(res["fwhm"])
-        r2_vals.append(res["r2"] if not np.isnan(res["r2"]) else 0.0)
-        success_vals.append(res["success"])
-        shape_vals.append(res["success_shape"])
-        amb_vals.append(res["ambiguous"])
-        snr_vals.append(res["dip_snr"])
-        cand_vals.append(res["candidates"])
-        popt_vals.append(res["popt"])  # shape (5,) or all-NaN
-        fit_win_lo_vals.append(res["fit_win_lo"])
-        fit_win_hi_vals.append(res["fit_win_hi"])
+        f0_vals.append(res.f0)
+        fwhm_vals.append(res.fwhm)
+        r2_vals.append(res.r2 if not np.isnan(res.r2) else 0.0)
+        success_vals.append(res.success)
+        shape_vals.append(res.success_shape)
+        amb_vals.append(res.ambiguous)
+        snr_vals.append(res.dip_snr)
+        cand_vals.append(res.candidates)
+        popt_vals.append(res.popt)  # shape (5,) or all-NaN
+        fit_win_lo_vals.append(res.fit_win_lo)
+        fit_win_hi_vals.append(res.fit_win_hi)
 
     popt_array = np.stack(popt_vals, axis=0)  # (n_qubits, 5)
 

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/analysis.py
@@ -621,8 +621,8 @@ def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode) -> xr.Dataset:
 def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> tuple[xr.Dataset, dict[str, FitParameters]]:
     """Fit a Lorentzian dip to each qubit's amplitude trace.
 
-    Reads re_fit_resonators / re_fit_centers_ghz / re_fit_span_mhz from
-    node.parameters to apply manual fit-window overrides for selected qubits.
+    Reads re-fit overrides from ``params.refit`` (re_fit_resonators /
+    re_fit_centers_ghz / re_fit_span_mhz).
 
     Returns
     -------
@@ -635,9 +635,9 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> tuple[xr.Dataset, di
 
     # Build per-qubit override lookup from the three parallel lists
     overrides: dict[str, dict[str, float]] = {}
-    re_fit_names = params.re_fit_resonators or []
-    re_fit_centers = params.re_fit_centers_ghz or []
-    re_fit_spans = params.re_fit_span_mhz or []
+    re_fit_names = params.refit.re_fit_resonators or []
+    re_fit_centers = params.refit.re_fit_centers_ghz or []
+    re_fit_spans = params.refit.re_fit_span_mhz or []
     for name, center_ghz, span_mhz in zip(re_fit_names, re_fit_centers, re_fit_spans):
         overrides[name] = {
             "center_hz": center_ghz * 1e9,
@@ -660,8 +660,8 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> tuple[xr.Dataset, di
             amplitude_q,
             override_center_hz=ov.get("center_hz"),
             override_span_hz=ov.get("span_hz"),
-            min_dip_snr=getattr(params, "min_dip_snr", 6.0),
-            dominance=getattr(params, "dip_dominance", 2.0),
+            min_dip_snr=params.analysis.min_dip_snr,
+            dominance=params.analysis.dip_dominance,
         )
 
         f0_vals.append(res.f0)

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/escalation.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/escalation.py
@@ -1,0 +1,85 @@
+"""No-dip span-escalation planning for resonator spectroscopy bring-up.
+
+Pure functions (no hardware, no node state) so the retry logic is unit-testable
+offline. The node applies the plan: widen the sweep for the qubits whose fit
+found no significant dip, re-centering the readout LO when the wider sweep
+would push the intermediate frequency past its limit (same tracked-LO pattern
+as node 09b's flux-detuned window).
+
+Fresh-from-fab context: the design resonator frequency can be off by hundreds
+of MHz, so the standard ±15 MHz scan sees nothing. The ladder doubles the span
+per retry up to ``max_span_hz`` (default ±400 MHz). With the LO re-centered on
+the expected frequency the IF sweep is symmetric (±span/2), which for the
+800 MHz ceiling sits exactly at the MW-FEM ±400 MHz IF reach.
+"""
+
+from typing import Any
+
+# MW-FEM upconverter (LO) reach per band — used to refuse an LO move that the
+# hardware cannot express. Matches the guards in node 09b (lower bounds) plus
+# the band upper edges.
+_BAND_LO_RANGE = {
+    1: (0.05e9, 5.5e9),
+    2: (4.5e9, 7.5e9),
+    3: (6.5e9, 10.5e9),
+}
+_IF_LIMIT_HZ = 400e6
+
+
+def plan_span_escalation(
+    fit_results: dict[str, dict[str, Any]],
+    current_span_hz: float,
+    max_span_hz: float,
+    *,
+    growth: float = 2.0,
+) -> dict[str, Any]:
+    """Decide whether/how to widen the sweep after a no-dip analysis pass.
+
+    ``fit_results`` maps qubit name -> dict with at least ``success`` (bool).
+    Only frequency-failures (no significant dip) participate; shape-poor fits
+    already delivered a frequency and are not re-measured.
+
+    Returns dict(retry: bool, qubits: [names], new_span_hz: float).
+    """
+    failed = [q for q, r in fit_results.items() if not r.get("success", False)]
+    if not failed or current_span_hz >= max_span_hz:
+        return dict(retry=False, qubits=failed, new_span_hz=current_span_hz)
+    new_span = min(current_span_hz * growth, max_span_hz)
+    return dict(retry=True, qubits=failed, new_span_hz=float(new_span))
+
+
+def plan_lo_recenter(
+    rf_hz: float,
+    lo_hz: float,
+    span_hz: float,
+    band: int | None,
+    *,
+    if_limit_hz: float = _IF_LIMIT_HZ,
+) -> dict[str, Any]:
+    """LO plan for a symmetric ±span/2 sweep around ``rf_hz``.
+
+    If the sweep fits within the IF limit at the current LO, no move is needed.
+    Otherwise the LO is re-centered ON the expected resonator frequency
+    (IF -> 0), making the required IF reach exactly ±span/2; if even that
+    exceeds the IF limit, or the new LO leaves the band, the plan reports an
+    error string instead (caller should cap the span or skip the qubit).
+
+    Returns dict(shift: bool, new_lo_hz: float, error: str|None).
+    """
+    if0 = rf_hz - lo_hz
+    lo_min, lo_max = _BAND_LO_RANGE.get(band, (0.0, float("inf")))
+    if abs(if0) + span_hz / 2.0 <= if_limit_hz:
+        return dict(shift=False, new_lo_hz=float(lo_hz), error=None)
+    if span_hz / 2.0 > if_limit_hz:
+        return dict(
+            shift=False, new_lo_hz=float(lo_hz),
+            error=f"span/2 = {span_hz / 2 / 1e6:.0f} MHz exceeds the ±{if_limit_hz / 1e6:.0f} MHz IF reach",
+        )
+    new_lo = float(rf_hz)  # IF -> 0 at the expected center
+    if not (lo_min <= new_lo <= lo_max):
+        return dict(
+            shift=False, new_lo_hz=float(lo_hz),
+            error=f"re-centered LO {new_lo / 1e9:.3f} GHz outside band-{band} range "
+                  f"[{lo_min / 1e9:.2f}, {lo_max / 1e9:.2f}] GHz",
+        )
+    return dict(shift=True, new_lo_hz=new_lo, error=None)

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/escalation.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/escalation.py
@@ -13,7 +13,9 @@ the expected frequency the IF sweep is symmetric (±span/2), which for the
 800 MHz ceiling sits exactly at the MW-FEM ±400 MHz IF reach.
 """
 
-from typing import Any
+from dataclasses import dataclass
+
+from .analysis import FitParameters
 
 # MW-FEM upconverter (LO) reach per band — used to refuse an LO move that the
 # hardware cannot express. Matches the guards in node 09b (lower bounds) plus
@@ -26,26 +28,52 @@ _BAND_LO_RANGE = {
 _IF_LIMIT_HZ = 400e6
 
 
+@dataclass
+class SpanEscalationPlan:
+    """Decision produced by :func:`plan_span_escalation` for one no-dip retry rung."""
+
+    retry: bool
+    """Whether another (wider) measurement pass should be attempted."""
+
+    qubits: list[str]
+    """Names of the qubits with no significant dip (the retry's participants, if any)."""
+
+    new_span_hz: float
+    """Span (Hz) to sweep next; equal to `current_span_hz` when `retry` is False."""
+
+
 def plan_span_escalation(
-    fit_results: dict[str, dict[str, Any]],
+    fit_results: dict[str, FitParameters],
     current_span_hz: float,
     max_span_hz: float,
     *,
     growth: float = 2.0,
-) -> dict[str, Any]:
+) -> SpanEscalationPlan:
     """Decide whether/how to widen the sweep after a no-dip analysis pass.
 
-    ``fit_results`` maps qubit name -> dict with at least ``success`` (bool).
-    Only frequency-failures (no significant dip) participate; shape-poor fits
+    ``fit_results`` maps qubit name -> :class:`FitParameters`. Only
+    frequency-failures (no significant dip) participate; shape-poor fits
     already delivered a frequency and are not re-measured.
-
-    Returns dict(retry: bool, qubits: [names], new_span_hz: float).
     """
-    failed = [q for q, r in fit_results.items() if not r.get("success", False)]
+    failed = [q for q, r in fit_results.items() if not r.success]
     if not failed or current_span_hz >= max_span_hz:
-        return dict(retry=False, qubits=failed, new_span_hz=current_span_hz)
+        return SpanEscalationPlan(retry=False, qubits=failed, new_span_hz=current_span_hz)
     new_span = min(current_span_hz * growth, max_span_hz)
-    return dict(retry=True, qubits=failed, new_span_hz=float(new_span))
+    return SpanEscalationPlan(retry=True, qubits=failed, new_span_hz=float(new_span))
+
+
+@dataclass
+class LoRecenterPlan:
+    """Decision produced by :func:`plan_lo_recenter` for one qubit's readout LO."""
+
+    shift: bool
+    """Whether the LO needs to move to fit the wider IF sweep."""
+
+    new_lo_hz: float
+    """LO frequency (Hz) to use; unchanged from the input when `shift` is False."""
+
+    error: str | None
+    """Reason the plan could not honour the requested span/band, or None on success."""
 
 
 def plan_lo_recenter(
@@ -55,7 +83,7 @@ def plan_lo_recenter(
     band: int | None,
     *,
     if_limit_hz: float = _IF_LIMIT_HZ,
-) -> dict[str, Any]:
+) -> LoRecenterPlan:
     """LO plan for a symmetric ±span/2 sweep around ``rf_hz``.
 
     If the sweep fits within the IF limit at the current LO, no move is needed.
@@ -63,25 +91,23 @@ def plan_lo_recenter(
     (IF -> 0), making the required IF reach exactly ±span/2; if even that
     exceeds the IF limit, or the new LO leaves the band, the plan reports an
     error string instead (caller should cap the span or skip the qubit).
-
-    Returns dict(shift: bool, new_lo_hz: float, error: str|None).
     """
     if0 = rf_hz - lo_hz
     lo_min, lo_max = _BAND_LO_RANGE.get(band, (0.0, float("inf")))
     if abs(if0) + span_hz / 2.0 <= if_limit_hz:
-        return dict(shift=False, new_lo_hz=float(lo_hz), error=None)
+        return LoRecenterPlan(shift=False, new_lo_hz=float(lo_hz), error=None)
     if span_hz / 2.0 > if_limit_hz:
-        return dict(
+        return LoRecenterPlan(
             shift=False,
             new_lo_hz=float(lo_hz),
             error=f"span/2 = {span_hz / 2 / 1e6:.0f} MHz exceeds the ±{if_limit_hz / 1e6:.0f} MHz IF reach",
         )
     new_lo = float(rf_hz)  # IF -> 0 at the expected center
     if not (lo_min <= new_lo <= lo_max):
-        return dict(
+        return LoRecenterPlan(
             shift=False,
             new_lo_hz=float(lo_hz),
             error=f"re-centered LO {new_lo / 1e9:.3f} GHz outside band-{band} range "
             f"[{lo_min / 1e9:.2f}, {lo_max / 1e9:.2f}] GHz",
         )
-    return dict(shift=True, new_lo_hz=new_lo, error=None)
+    return LoRecenterPlan(shift=True, new_lo_hz=new_lo, error=None)

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/escalation.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/escalation.py
@@ -72,14 +72,16 @@ def plan_lo_recenter(
         return dict(shift=False, new_lo_hz=float(lo_hz), error=None)
     if span_hz / 2.0 > if_limit_hz:
         return dict(
-            shift=False, new_lo_hz=float(lo_hz),
+            shift=False,
+            new_lo_hz=float(lo_hz),
             error=f"span/2 = {span_hz / 2 / 1e6:.0f} MHz exceeds the ±{if_limit_hz / 1e6:.0f} MHz IF reach",
         )
     new_lo = float(rf_hz)  # IF -> 0 at the expected center
     if not (lo_min <= new_lo <= lo_max):
         return dict(
-            shift=False, new_lo_hz=float(lo_hz),
+            shift=False,
+            new_lo_hz=float(lo_hz),
             error=f"re-centered LO {new_lo / 1e9:.3f} GHz outside band-{band} range "
-                  f"[{lo_min / 1e9:.2f}, {lo_max / 1e9:.2f}] GHz",
+            f"[{lo_min / 1e9:.2f}, {lo_max / 1e9:.2f}] GHz",
         )
     return dict(shift=True, new_lo_hz=new_lo, error=None)

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/parameters.py
@@ -1,15 +1,51 @@
 from qualibrate import NodeParameters
 from qualibrate.core.parameters import RunnableParameters
-from qualibration_libs.parameters import QubitsExperimentNodeParameters, CommonNodeParameters
+from qualibration_libs.parameters import CommonNodeParameters, QubitsExperimentNodeParameters
 
 
 class NodeSpecificParameters(RunnableParameters):
+    """Resonator spectroscopy specific parameters."""
+
     num_shots: int = 100
     """Number of averages to perform. Default is 100."""
+
     frequency_span_in_mhz: float = 30.0
     """Span of frequencies to sweep in MHz. Default is 30 MHz."""
+
     frequency_step_in_mhz: float = 0.1
     """Step size for frequency sweep in MHz. Default is 0.1 MHz."""
+
+    # --- v2 fit gates ---
+    min_dip_snr: float = 6.0
+    """FREQUENCY gate: minimum dip significance (baseline-subtracted prominence / per-point noise sigma) to count the resonator as found; only R²/FWHM/contrast (not this) gate `success_shape`."""
+
+    dip_dominance: float = 2.0
+    """Flags a window `ambiguous` when the second-most-prominent dip is within this factor of the top one, e.g. wide bring-up scans catching feedline neighbours; verify against expected frequency or vs-power punch-out."""
+
+    # --- Bring-up span escalation (no-dip retry) ---
+    escalate_on_no_dip: bool = False
+    """When True, re-measures qubits with no significant dip using a doubled span (up to `max_escalation_span_in_mhz`), re-centering the readout LO as needed; fresh-from-fab bring-up only, leave False for routine tracking."""
+
+    max_escalation_span_in_mhz: float = 800.0
+    """Span ceiling (MHz) for the no-dip escalation ladder. Default ±400 MHz."""
+
+    # --- Optional diagnostic plots (off by default; amplitude+fit and detrended
+    # phase are shown unconditionally) ---
+    show_raw_phase_plot: bool = False
+    """Show the raw phase + group delay figure; useful when the amplitude dip is weak/ambiguous and phase gives a sharper resonance feature."""
+
+    show_iq_circle_plot: bool = False
+    """Show the I/Q parametric trace figure; a readout-troubleshooting tool (impedance mismatch, weak coupling, mixer issues), not needed for routine fits."""
+
+    # --- Re-fit overrides (used together with load_data_id) ---
+    re_fit_resonators: list[str] | None = None
+    """Qubit names to re-fit with a manually specified window, e.g. ["qA1", "qD3"]; must be the same length as re_fit_centers_ghz and re_fit_span_mhz."""
+
+    re_fit_centers_ghz: list[float] | None = None
+    """Absolute RF center frequency (GHz) for each qubit in re_fit_resonators."""
+
+    re_fit_span_mhz: list[float] | None = None
+    """Fit span (MHz) around the center for each qubit in re_fit_resonators."""
 
 
 class Parameters(

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/parameters.py
@@ -1,10 +1,12 @@
+from pydantic import Field
+
 from qualibrate import NodeParameters
-from qualibrate.core.parameters import RunnableParameters
+from qualibrate.core.parameters import GroupParameters
 from qualibration_libs.parameters import CommonNodeParameters, QubitsExperimentNodeParameters
 
 
-class NodeSpecificParameters(RunnableParameters):
-    """Resonator spectroscopy specific parameters."""
+class SweepParameters(GroupParameters):
+    """Frequency sweep and acquisition settings."""
 
     num_shots: int = 100
     """Number of averages to perform. Default is 100."""
@@ -15,29 +17,40 @@ class NodeSpecificParameters(RunnableParameters):
     frequency_step_in_mhz: float = 0.1
     """Step size for frequency sweep in MHz. Default is 0.1 MHz."""
 
-    # --- v2 fit gates ---
+
+class AnalysisParameters(GroupParameters):
+    """v2 dip-detection and ambiguity gates."""
+
     min_dip_snr: float = 6.0
     """FREQUENCY gate: minimum dip significance (baseline-subtracted prominence / per-point noise sigma) to count the resonator as found; only R²/FWHM/contrast (not this) gate `success_shape`."""
 
     dip_dominance: float = 2.0
     """Flags a window `ambiguous` when the second-most-prominent dip is within this factor of the top one, e.g. wide bring-up scans catching feedline neighbours; verify against expected frequency or vs-power punch-out."""
 
-    # --- Bring-up span escalation (no-dip retry) ---
+
+class EscalationParameters(GroupParameters):
+    """Bring-up span escalation (no-dip retry)."""
+
     escalate_on_no_dip: bool = False
     """When True, re-measures qubits with no significant dip using a doubled span (up to `max_escalation_span_in_mhz`), re-centering the readout LO as needed; fresh-from-fab bring-up only, leave False for routine tracking."""
 
     max_escalation_span_in_mhz: float = 800.0
     """Span ceiling (MHz) for the no-dip escalation ladder. Default ±400 MHz."""
 
-    # --- Optional diagnostic plots (off by default; amplitude+fit and detrended
-    # phase are shown unconditionally) ---
+
+class PlotParameters(GroupParameters):
+    """Optional diagnostic plots (amplitude+fit and detrended phase are always shown)."""
+
     show_raw_phase_plot: bool = False
     """Show the raw phase + group delay figure; useful when the amplitude dip is weak/ambiguous and phase gives a sharper resonance feature."""
 
     show_iq_circle_plot: bool = False
     """Show the I/Q parametric trace figure; a readout-troubleshooting tool (impedance mismatch, weak coupling, mixer issues), not needed for routine fits."""
 
-    # --- Re-fit overrides (used together with load_data_id) ---
+
+class ReFitParameters(GroupParameters):
+    """Manual re-fit window overrides (used together with load_data_id)."""
+
     re_fit_resonators: list[str] | None = None
     """Qubit names to re-fit with a manually specified window, e.g. ["qA1", "qD3"]; must be the same length as re_fit_centers_ghz and re_fit_span_mhz."""
 
@@ -51,7 +64,12 @@ class NodeSpecificParameters(RunnableParameters):
 class Parameters(
     NodeParameters,
     CommonNodeParameters,
-    NodeSpecificParameters,
     QubitsExperimentNodeParameters,
 ):
-    pass
+    """Combined parameter class for resonator spectroscopy calibration node."""
+
+    sweep: SweepParameters = Field(default_factory=SweepParameters)
+    analysis: AnalysisParameters = Field(default_factory=AnalysisParameters)
+    escalation: EscalationParameters = Field(default_factory=EscalationParameters)
+    plotting: PlotParameters = Field(default_factory=PlotParameters)
+    refit: ReFitParameters = Field(default_factory=ReFitParameters)

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/plotting.py
@@ -1,125 +1,496 @@
-from typing import List
+"""Plotting utilities for resonator spectroscopy calibration.
+
+Grid-size-aware variant (``_new``)
+----------------------------------
+The original module hard-coded a fixed figure size (15x9 in) **and** large
+absolute font sizes tuned for a *single* 15x9 panel.  On a multiplexed grid
+(e.g. 3x3) the figure stayed 15x9, so each panel shrank to ~5x3 in while the
+fonts stayed at 24 pt -> giant text on tiny plots.
+
+Here every figure derives a single scale factor ``s`` from the grid layout
+(``grid.all_axes.shape``) and scales the figure size **and** all text/marker
+sizes together.  Result:
+
+* 1 qubit  -> ``s = 1`` -> 15x9 in with the original (gold) fonts, i.e. the
+  single-qubit plot is byte-for-byte the look of the reference dataset.
+* N qubits -> the total figure is bounded to ~``_TARGET_W`` x ``_TARGET_H``
+  inches and the per-panel fonts shrink proportionally, so each panel keeps
+  the same font-to-panel ratio as the single-qubit plot.
+
+Everything is driven by the constants below, so the whole look can be retuned
+in one place (raise ``_TARGET_W/_TARGET_H`` to grow panels, lower them to make
+things more compact).
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
 import xarray as xr
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from qualang_tools.units import unit
 from qualibration_libs.plotting import QubitGrid, grid_iter
-from qualibration_libs.analysis import lorentzian_dip
 from quam_builder.architecture.superconducting.qubit import AnyTransmon
+
+from .analysis import lorentzian_dip_linbg
 
 u = unit(coerce_to_integer=True)
 
 
-def plot_raw_phase(ds: xr.Dataset, qubits: List[AnyTransmon]) -> Figure:
+def _relock_twin_axis(ax: Axes, ax2: Axes, center_hz: float) -> None:
+    """Re-pin the detuning twin axis ``ax2`` to the affine image of RF axis ``ax``.
+
+    The amplitude/phase panels draw the data on a bottom RF axis ``ax`` AND a ``twiny()``
+    top detuning axis ``ax2`` (related by full_freq = detuning + center_hz). They overlap
+    only while the two x-axes stay affine-aligned; on a bad/edge fit the FWHM band
+    ``axvspan`` (or any marker) outside the swept range independently stretches ``ax2``'s
+    autoscale, desyncing the twins so the one trace renders as "two diverging lines". Call
+    this AFTER all overlays to force ``ax2`` back onto ``ax`` (a no-op when already aligned).
     """
-    Plots the raw phase data for the given qubits.
+    lo, hi = ax.get_xlim()  # GHz
+    ax2.set_xlim((lo * u.GHz - center_hz) / u.MHz, (hi * u.GHz - center_hz) / u.MHz)
+
+# ---------------------------------------------------------------------------
+# Reference single-panel geometry + bounds (tune the figure look here)
+# ---------------------------------------------------------------------------
+# The "gold" single-qubit panel: a 1x1 grid renders at exactly this size with
+# the base font sizes below, reproducing the original single-qubit figure.
+_REF_PANEL_W = 15.0   # inches, width of one reference panel
+_REF_PANEL_H = 9.0    # inches, height of one reference panel
+
+# Maximum total figure size for a multiplexed grid.  The scale factor never
+# exceeds 1, so panels are never *larger* than the reference; for large grids
+# the figure is capped at these dimensions and fonts shrink to fit.
+_TARGET_W = 24.0      # inches, max total figure width
+_TARGET_H = 15.0      # inches, max total figure height
+
+# ---------------------------------------------------------------------------
+# Base (gold) font / pad sizes — these apply unscaled to a single panel
+# ---------------------------------------------------------------------------
+_BASE_FS_SUPTITLE = 28   # figure suptitle
+_BASE_FS_TITLE    = 24   # per-subplot title
+_BASE_FS_LABEL    = 24   # axis label (xlabel / ylabel)
+_BASE_FS_TICK     = 22   # tick-label size
+_BASE_FS_LEGEND   = 20   # legend text
+_BASE_FS_CBAR     = 20   # colorbar label / ticks
+
+# Extra vertical padding (pts) for subplot titles on plots that have a twiny()
+# top x-axis: the top ticks + "Detuning [MHz]" label need to be cleared.
+# Rule of thumb: ~1.5 x (_FS_TICK + _FS_LABEL) in points (at full scale).
+_BASE_TITLE_PAD_TWINY = 40   # plots with twiny top x-axis
+_BASE_TITLE_PAD       =  8   # plots without a top x-axis
+
+
+def _clip(value: float, floor: float) -> float:
+    """Return *value* but never below *floor* (keeps thin lines/markers visible)."""
+    return value if value >= floor else floor
+
+
+def _style_for_grid(grid: QubitGrid) -> SimpleNamespace:
+    """Derive a grid-size-aware style from a constructed :class:`QubitGrid`.
+
+    ``grid.all_axes`` is the full ``(nrows, ncols)`` array of axes created by
+    ``plt.subplots`` inside ``QubitGrid``, so its shape gives the layout.  The
+    scale factor ``s`` is chosen so the total figure fits within
+    ``_TARGET_W`` x ``_TARGET_H`` while never exceeding the reference panel
+    size (``s <= 1``).  All font / pad / line / marker sizes scale with ``s``.
+    """
+    nrows, ncols = grid.all_axes.shape
+    s = min(
+        1.0,
+        _TARGET_W / (_REF_PANEL_W * ncols),
+        _TARGET_H / (_REF_PANEL_H * nrows),
+    )
+    return SimpleNamespace(
+        s=s,
+        nrows=nrows,
+        ncols=ncols,
+        # Total figure size (bounded by the targets; >= a single reference panel)
+        fig_w=_REF_PANEL_W * s * ncols,
+        fig_h=_REF_PANEL_H * s * nrows,
+        # Fonts scale linearly with the panel
+        fs_suptitle=_BASE_FS_SUPTITLE * s,
+        fs_title=_BASE_FS_TITLE * s,
+        fs_label=_BASE_FS_LABEL * s,
+        fs_tick=_BASE_FS_TICK * s,
+        fs_legend=_BASE_FS_LEGEND * s,
+        fs_cbar=_BASE_FS_CBAR * s,
+        # Title padding scales with the panel too (it must clear the top axis)
+        pad_twiny=_BASE_TITLE_PAD_TWINY * s,
+        pad=_BASE_TITLE_PAD * s,
+        # Line widths scale linearly (with small visibility floors)
+        lw_fit=_clip(1.5 * s, 0.8),
+        lw_gd=_clip(1.0 * s, 0.6),
+        lw_line=_clip(1.0 * s, 0.6),
+        lw_thin=_clip(0.8 * s, 0.5),
+        lw_hair=_clip(0.5 * s, 0.4),
+        # Marker areas: small dots scale ~linearly, the big f0 star ~by area
+        scatter_s=_clip(8.0 * s, 3.0),
+        star_s=_clip(200.0 * s * s, 40.0),
+        arrow_scale=_clip(14.0 * s, 8.0),
+    )
+
+
+def _apply_tick_fontsize(ax: Axes, size: float) -> None:
+    """Set tick-label fontsize on both axes of *ax*."""
+    ax.tick_params(axis="both", labelsize=size)
+
+
+def _finalize(grid: QubitGrid, st: SimpleNamespace, suptitle: str) -> Figure:
+    """Apply the shared figure-level styling (size, suptitle, layout)."""
+    grid.fig.suptitle(suptitle, fontsize=st.fs_suptitle)
+    grid.fig.set_size_inches(st.fig_w, st.fig_h)
+    # Reserve a little headroom for the (scaled) suptitle so it never collides
+    # with the per-subplot titles / twiny top axes.
+    grid.fig.tight_layout(rect=[0, 0, 1, 0.97])
+    return grid.fig
+
+
+def plot_raw_phase(
+    ds: xr.Dataset,
+    qubits: list[AnyTransmon],
+    fits: xr.Dataset | None = None,
+) -> Figure:
+    """Plot raw phase with group delay overlay and optional f0 marker.
 
     Parameters
     ----------
-    ds : xr.Dataset
-        The dataset containing the quadrature data.
-    qubits : list
-        A list of qubits to plot.
-
-    Returns
-    -------
-    Figure
-        The matplotlib figure object containing the plots.
-
-    Notes
-    -----
-    - The function creates a grid of subplots, one for each qubit.
-    - Each subplot contains two x-axes: one for the full frequency in GHz and one for the detuning in MHz.
+    ds:
+        Raw dataset containing 'phase', 'detuning', and 'full_freq'.
+    qubits:
+        List of transmon qubits.
+    fits:
+        Optional fit dataset (ds_fit).  When provided, a vertical dashed red
+        line is drawn at the fitted resonance frequency f0.
     """
     grid = QubitGrid(ds, [q.grid_location for q in qubits])
+    st = _style_for_grid(grid)
     for ax1, qubit in grid_iter(grid):
-        # Create a first x-axis for full_freq_GHz
-        ds.assign_coords(full_freq_GHz=ds.full_freq / u.GHz).loc[qubit].phase.plot(ax=ax1, x="full_freq_GHz")
-        ax1.set_xlabel("RF frequency [GHz]")
-        ax1.set_ylabel("phase [rad]")
-        # Create a second x-axis for detuning_MHz
+        ds_q = ds.loc[qubit]
+        full_freq_ghz = ds_q.full_freq.values / u.GHz
+        full_freq_hz = ds_q.full_freq.values
+        phase = ds_q.phase.values
+        qubit_name = qubit["qubit"]
+
+        # Primary axis: absolute RF frequency [GHz], left y: phase
+        ds_q.assign_coords(full_freq_GHz=ds_q.full_freq / u.GHz).phase.plot(
+            ax=ax1, x="full_freq_GHz"
+        )
+        ax1.set_xlabel("RF frequency [GHz]", fontsize=st.fs_label)
+        ax1.set_ylabel("phase [rad]", fontsize=st.fs_label)
+        _apply_tick_fontsize(ax1, st.fs_tick)
+
+        # Top x-axis: detuning [MHz]
         ax2 = ax1.twiny()
-        ds.assign_coords(detuning_MHz=ds.detuning / u.MHz).loc[qubit].phase.plot(ax=ax2, x="detuning_MHz")
-        ax2.set_xlabel("Detuning [MHz]")
-    grid.fig.suptitle("Resonator spectroscopy (phase)")
-    grid.fig.set_size_inches(15, 9)
-    grid.fig.tight_layout()
+        ds_q.assign_coords(detuning_MHz=ds_q.detuning / u.MHz).phase.plot(
+            ax=ax2, x="detuning_MHz"
+        )
+        ax2.set_xlabel("Detuning [MHz]", fontsize=st.fs_label)
+        ax2.set_title("")  # clear any auto-title xarray set on the twin axis
+        _apply_tick_fontsize(ax2, st.fs_tick)
 
-    return grid.fig
+        # Right y-axis: group delay  -dφ/df  [ns]
+        tau_ns = -np.gradient(phase, full_freq_hz) * 1e9
+        ax_gd = ax1.twinx()
+        ax_gd.plot(
+            full_freq_ghz, tau_ns,
+            color="darkorange", linewidth=st.lw_gd, alpha=0.7, label="group delay",
+        )
+        ax_gd.set_ylabel("-dφ/df [ns]", color="darkorange", fontsize=st.fs_label)
+        ax_gd.tick_params(axis="y", colors="darkorange", labelsize=st.fs_tick)
+
+        # Explicit centered subplot title — pad clears the twiny top-axis label
+        ax1.set_title(f"qubit = {qubit_name}", loc="center", fontsize=st.fs_title, pad=st.pad_twiny)
+
+        # Vertical dashed line at fitted f0
+        if fits is not None:
+            fit_q = fits.sel(qubit=qubit_name)
+            f0_hz = float(fit_q.f0.values)
+            if not np.isnan(f0_hz):
+                f0_ghz_val = f0_hz / u.GHz
+                ax1.axvline(
+                    f0_ghz_val, color="red", linestyle="--", linewidth=st.lw_gd,
+                    label=f"f₀={f0_ghz_val:.4f} GHz",
+                )
+                ax1.legend(fontsize=st.fs_legend, loc="upper right")
+
+        # Keep the detuning twin axis pinned to the RF axis (one trace, not two).
+        _relock_twin_axis(ax1, ax2, full_freq_hz[0] - ds_q.detuning.values[0])
+
+    return _finalize(grid, st, "Resonator spectroscopy (phase)")
 
 
-def plot_raw_amplitude_with_fit(ds: xr.Dataset, qubits: List[AnyTransmon], fits: xr.Dataset):
+def plot_raw_amplitude_with_fit(
+    ds: xr.Dataset, qubits: list[AnyTransmon], fits: xr.Dataset
+) -> Figure:
+    """Plot IQ amplitude with fitted curves for all qubits on a grid."""
+    grid = QubitGrid(ds, [q.grid_location for q in qubits])
+    st = _style_for_grid(grid)
+    for ax, qubit in grid_iter(grid):
+        plot_individual_amplitude_with_fit(ax, ds, qubit, fits.sel(qubit=qubit["qubit"]), st)
+    return _finalize(grid, st, "Resonator spectroscopy (amplitude + fit)")
+
+
+def plot_individual_amplitude_with_fit(
+    ax: Axes,
+    ds: xr.Dataset,
+    qubit: dict[str, Any],
+    fit: xr.Dataset | None = None,
+    st: SimpleNamespace | None = None,
+) -> None:
+    """Plot a single qubit's amplitude trace with the fitted Lorentzian overlay.
+
+    The fit curve is reconstructed from the stored popt = [f0, fwhm, amp, bg0, bg1]
+    using lorentzian_dip_linbg evaluated over the full absolute-frequency axis.
+    A NaN popt (failed fit) suppresses the overlay.
+
+    Enhancements:
+    - Fit line is dashed (r--) instead of solid.
+    - Legend shows fitted f0 [GHz] and FWHM [MHz].
+    - A semi-transparent red band marks the FWHM width around f0.
+
+    ``st`` carries the grid-size-aware font/line sizes.  It is optional so the
+    helper can be reused standalone; when omitted a single-panel (gold) style
+    is used.
     """
-    Plots the resonator spectroscopy amplitude IQ_abs with fitted curves for the given qubits.
+    if st is None:
+        st = SimpleNamespace(
+            fs_label=_BASE_FS_LABEL, fs_title=_BASE_FS_TITLE, fs_tick=_BASE_FS_TICK,
+            fs_legend=_BASE_FS_LEGEND, pad_twiny=_BASE_TITLE_PAD_TWINY, lw_fit=1.5,
+        )
 
-    Parameters
-    ----------
-    ds : xr.Dataset
-        The dataset containing the quadrature data.
-    qubits : list of AnyTransmon
-        A list of qubits to plot.
-    fits : xr.Dataset
-        The dataset containing the fit parameters.
+    ds_q = ds.loc[qubit]
+    qubit_name = qubit["qubit"]
 
-    Returns
-    -------
-    Figure
-        The matplotlib figure object containing the plots.
+    # Primary x-axis: absolute RF frequency in GHz
+    (ds_q.assign_coords(full_freq_GHz=ds_q.full_freq / u.GHz).IQ_abs / u.mV).plot(
+        ax=ax, x="full_freq_GHz"
+    )
+    ax.set_xlabel("RF frequency [GHz]", fontsize=st.fs_label)
+    ax.set_ylabel(r"$R=\sqrt{I^2+Q^2}$ [mV]", fontsize=st.fs_label)
+    _apply_tick_fontsize(ax, st.fs_tick)
 
-    Notes
-    -----
-    - The function creates a grid of subplots, one for each qubit.
-    - Each subplot contains the raw data and the fitted curve.
+    # Secondary x-axis: detuning in MHz
+    ax2 = ax.twiny()
+    (ds_q.assign_coords(detuning_MHz=ds_q.detuning / u.MHz).IQ_abs / u.mV).plot(
+        ax=ax2, x="detuning_MHz"
+    )
+    ax2.set_xlabel("Detuning [MHz]", fontsize=st.fs_label)
+    ax2.set_title("")  # clear xarray auto-title on twin axis
+    _apply_tick_fontsize(ax2, st.fs_tick)
+
+    # Explicit centered subplot title — three-state in v2:
+    #   black   "qubit = qA1"                  frequency + lineshape both good
+    #   amber   "... (freq OK, shape poor)"    dip found; Lorentzian gates failed
+    #   crimson "... (NO DIP)"                 no significant dip — nothing written
+    # An "[AMBIG]" suffix marks windows with several comparable dips
+    # (downstream disambiguates via expected frequency / punch-out).
+    title = f"qubit = {qubit_name}"
+    color = "black"
+    if fit is not None and "success" in fit:
+        _succ = bool(fit.success.values)
+        _shape = bool(fit.success_shape.values) if "success_shape" in fit else _succ
+        if not _succ:
+            title += "  (NO DIP)"
+            color = "crimson"
+        elif not _shape:
+            title += "  (freq OK, shape poor)"
+            color = "darkorange"
+        if "ambiguous" in fit and bool(fit.ambiguous.values):
+            title += "  [AMBIG]"
+            if color == "black":
+                color = "darkorange"
+    ax.set_title(title, loc="center", fontsize=st.fs_title, pad=st.pad_twiny, color=color)
+
+    # Overlay fitted curve if the fit succeeded (popt has no NaN)
+    if fit is not None:
+        popt = fit.popt.values  # shape (5,): [f0, fwhm, amp, bg0, bg1]
+        if not np.any(np.isnan(popt)):
+            full_freq_q = ds_q.full_freq.values  # absolute Hz
+            detuning_mhz = ds_q.detuning.values / u.MHz
+
+            # Restrict the drawn curve to the window popt was actually fit on: the
+            # background (bg0, bg1) is only valid there, and linearly extrapolating
+            # it across the full sweep can diverge sharply from the data outside it.
+            if "fit_win_lo" in fit and "fit_win_hi" in fit:
+                win_lo, win_hi = float(fit.fit_win_lo.values), float(fit.fit_win_hi.values)
+                if not (np.isnan(win_lo) or np.isnan(win_hi)):
+                    win_mask = (full_freq_q >= win_lo) & (full_freq_q <= win_hi)
+                    full_freq_q = full_freq_q[win_mask]
+                    detuning_mhz = detuning_mhz[win_mask]
+
+            fitted_curve_mv = lorentzian_dip_linbg(full_freq_q, *popt) / u.mV
+
+            f0_ghz = popt[0] / u.GHz
+            fwhm_mhz = popt[1] / u.MHz
+
+            # Dashed fit line with annotation in legend
+            ax2.plot(
+                detuning_mhz, fitted_curve_mv,
+                "r--", linewidth=st.lw_fit,
+                label=f"fit: f₀={f0_ghz:.4f} GHz, FWHM={fwhm_mhz:.2f} MHz",
+            )
+
+            # Semi-transparent FWHM band (on detuning axis). center_hz is the constant
+            # RF_frequency offset (full_freq - detuning); must come from the unfiltered
+            # arrays so its index-0 pairing is valid even after full_freq_q is windowed.
+            center_hz = ds_q.full_freq.values[0] - ds_q.detuning.values[0]
+            det_f0_mhz = (popt[0] - center_hz) / u.MHz
+            ax2.axvspan(
+                det_f0_mhz - fwhm_mhz / 2,
+                det_f0_mhz + fwhm_mhz / 2,
+                alpha=0.15, color="red",
+            )
+
+            ax2.legend(fontsize=st.fs_legend, loc="upper right")
+
+    # Pin the detuning twin to the RF axis after all overlays (fixes the "two diverging
+    # lines" desync when a bad/edge fit's FWHM band falls outside the swept range).
+    _relock_twin_axis(ax, ax2, ds_q.full_freq.values[0] - ds_q.detuning.values[0])
+
+
+def plot_detrended_phase(
+    ds: xr.Dataset,
+    qubits: list[AnyTransmon],
+    fits: xr.Dataset | None = None,
+) -> Figure:
+    """Plot background-subtracted phase to isolate the resonance phase step.
+
+    A degree-3 polynomial is fitted to phase data outside ±3×FWHM around f0
+    (when fit data is available) and subtracted from the raw phase.  Without
+    fit data a global degree-3 polynomial is used.  This removes the large
+    bowl-shaped cable/electronics background and shows just the dispersive
+    resonance phase step.
     """
     grid = QubitGrid(ds, [q.grid_location for q in qubits])
+    st = _style_for_grid(grid)
     for ax, qubit in grid_iter(grid):
-        plot_individual_amplitude_with_fit(ax, ds, qubit, fits.sel(qubit=qubit["qubit"]))
+        ds_q = ds.loc[qubit]
+        detuning_mhz = ds_q.detuning.values / u.MHz
+        phase = ds_q.phase.values
+        full_freq_hz = ds_q.full_freq.values
+        qubit_name = qubit["qubit"]
 
-    grid.fig.suptitle("Resonator spectroscopy (amplitude + fit)")
-    grid.fig.set_size_inches(15, 9)
-    grid.fig.tight_layout()
-    return grid.fig
+        det_f0_mhz = None
+        f0_hz_val = np.nan
+        bg_mask = np.ones(len(detuning_mhz), dtype=bool)
+
+        if fits is not None:
+            fit_q = fits.sel(qubit=qubit_name)
+            f0_hz_val = float(fit_q.f0.values)
+            fwhm_hz_val = float(fit_q.fwhm.values)
+            if not np.isnan(f0_hz_val) and not np.isnan(fwhm_hz_val) and fwhm_hz_val > 0:
+                center_hz = full_freq_hz[0] - ds_q.detuning.values[0]
+                det_f0_mhz = (f0_hz_val - center_hz) / u.MHz
+                exclusion_half_mhz = 3.0 * fwhm_hz_val / u.MHz
+                bg_mask = np.abs(detuning_mhz - det_f0_mhz) > exclusion_half_mhz
+
+        # Polynomial background fit; fall back to full trace if mask too sparse
+        if bg_mask.sum() >= 4:
+            coeffs = np.polyfit(detuning_mhz[bg_mask], phase[bg_mask], deg=3)
+        else:
+            coeffs = np.polyfit(detuning_mhz, phase, deg=3)
+        phase_bg = np.polyval(coeffs, detuning_mhz)
+        phase_detrended = phase - phase_bg
+
+        ax.plot(detuning_mhz, phase_detrended, color="steelblue", linewidth=st.lw_line)
+        ax.axhline(0, color="gray", linewidth=st.lw_hair, linestyle=":")
+        ax.set_xlabel("Detuning [MHz]", fontsize=st.fs_label)
+        ax.set_ylabel("phase residual [rad]", fontsize=st.fs_label)
+        ax.set_title(f"qubit = {qubit_name}", loc="center", fontsize=st.fs_title, pad=st.pad)
+        _apply_tick_fontsize(ax, st.fs_tick)
+
+        if det_f0_mhz is not None:
+            ax.axvline(
+                det_f0_mhz, color="red", linestyle="--", linewidth=st.lw_gd,
+                label=f"f₀={f0_hz_val / u.GHz:.4f} GHz",
+            )
+            ax.legend(fontsize=st.fs_legend, loc="upper right")
+
+    return _finalize(grid, st, "Resonator spectroscopy (detrended phase)")
 
 
-def plot_individual_amplitude_with_fit(ax: Axes, ds: xr.Dataset, qubit: dict[str, str], fit: xr.Dataset = None):
+def plot_iq_circle(
+    ds: xr.Dataset,
+    qubits: list[AnyTransmon],
+    fits: xr.Dataset | None = None,
+) -> Figure:
+    """Plot I vs Q parametric trace, colour-coded by detuning.
+
+    Each point corresponds to one frequency step.  A semi-transparent line
+    connects the points in frequency order to make the trace direction visible.
+    Evenly-spaced arrows are added along the trace to indicate sweep direction.
+    The colour encodes the detuning value so that the rotation around the
+    resonance is immediately visible.  A red star marks the IQ point closest
+    to the fitted f0.
+
+    A single shared colorbar is used for the whole figure so that per-subplot
+    axes are not shifted — this keeps subplot titles visually centered.
     """
-    Plots individual qubit data on a given axis with optional fit.
+    grid = QubitGrid(ds, [q.grid_location for q in qubits])
+    st = _style_for_grid(grid)
 
-    Parameters
-    ----------
-    ax : matplotlib.axes.Axes
-        The axis on which to plot the data.
-    ds : xr.Dataset
-        The dataset containing the quadrature data.
-    qubit : dict[str, str]
-        mapping to the qubit to plot.
-    fit : xr.Dataset, optional
-        The dataset containing the fit parameters (default is None).
+    for ax, qubit in grid_iter(grid):
+        ds_q = ds.loc[qubit]
+        I_mV = ds_q["I"].values / u.mV
+        Q_mV = ds_q["Q"].values / u.mV
+        detuning_mhz = ds_q.detuning.values / u.MHz
+        qubit_name = qubit["qubit"]
 
-    Notes
-    -----
-    - If the fit dataset is provided, the fitted curve is plotted along with the raw data.
-    """
-    if fit:
-        fitted_data = lorentzian_dip(
-            ds.detuning,
-            float(fit.amplitude.values),
-            float(fit.position.values),
-            float(fit.width.values) / 2,
-            float(fit.base_line.mean().values),
+        # Connecting line (behind dots) to show trace continuity
+        ax.plot(I_mV, Q_mV, color="gray", linewidth=st.lw_thin, alpha=0.35, zorder=1)
+
+        # Scatter coloured by detuning
+        sc = ax.scatter(
+            I_mV, Q_mV,
+            c=detuning_mhz, cmap="plasma", s=st.scatter_s, zorder=2,
         )
-    else:
-        fitted_data = None
 
-    # Create a first x-axis for full_freq_GHz
-    (ds.assign_coords(full_freq_GHz=ds.full_freq / u.GHz).loc[qubit].IQ_abs / u.mV).plot(ax=ax, x="full_freq_GHz")
-    ax.set_xlabel("RF frequency [GHz]")
-    ax.set_ylabel(r"$R=\sqrt{I^2 + Q^2}$ [mV]")
-    # Create a second x-axis for detuning_MHz
-    ax2 = ax.twiny()
-    (ds.assign_coords(detuning_MHz=ds.detuning / u.MHz).loc[qubit].IQ_abs / u.mV).plot(ax=ax2, x="detuning_MHz")
-    ax2.set_xlabel("Detuning [MHz]")
-    # Plot the fitted data
-    if fitted_data is not None:
-        ax2.plot(ds.detuning / u.MHz, fitted_data / u.mV, "r--")
+        # Directional arrows evenly spaced along the trace (skip for a degenerate trace)
+        n_arrows = 8
+        arrow_indices = np.linspace(0, len(I_mV) - 2, n_arrows, dtype=int) if len(I_mV) >= 3 else []
+        for ai in arrow_indices:
+            ax.annotate(
+                "",
+                xy=(I_mV[ai + 1], Q_mV[ai + 1]),
+                xytext=(I_mV[ai], Q_mV[ai]),
+                arrowprops=dict(
+                    arrowstyle="-|>",
+                    color="dimgray",
+                    lw=st.lw_fit,
+                    alpha=0.55,
+                    mutation_scale=st.arrow_scale,
+                ),
+                zorder=4,
+            )
+
+        ax.set_aspect("equal")
+        ax.set_xlabel("I [mV]", fontsize=st.fs_label)
+        ax.set_ylabel("Q [mV]", fontsize=st.fs_label)
+        _apply_tick_fontsize(ax, st.fs_tick)
+
+        # Per-subplot colorbar (placed adjacent to this axes)
+        cbar = ax.figure.colorbar(sc, ax=ax, pad=0.02)
+        cbar.set_label("Detuning [MHz]", fontsize=st.fs_cbar)
+        cbar.ax.tick_params(labelsize=st.fs_cbar)
+
+        # Title set AFTER colorbar so it is centered over the (now-final) axes width
+        ax.set_title(f"qubit = {qubit_name}", loc="center", fontsize=st.fs_title, pad=st.pad)
+
+        # Mark the IQ point nearest the fitted resonance frequency
+        if fits is not None:
+            fit_q = fits.sel(qubit=qubit_name)
+            f0_hz = float(fit_q.f0.values)
+            if not np.isnan(f0_hz):
+                full_freq_hz = ds_q.full_freq.values
+                idx = int(np.argmin(np.abs(full_freq_hz - f0_hz)))
+                ax.scatter(
+                    I_mV[idx], Q_mV[idx],
+                    color="red", marker="*", s=st.star_s, zorder=5,
+                    label=f"f₀={f0_hz / u.GHz:.4f} GHz",
+                )
+                ax.legend(fontsize=st.fs_legend, loc="upper right")
+
+    return _finalize(grid, st, "Resonator spectroscopy (IQ circle)")

--- a/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/resonator_spectroscopy/plotting.py
@@ -52,35 +52,36 @@ def _relock_twin_axis(ax: Axes, ax2: Axes, center_hz: float) -> None:
     lo, hi = ax.get_xlim()  # GHz
     ax2.set_xlim((lo * u.GHz - center_hz) / u.MHz, (hi * u.GHz - center_hz) / u.MHz)
 
+
 # ---------------------------------------------------------------------------
 # Reference single-panel geometry + bounds (tune the figure look here)
 # ---------------------------------------------------------------------------
 # The "gold" single-qubit panel: a 1x1 grid renders at exactly this size with
 # the base font sizes below, reproducing the original single-qubit figure.
-_REF_PANEL_W = 15.0   # inches, width of one reference panel
-_REF_PANEL_H = 9.0    # inches, height of one reference panel
+_REF_PANEL_W = 15.0  # inches, width of one reference panel
+_REF_PANEL_H = 9.0  # inches, height of one reference panel
 
 # Maximum total figure size for a multiplexed grid.  The scale factor never
 # exceeds 1, so panels are never *larger* than the reference; for large grids
 # the figure is capped at these dimensions and fonts shrink to fit.
-_TARGET_W = 24.0      # inches, max total figure width
-_TARGET_H = 15.0      # inches, max total figure height
+_TARGET_W = 24.0  # inches, max total figure width
+_TARGET_H = 15.0  # inches, max total figure height
 
 # ---------------------------------------------------------------------------
 # Base (gold) font / pad sizes — these apply unscaled to a single panel
 # ---------------------------------------------------------------------------
-_BASE_FS_SUPTITLE = 28   # figure suptitle
-_BASE_FS_TITLE    = 24   # per-subplot title
-_BASE_FS_LABEL    = 24   # axis label (xlabel / ylabel)
-_BASE_FS_TICK     = 22   # tick-label size
-_BASE_FS_LEGEND   = 20   # legend text
-_BASE_FS_CBAR     = 20   # colorbar label / ticks
+_BASE_FS_SUPTITLE = 28  # figure suptitle
+_BASE_FS_TITLE = 24  # per-subplot title
+_BASE_FS_LABEL = 24  # axis label (xlabel / ylabel)
+_BASE_FS_TICK = 22  # tick-label size
+_BASE_FS_LEGEND = 20  # legend text
+_BASE_FS_CBAR = 20  # colorbar label / ticks
 
 # Extra vertical padding (pts) for subplot titles on plots that have a twiny()
 # top x-axis: the top ticks + "Detuning [MHz]" label need to be cleared.
 # Rule of thumb: ~1.5 x (_FS_TICK + _FS_LABEL) in points (at full scale).
-_BASE_TITLE_PAD_TWINY = 40   # plots with twiny top x-axis
-_BASE_TITLE_PAD       =  8   # plots without a top x-axis
+_BASE_TITLE_PAD_TWINY = 40  # plots with twiny top x-axis
+_BASE_TITLE_PAD = 8  # plots without a top x-axis
 
 
 def _clip(value: float, floor: float) -> float:
@@ -175,18 +176,14 @@ def plot_raw_phase(
         qubit_name = qubit["qubit"]
 
         # Primary axis: absolute RF frequency [GHz], left y: phase
-        ds_q.assign_coords(full_freq_GHz=ds_q.full_freq / u.GHz).phase.plot(
-            ax=ax1, x="full_freq_GHz"
-        )
+        ds_q.assign_coords(full_freq_GHz=ds_q.full_freq / u.GHz).phase.plot(ax=ax1, x="full_freq_GHz")
         ax1.set_xlabel("RF frequency [GHz]", fontsize=st.fs_label)
         ax1.set_ylabel("phase [rad]", fontsize=st.fs_label)
         _apply_tick_fontsize(ax1, st.fs_tick)
 
         # Top x-axis: detuning [MHz]
         ax2 = ax1.twiny()
-        ds_q.assign_coords(detuning_MHz=ds_q.detuning / u.MHz).phase.plot(
-            ax=ax2, x="detuning_MHz"
-        )
+        ds_q.assign_coords(detuning_MHz=ds_q.detuning / u.MHz).phase.plot(ax=ax2, x="detuning_MHz")
         ax2.set_xlabel("Detuning [MHz]", fontsize=st.fs_label)
         ax2.set_title("")  # clear any auto-title xarray set on the twin axis
         _apply_tick_fontsize(ax2, st.fs_tick)
@@ -195,8 +192,12 @@ def plot_raw_phase(
         tau_ns = -np.gradient(phase, full_freq_hz) * 1e9
         ax_gd = ax1.twinx()
         ax_gd.plot(
-            full_freq_ghz, tau_ns,
-            color="darkorange", linewidth=st.lw_gd, alpha=0.7, label="group delay",
+            full_freq_ghz,
+            tau_ns,
+            color="darkorange",
+            linewidth=st.lw_gd,
+            alpha=0.7,
+            label="group delay",
         )
         ax_gd.set_ylabel("-dφ/df [ns]", color="darkorange", fontsize=st.fs_label)
         ax_gd.tick_params(axis="y", colors="darkorange", labelsize=st.fs_tick)
@@ -211,7 +212,10 @@ def plot_raw_phase(
             if not np.isnan(f0_hz):
                 f0_ghz_val = f0_hz / u.GHz
                 ax1.axvline(
-                    f0_ghz_val, color="red", linestyle="--", linewidth=st.lw_gd,
+                    f0_ghz_val,
+                    color="red",
+                    linestyle="--",
+                    linewidth=st.lw_gd,
                     label=f"f₀={f0_ghz_val:.4f} GHz",
                 )
                 ax1.legend(fontsize=st.fs_legend, loc="upper right")
@@ -222,9 +226,7 @@ def plot_raw_phase(
     return _finalize(grid, st, "Resonator spectroscopy (phase)")
 
 
-def plot_raw_amplitude_with_fit(
-    ds: xr.Dataset, qubits: list[AnyTransmon], fits: xr.Dataset
-) -> Figure:
+def plot_raw_amplitude_with_fit(ds: xr.Dataset, qubits: list[AnyTransmon], fits: xr.Dataset) -> Figure:
     """Plot IQ amplitude with fitted curves for all qubits on a grid."""
     grid = QubitGrid(ds, [q.grid_location for q in qubits])
     st = _style_for_grid(grid)
@@ -257,26 +259,26 @@ def plot_individual_amplitude_with_fit(
     """
     if st is None:
         st = SimpleNamespace(
-            fs_label=_BASE_FS_LABEL, fs_title=_BASE_FS_TITLE, fs_tick=_BASE_FS_TICK,
-            fs_legend=_BASE_FS_LEGEND, pad_twiny=_BASE_TITLE_PAD_TWINY, lw_fit=1.5,
+            fs_label=_BASE_FS_LABEL,
+            fs_title=_BASE_FS_TITLE,
+            fs_tick=_BASE_FS_TICK,
+            fs_legend=_BASE_FS_LEGEND,
+            pad_twiny=_BASE_TITLE_PAD_TWINY,
+            lw_fit=1.5,
         )
 
     ds_q = ds.loc[qubit]
     qubit_name = qubit["qubit"]
 
     # Primary x-axis: absolute RF frequency in GHz
-    (ds_q.assign_coords(full_freq_GHz=ds_q.full_freq / u.GHz).IQ_abs / u.mV).plot(
-        ax=ax, x="full_freq_GHz"
-    )
+    (ds_q.assign_coords(full_freq_GHz=ds_q.full_freq / u.GHz).IQ_abs / u.mV).plot(ax=ax, x="full_freq_GHz")
     ax.set_xlabel("RF frequency [GHz]", fontsize=st.fs_label)
     ax.set_ylabel(r"$R=\sqrt{I^2+Q^2}$ [mV]", fontsize=st.fs_label)
     _apply_tick_fontsize(ax, st.fs_tick)
 
     # Secondary x-axis: detuning in MHz
     ax2 = ax.twiny()
-    (ds_q.assign_coords(detuning_MHz=ds_q.detuning / u.MHz).IQ_abs / u.mV).plot(
-        ax=ax2, x="detuning_MHz"
-    )
+    (ds_q.assign_coords(detuning_MHz=ds_q.detuning / u.MHz).IQ_abs / u.mV).plot(ax=ax2, x="detuning_MHz")
     ax2.set_xlabel("Detuning [MHz]", fontsize=st.fs_label)
     ax2.set_title("")  # clear xarray auto-title on twin axis
     _apply_tick_fontsize(ax2, st.fs_tick)
@@ -328,8 +330,10 @@ def plot_individual_amplitude_with_fit(
 
             # Dashed fit line with annotation in legend
             ax2.plot(
-                detuning_mhz, fitted_curve_mv,
-                "r--", linewidth=st.lw_fit,
+                detuning_mhz,
+                fitted_curve_mv,
+                "r--",
+                linewidth=st.lw_fit,
                 label=f"fit: f₀={f0_ghz:.4f} GHz, FWHM={fwhm_mhz:.2f} MHz",
             )
 
@@ -341,7 +345,8 @@ def plot_individual_amplitude_with_fit(
             ax2.axvspan(
                 det_f0_mhz - fwhm_mhz / 2,
                 det_f0_mhz + fwhm_mhz / 2,
-                alpha=0.15, color="red",
+                alpha=0.15,
+                color="red",
             )
 
             ax2.legend(fontsize=st.fs_legend, loc="upper right")
@@ -404,7 +409,10 @@ def plot_detrended_phase(
 
         if det_f0_mhz is not None:
             ax.axvline(
-                det_f0_mhz, color="red", linestyle="--", linewidth=st.lw_gd,
+                det_f0_mhz,
+                color="red",
+                linestyle="--",
+                linewidth=st.lw_gd,
                 label=f"f₀={f0_hz_val / u.GHz:.4f} GHz",
             )
             ax.legend(fontsize=st.fs_legend, loc="upper right")
@@ -444,8 +452,12 @@ def plot_iq_circle(
 
         # Scatter coloured by detuning
         sc = ax.scatter(
-            I_mV, Q_mV,
-            c=detuning_mhz, cmap="plasma", s=st.scatter_s, zorder=2,
+            I_mV,
+            Q_mV,
+            c=detuning_mhz,
+            cmap="plasma",
+            s=st.scatter_s,
+            zorder=2,
         )
 
         # Directional arrows evenly spaced along the trace (skip for a degenerate trace)
@@ -487,8 +499,12 @@ def plot_iq_circle(
                 full_freq_hz = ds_q.full_freq.values
                 idx = int(np.argmin(np.abs(full_freq_hz - f0_hz)))
                 ax.scatter(
-                    I_mV[idx], Q_mV[idx],
-                    color="red", marker="*", s=st.star_s, zorder=5,
+                    I_mV[idx],
+                    Q_mV[idx],
+                    color="red",
+                    marker="*",
+                    s=st.star_s,
+                    zorder=5,
                     label=f"f₀={f0_hz / u.GHz:.4f} GHz",
                 )
                 ax.legend(fontsize=st.fs_legend, loc="upper right")

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
@@ -1,8 +1,9 @@
 # %% {Imports}
-import matplotlib.pyplot as plt
+from dataclasses import asdict
+
 import numpy as np
 import xarray as xr
-from dataclasses import asdict
+import matplotlib.pyplot as plt
 
 from qm.qua import *
 
@@ -11,8 +12,15 @@ from qualang_tools.multi_user import qm_session
 from qualang_tools.results import progress_counter
 from qualang_tools.units import unit
 
+from qualibration_libs.core import tracked_updates
+from qualibration_libs.parameters import get_qubits
+from qualibration_libs.runtime import simulate_and_plot
+from qualibration_libs.data import XarrayDataFetcher
+
 from qualibrate import QualibrationNode
+
 from quam_config import Quam
+
 from calibration_utils.resonator_spectroscopy import (
     Parameters,
     process_raw_dataset,
@@ -20,10 +28,14 @@ from calibration_utils.resonator_spectroscopy import (
     log_fitted_results,
     plot_raw_amplitude_with_fit,
     plot_raw_phase,
+    plot_detrended_phase,
+    plot_iq_circle,
 )
-from qualibration_libs.parameters import get_qubits
-from qualibration_libs.runtime import simulate_and_plot
-from qualibration_libs.data import XarrayDataFetcher
+from calibration_utils.resonator_spectroscopy.escalation import (
+    plan_span_escalation,
+    plan_lo_recenter,
+)
+
 
 # %% {Node initialisation}
 description = """
@@ -55,28 +67,34 @@ node = QualibrationNode[Parameters, Quam](
 # Any parameters that should change for debugging purposes only should go in here
 # These parameters are ignored when run through the GUI or as part of a graph
 @node.run_action(skip_if=node.modes.external)
-def custom_param(node: QualibrationNode[Parameters, Quam]):
+def custom_param(node: QualibrationNode[Parameters, Quam]) -> None:
     """Allow the user to locally set the node parameters for debugging purposes, or execution in the Python IDE."""
     # You can get type hinting in your IDE by typing node.parameters.
-    # node.parameters.qubits = ["q1", "q2"]
+    node.parameters.qubits = ["qA1"] # XXX
     pass
 
 
-# %% {Create_QUA_program}
-@node.run_action(skip_if=node.parameters.load_data_id is not None)
-def create_qua_program(node: QualibrationNode[Parameters, Quam]):
-    """Create the sweep axes and generate the QUA program from the pulse sequence and the node parameters."""
+# Stash the re-fit overrides before load_from_id() can overwrite node.parameters
+_stored_re_fit_resonators = node.parameters.re_fit_resonators
+_stored_re_fit_centers_ghz = node.parameters.re_fit_centers_ghz
+_stored_re_fit_span_mhz = node.parameters.re_fit_span_mhz
+
+
+# %% {Program_helpers}
+def _setup_sweep_and_program(node: QualibrationNode[Parameters, Quam], span_hz: float) -> None:
+    """Build the sweep axes + QUA program for a symmetric ±span/2 scan.
+
+    Shared by the initial pass and the no-dip span-escalation retries, so both
+    measure through the identical sequence (only the span differs).
+    """
     # Class containing tools to help handle units and conversions.
     u = unit(coerce_to_integer=True)
-    # Get the active qubits from the node and organize them by batches
-    node.namespace["qubits"] = qubits = get_qubits(node)
+    qubits = node.namespace["qubits"]
     num_qubits = len(qubits)
     # Extract the sweep parameters and axes from the node parameters
     n_avg = node.parameters.num_shots
-    # The frequency sweep around the resonator resonance frequency
-    span = node.parameters.frequency_span_in_mhz * u.MHz
     step = node.parameters.frequency_step_in_mhz * u.MHz
-    dfs = np.arange(-span / 2, +span / 2, step)
+    dfs = np.arange(-span_hz / 2, +span_hz / 2, step)
     # Register the sweep axes to be added to the dataset when fetching data
     node.namespace["sweep_axes"] = {
         "qubit": xr.DataArray(qubits.get_names()),
@@ -116,24 +134,8 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
                 Q_st[i].buffer(len(dfs)).average().save(f"Q{i + 1}")
 
 
-# %% {Simulate}
-@node.run_action(skip_if=node.parameters.load_data_id is not None or not node.parameters.simulate)
-def simulate_qua_program(node: QualibrationNode[Parameters, Quam]):
-    """Connect to the QOP and simulate the QUA program"""
-    # Connect to the QOP
-    qmm = node.machine.connect()
-    # Get the config from the machine
-    config = node.machine.generate_config()
-    # Simulate the QUA program, generate the waveform report and plot the simulated samples
-    samples, fig, wf_report = simulate_and_plot(qmm, config, node.namespace["qua_program"], node.parameters)
-    # Store the figure, waveform report and simulated samples
-    node.results["simulation"] = {"figure": fig, "wf_report": wf_report, "samples": samples}
-
-
-# %% {Execute}
-@node.run_action(skip_if=node.parameters.load_data_id is not None or node.parameters.simulate)
-def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
-    """Connect to the QOP, execute the QUA program and fetch the raw data and store it in a xarray dataset called "ds_raw"."""
+def _execute_and_fetch(node: QualibrationNode[Parameters, Quam]) -> None:
+    """Connect, run the prepared QUA program, and store "ds_raw" (shared with the retries)."""
     # Connect to the QOP
     qmm = node.machine.connect()
     # Get the config from the machine
@@ -156,22 +158,8 @@ def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
     node.results["ds_raw"] = dataset
 
 
-# %% {Load_historical_data}
-@node.run_action(skip_if=node.parameters.load_data_id is None)
-def load_data(node: QualibrationNode[Parameters, Quam]):
-    """Load a previously acquired dataset."""
-    load_data_id = node.parameters.load_data_id
-    # Load the specified dataset
-    node.load_from_id(node.parameters.load_data_id)
-    node.parameters.load_data_id = load_data_id
-    # Get the active qubits from the loaded node parameters
-    node.namespace["qubits"] = get_qubits(node)
-
-
-# %% {Analyse_data}
-@node.run_action(skip_if=node.parameters.simulate)
-def analyse_data(node: QualibrationNode[Parameters, Quam]):
-    """Analyse the raw data and store the fitted data in another xarray dataset "ds_fit" and the fitted results in the "fit_results" dictionary."""
+def _analyse(node: QualibrationNode[Parameters, Quam]) -> None:
+    """Process + fit + log + outcomes (shared between the main pass and the retries)."""
     node.results["ds_raw"] = process_raw_dataset(node.results["ds_raw"], node)
     node.results["ds_fit"], fit_results = fit_raw_data(node.results["ds_raw"], node)
     node.results["fit_results"] = {k: asdict(v) for k, v in fit_results.items()}
@@ -184,25 +172,155 @@ def analyse_data(node: QualibrationNode[Parameters, Quam]):
     }
 
 
+# %% {Create_QUA_program}
+@node.run_action(skip_if=node.parameters.load_data_id is not None)
+def create_qua_program(node: QualibrationNode[Parameters, Quam]) -> None:
+    """Create the sweep axes and generate the QUA program from the pulse sequence and the node parameters."""
+    # Class containing tools to help handle units and conversions.
+    u = unit(coerce_to_integer=True)
+    # Get the active qubits from the node and organize them by batches
+    node.namespace["qubits"] = get_qubits(node)
+    _setup_sweep_and_program(node, node.parameters.frequency_span_in_mhz * u.MHz)
+
+
+# %% {Simulate}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or not node.parameters.simulate)
+def simulate_qua_program(node: QualibrationNode[Parameters, Quam]) -> None:
+    """Connect to the QOP and simulate the QUA program"""
+    # Connect to the QOP
+    qmm = node.machine.connect()
+    # Get the config from the machine
+    config = node.machine.generate_config()
+    # Simulate the QUA program, generate the waveform report and plot the simulated samples
+    samples, fig, wf_report = simulate_and_plot(qmm, config, node.namespace["qua_program"], node.parameters)
+    # Store the figure, waveform report and simulated samples
+    node.results["simulation"] = {"figure": fig, "wf_report": wf_report, "samples": samples}
+
+
+# %% {Execute}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or node.parameters.simulate)
+def execute_qua_program(node: QualibrationNode[Parameters, Quam]) -> None:
+    """Connect to the QOP, execute the QUA program and fetch the raw data and store it in a xarray dataset called "ds_raw"."""
+    _execute_and_fetch(node)
+
+
+# %% {Load_historical_data}
+@node.run_action(skip_if=node.parameters.load_data_id is None)
+def load_data(node: QualibrationNode[Parameters, Quam]) -> None:
+    """Load a previously acquired dataset."""
+    load_data_id = node.parameters.load_data_id
+    # Load the specified dataset (this overwrites node.parameters)
+    node.load_from_id(node.parameters.load_data_id)
+    node.parameters.load_data_id = load_data_id
+    # Restore the re-fit overrides that were set by the user for this re-analysis run
+    node.parameters.re_fit_resonators = _stored_re_fit_resonators
+    node.parameters.re_fit_centers_ghz = _stored_re_fit_centers_ghz
+    node.parameters.re_fit_span_mhz = _stored_re_fit_span_mhz
+    # Get the active qubits from the loaded node parameters
+    node.namespace["qubits"] = get_qubits(node)
+
+
+# %% {Analyse_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def analyse_data(node: QualibrationNode[Parameters, Quam]) -> None:
+    """Analyse the raw data and store the fitted data in another xarray dataset "ds_fit" and the fitted results in the "fit_results" dictionary."""
+    _analyse(node)
+
+
+# %% {Escalate_no_dip}
+@node.run_action(
+    skip_if=node.parameters.simulate
+    or node.parameters.load_data_id is not None
+    or not node.parameters.escalate_on_no_dip
+)
+def escalate_no_dip(node: QualibrationNode[Parameters, Quam]) -> None:
+    """Bring-up span-escalation: when no significant dip was found, re-measure with
+    the span doubled (up to ``max_escalation_span_in_mhz``), re-centering each
+    affected readout LO when the wider sweep would exceed the IF reach (same
+    tracked-LO pattern as node 09b; reverted after the retry ladder).
+
+    All active qubits are re-measured together at the wider span (homogeneous
+    dataset -> plots and ds_fit stay consistent); already-found dips simply
+    re-fit at the wider span. Every rung is recorded in results["escalation"].
+    """
+    u = unit(coerce_to_integer=True)
+    span = node.parameters.frequency_span_in_mhz * u.MHz
+    max_span = node.parameters.max_escalation_span_in_mhz * u.MHz
+    audit = []
+    tracked = node.namespace.setdefault("tracked_lo_qubits", [])
+
+    while True:
+        plan = plan_span_escalation(node.results["fit_results"], span, max_span)
+        if not plan["retry"]:
+            break
+        span = plan["new_span_hz"]
+        node.log(
+            f"escalation: no dip on {plan['qubits']} -> re-measuring all active qubits "
+            f"at span {span / 1e6:.0f} MHz"
+        )
+        # Re-center LOs where the wider sweep would push the IF out of reach.
+        lo_moves = {}
+        for q in node.namespace["qubits"]:
+            rr = q.resonator
+            lo_plan = plan_lo_recenter(
+                rf_hz=rr.RF_frequency,
+                lo_hz=rr.opx_output.upconverter_frequency,
+                span_hz=span,
+                band=getattr(rr.opx_output, "band", None),
+            )
+            if lo_plan["error"]:
+                node.log(f"escalation: {q.name}: {lo_plan['error']} — keeping current LO")
+                continue
+            if lo_plan["shift"]:
+                with tracked_updates(q, auto_revert=False, dont_assign_to_none=False) as q_upd:
+                    q_upd.resonator.opx_output.upconverter_frequency = lo_plan["new_lo_hz"]
+                    tracked.append(q_upd)
+                lo_moves[q.name] = lo_plan["new_lo_hz"]
+                node.log(f"escalation: {q.name}: LO re-centered to {lo_plan['new_lo_hz'] / 1e9:.4f} GHz")
+        audit.append(dict(span_hz=float(span), retried=plan["qubits"], lo_moves=lo_moves))
+        _setup_sweep_and_program(node, span)
+        _execute_and_fetch(node)
+        _analyse(node)
+
+    node.results["escalation"] = audit
+    # Revert the LO moves so the state file is untouched by the scan mechanics
+    # (the resonator frequency itself is written by update_state from the fit).
+    for q_upd in tracked:
+        q_upd.revert_changes()
+    node.namespace["tracked_lo_qubits"] = []
+
+
 # %% {Plot_data}
 @node.run_action(skip_if=node.parameters.simulate)
-def plot_data(node: QualibrationNode[Parameters, Quam]):
-    """Plot the raw and fitted data in specific figures whose shape is given by qubit.grid_location."""
-    fig_raw_phase = plot_raw_phase(node.results["ds_raw"], node.namespace["qubits"])
-    fig_fit_amplitude = plot_raw_amplitude_with_fit(
-        node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"]
-    )
+def plot_data(node: QualibrationNode[Parameters, Quam]) -> None:
+    """Plot the raw and fitted data in specific figures whose shape is given by qubit.grid_location.
+
+    Amplitude+fit and detrended phase are the primary diagnostics and always shown.
+    Raw phase and the IQ circle are secondary/troubleshooting views, gated behind
+    show_raw_phase_plot / show_iq_circle_plot to keep the default output focused.
+    """
+    figures = {
+        "amplitude": plot_raw_amplitude_with_fit(
+            node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"]
+        ),
+        "detrended_phase": plot_detrended_phase(
+            node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"]
+        ),
+    }
+    if node.parameters.show_raw_phase_plot:
+        figures["phase"] = plot_raw_phase(node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"])
+    if node.parameters.show_iq_circle_plot:
+        figures["iq_circle"] = plot_iq_circle(
+            node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"]
+        )
     plt.show()
     # Store the generated figures
-    node.results["figures"] = {
-        "phase": fig_raw_phase,
-        "amplitude": fig_fit_amplitude,
-    }
+    node.results["figures"] = figures
 
 
 # %% {Update_state}
 @node.run_action(skip_if=node.parameters.simulate)
-def update_state(node: QualibrationNode[Parameters, Quam]):
+def update_state(node: QualibrationNode[Parameters, Quam]) -> None:
     """Update the relevant parameters if the qubit data analysis was successful."""
     with node.record_state_updates():
         for q in node.namespace["qubits"]:
@@ -215,5 +333,9 @@ def update_state(node: QualibrationNode[Parameters, Quam]):
 
 # %% {Save_results}
 @node.run_action()
-def save_results(node: QualibrationNode[Parameters, Quam]):
+def save_results(node: QualibrationNode[Parameters, Quam]) -> None:
+    # Safety net: revert any escalation LO shift that survived an aborted retry
+    # ladder (e.g. an exception between shift and revert) before saving state.
+    for q_upd in node.namespace.get("tracked_lo_qubits", []) or []:
+        q_upd.revert_changes()
     node.save()

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
@@ -167,7 +167,7 @@ def _analyse(node: QualibrationNode[Parameters, Quam]) -> None:
 
     node.results["ds_fit"] = ds_fit
     node.results["fit_results"] = {k: asdict(v) for k, v in fit_results.items()}
-    
+
     # Keep the typed results around too, for the escalation retry ladder.
     node.namespace["fit_results"] = fit_results
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
@@ -166,7 +166,11 @@ def _analyse(node: QualibrationNode[Parameters, Quam]) -> None:
     # Log the relevant information extracted from the data analysis
     log_fitted_results(node.results["fit_results"], log_callable=node.log)
     node.outcomes = {
-        qubit_name: ("successful" if fit_result["success"] else "failed")
+        qubit_name: (
+            "successful"
+            if fit_result["success"] and not fit_result.get("ambiguous", False)
+            else "failed"
+        )
         for qubit_name, fit_result in node.results["fit_results"].items()
     }
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
@@ -23,6 +23,7 @@ from quam_config import Quam
 
 from calibration_utils.resonator_spectroscopy import (
     Parameters,
+    FitParameters,
     process_raw_dataset,
     fit_raw_data,
     log_fitted_results,
@@ -159,19 +160,22 @@ def _execute_and_fetch(node: QualibrationNode[Parameters, Quam]) -> None:
 
 def _analyse(node: QualibrationNode[Parameters, Quam]) -> None:
     """Process + fit + log + outcomes (shared between the main pass and the retries)."""
+
     node.results["ds_raw"] = process_raw_dataset(node.results["ds_raw"], node)
-    node.results["ds_fit"], fit_results = fit_raw_data(node.results["ds_raw"], node)
+    ds_fit, fit_results = fit_raw_data(node.results["ds_raw"], node)
+    fit_results: dict[str, FitParameters]
+
+    node.results["ds_fit"] = ds_fit
     node.results["fit_results"] = {k: asdict(v) for k, v in fit_results.items()}
+    
+    # Keep the typed results around too, for the escalation retry ladder.
+    node.namespace["fit_results"] = fit_results
 
     # Log the relevant information extracted from the data analysis
-    log_fitted_results(node.results["fit_results"], log_callable=node.log)
+    log_fitted_results(fit_results, log_callable=node.log)
     node.outcomes = {
-        qubit_name: (
-            "successful"
-            if fit_result["success"] and not fit_result.get("ambiguous", False)
-            else "failed"
-        )
-        for qubit_name, fit_result in node.results["fit_results"].items()
+        qubit_name: ("successful" if fit_result.success and not fit_result.ambiguous else "failed")
+        for qubit_name, fit_result in fit_results.items()
     }
 
 
@@ -253,12 +257,12 @@ def escalate_no_dip(node: QualibrationNode[Parameters, Quam]) -> None:
     tracked = node.namespace.setdefault("tracked_lo_qubits", [])
 
     while True:
-        plan = plan_span_escalation(node.results["fit_results"], span, max_span)
-        if not plan["retry"]:
+        plan = plan_span_escalation(node.namespace["fit_results"], span, max_span)
+        if not plan.retry:
             break
-        span = plan["new_span_hz"]
+        span = plan.new_span_hz
         node.log(
-            f"escalation: no dip on {plan['qubits']} -> re-measuring all active qubits " f"at span {span / 1e6:.0f} MHz"
+            f"escalation: no dip on {plan.qubits} -> re-measuring all active qubits " f"at span {span / 1e6:.0f} MHz"
         )
         # Re-center LOs where the wider sweep would push the IF out of reach.
         lo_moves = {}
@@ -270,16 +274,16 @@ def escalate_no_dip(node: QualibrationNode[Parameters, Quam]) -> None:
                 span_hz=span,
                 band=getattr(rr.opx_output, "band", None),
             )
-            if lo_plan["error"]:
-                node.log(f"escalation: {q.name}: {lo_plan['error']} — keeping current LO")
+            if lo_plan.error:
+                node.log(f"escalation: {q.name}: {lo_plan.error} — keeping current LO")
                 continue
-            if lo_plan["shift"]:
+            if lo_plan.shift:
                 with tracked_updates(q, auto_revert=False, dont_assign_to_none=False) as q_upd:
-                    q_upd.resonator.opx_output.upconverter_frequency = lo_plan["new_lo_hz"]
+                    q_upd.resonator.opx_output.upconverter_frequency = lo_plan.new_lo_hz
                     tracked.append(q_upd)
-                lo_moves[q.name] = lo_plan["new_lo_hz"]
-                node.log(f"escalation: {q.name}: LO re-centered to {lo_plan['new_lo_hz'] / 1e9:.4f} GHz")
-        audit.append(dict(span_hz=float(span), retried=plan["qubits"], lo_moves=lo_moves))
+                lo_moves[q.name] = lo_plan.new_lo_hz
+                node.log(f"escalation: {q.name}: LO re-centered to {lo_plan.new_lo_hz / 1e9:.4f} GHz")
+        audit.append(dict(span_hz=float(span), retried=plan.qubits, lo_moves=lo_moves))
         _setup_sweep_and_program(node, span)
         _execute_and_fetch(node)
         _analyse(node)

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
@@ -36,7 +36,6 @@ from calibration_utils.resonator_spectroscopy.escalation import (
     plan_lo_recenter,
 )
 
-
 # %% {Node initialisation}
 description = """
         1D RESONATOR SPECTROSCOPY
@@ -70,7 +69,7 @@ node = QualibrationNode[Parameters, Quam](
 def custom_param(node: QualibrationNode[Parameters, Quam]) -> None:
     """Allow the user to locally set the node parameters for debugging purposes, or execution in the Python IDE."""
     # You can get type hinting in your IDE by typing node.parameters.
-    node.parameters.qubits = ["qA1"] # XXX
+    node.parameters.qubits = ["qA1"]  # XXX
     pass
 
 
@@ -255,8 +254,7 @@ def escalate_no_dip(node: QualibrationNode[Parameters, Quam]) -> None:
             break
         span = plan["new_span_hz"]
         node.log(
-            f"escalation: no dip on {plan['qubits']} -> re-measuring all active qubits "
-            f"at span {span / 1e6:.0f} MHz"
+            f"escalation: no dip on {plan['qubits']} -> re-measuring all active qubits " f"at span {span / 1e6:.0f} MHz"
         )
         # Re-center LOs where the wider sweep would push the IF out of reach.
         lo_moves = {}
@@ -310,9 +308,7 @@ def plot_data(node: QualibrationNode[Parameters, Quam]) -> None:
     if node.parameters.show_raw_phase_plot:
         figures["phase"] = plot_raw_phase(node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"])
     if node.parameters.show_iq_circle_plot:
-        figures["iq_circle"] = plot_iq_circle(
-            node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"]
-        )
+        figures["iq_circle"] = plot_iq_circle(node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"])
     plt.show()
     # Store the generated figures
     node.results["figures"] = figures

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
@@ -69,7 +69,7 @@ node = QualibrationNode[Parameters, Quam](
 def custom_param(node: QualibrationNode[Parameters, Quam]) -> None:
     """Allow the user to locally set the node parameters for debugging purposes, or execution in the Python IDE."""
     # You can get type hinting in your IDE by typing node.parameters.
-    node.parameters.qubits = ["qA1"]  # XXX
+    # node.parameters.qubits = ["q1", "q2"]
     pass
 
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/02a_resonator_spectroscopy.py
@@ -75,9 +75,9 @@ def custom_param(node: QualibrationNode[Parameters, Quam]) -> None:
 
 
 # Stash the re-fit overrides before load_from_id() can overwrite node.parameters
-_stored_re_fit_resonators = node.parameters.re_fit_resonators
-_stored_re_fit_centers_ghz = node.parameters.re_fit_centers_ghz
-_stored_re_fit_span_mhz = node.parameters.re_fit_span_mhz
+_stored_re_fit_resonators = node.parameters.refit.re_fit_resonators
+_stored_re_fit_centers_ghz = node.parameters.refit.re_fit_centers_ghz
+_stored_re_fit_span_mhz = node.parameters.refit.re_fit_span_mhz
 
 
 # %% {Program_helpers}
@@ -92,8 +92,8 @@ def _setup_sweep_and_program(node: QualibrationNode[Parameters, Quam], span_hz: 
     qubits = node.namespace["qubits"]
     num_qubits = len(qubits)
     # Extract the sweep parameters and axes from the node parameters
-    n_avg = node.parameters.num_shots
-    step = node.parameters.frequency_step_in_mhz * u.MHz
+    n_avg = node.parameters.sweep.num_shots
+    step = node.parameters.sweep.frequency_step_in_mhz * u.MHz
     dfs = np.arange(-span_hz / 2, +span_hz / 2, step)
     # Register the sweep axes to be added to the dataset when fetching data
     node.namespace["sweep_axes"] = {
@@ -149,7 +149,7 @@ def _execute_and_fetch(node: QualibrationNode[Parameters, Quam]) -> None:
         for dataset in data_fetcher:
             progress_counter(
                 data_fetcher.get("n", 0),
-                node.parameters.num_shots,
+                node.parameters.sweep.num_shots,
                 start_time=data_fetcher.t_start,
             )
         # Display the execution report to expose possible runtime errors
@@ -187,7 +187,7 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]) -> None:
     u = unit(coerce_to_integer=True)
     # Get the active qubits from the node and organize them by batches
     node.namespace["qubits"] = get_qubits(node)
-    _setup_sweep_and_program(node, node.parameters.frequency_span_in_mhz * u.MHz)
+    _setup_sweep_and_program(node, node.parameters.sweep.frequency_span_in_mhz * u.MHz)
 
 
 # %% {Simulate}
@@ -220,9 +220,9 @@ def load_data(node: QualibrationNode[Parameters, Quam]) -> None:
     node.load_from_id(node.parameters.load_data_id)
     node.parameters.load_data_id = load_data_id
     # Restore the re-fit overrides that were set by the user for this re-analysis run
-    node.parameters.re_fit_resonators = _stored_re_fit_resonators
-    node.parameters.re_fit_centers_ghz = _stored_re_fit_centers_ghz
-    node.parameters.re_fit_span_mhz = _stored_re_fit_span_mhz
+    node.parameters.refit.re_fit_resonators = _stored_re_fit_resonators
+    node.parameters.refit.re_fit_centers_ghz = _stored_re_fit_centers_ghz
+    node.parameters.refit.re_fit_span_mhz = _stored_re_fit_span_mhz
     # Get the active qubits from the loaded node parameters
     node.namespace["qubits"] = get_qubits(node)
 
@@ -238,7 +238,7 @@ def analyse_data(node: QualibrationNode[Parameters, Quam]) -> None:
 @node.run_action(
     skip_if=node.parameters.simulate
     or node.parameters.load_data_id is not None
-    or not node.parameters.escalate_on_no_dip
+    or not node.parameters.escalation.escalate_on_no_dip
 )
 def escalate_no_dip(node: QualibrationNode[Parameters, Quam]) -> None:
     """Bring-up span-escalation: when no significant dip was found, re-measure with
@@ -251,8 +251,8 @@ def escalate_no_dip(node: QualibrationNode[Parameters, Quam]) -> None:
     re-fit at the wider span. Every rung is recorded in results["escalation"].
     """
     u = unit(coerce_to_integer=True)
-    span = node.parameters.frequency_span_in_mhz * u.MHz
-    max_span = node.parameters.max_escalation_span_in_mhz * u.MHz
+    span = node.parameters.sweep.frequency_span_in_mhz * u.MHz
+    max_span = node.parameters.escalation.max_escalation_span_in_mhz * u.MHz
     audit = []
     tracked = node.namespace.setdefault("tracked_lo_qubits", [])
 
@@ -313,9 +313,9 @@ def plot_data(node: QualibrationNode[Parameters, Quam]) -> None:
             node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"]
         ),
     }
-    if node.parameters.show_raw_phase_plot:
+    if node.parameters.plotting.show_raw_phase_plot:
         figures["phase"] = plot_raw_phase(node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"])
-    if node.parameters.show_iq_circle_plot:
+    if node.parameters.plotting.show_iq_circle_plot:
         figures["iq_circle"] = plot_iq_circle(node.results["ds_raw"], node.namespace["qubits"], node.results["ds_fit"])
     plt.show()
     # Store the generated figures


### PR DESCRIPTION
- Replace the peaks_dips-based fit with a bring-up-grade Lorentzian-dip fitter (analysis.py):
    - Noise-relative dip detection with background removal.
    - A fit ladder over window size and linear/quadratic backgrounds.
    - Multi-dip/ambiguity reporting.
    
- Report two independent fit outcomes instead of one: whether a resonator dip was actually found (usable frequency), and whether the fitted lineshape itself was clean.

- Add optional no-dip span-escalation (escalation.py) for fresh-from-fab bring-up, doubling the sweep span and re-centering the readout LO when no resonator is found.

- Add grid-size-aware plotting (plotting.py) so figure/font sizes scale with the qubit grid instead of a fixed 15x9 layout.

- Add optional plot_detrended_phase and plot_iq_circle diagnostics plots.

- Add a manual per-qubit re-fit window overrides (parameters.py).