### PR TITLE
fix old qualibrate imports and incorrect bool type

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/power_rabi/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/power_rabi/analysis.py
@@ -122,7 +122,7 @@ def _rabi_fit_quality(fit: xr.Dataset, use_state_disc: bool) -> dict[str, dict[s
 
 def _gate_ok(value: float, threshold: float, minimum: bool) -> bool:
     """True if `value` clears `threshold`; a NaN value (metric not computed) is never gated."""
-    return np.isnan(value) or (value >= threshold if minimum else value <= threshold)
+    return bool(np.isnan(value) or (value >= threshold if minimum else value <= threshold))
 
 
 def _raw_gap_ok(rec: dict[str, float]) -> bool:
@@ -318,7 +318,7 @@ def _extract_relevant_fit_parameters(
             osc_amp_snr=quality.get(str(q), {}).get("osc_amp_snr", float("nan")),
             n_periods=quality.get(str(q), {}).get("n_periods", float("nan")),
             pts_per_period=quality.get(str(q), {}).get("pts_per_period", float("nan")),
-            raw_fit_consistent=_raw_gap_ok(quality.get(str(q), {})),
+            raw_fit_consistent=bool(_raw_gap_ok(quality.get(str(q), {}))),
         )
         for q in fit.qubit.values
     }

--- a/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/ramsey_versus_flux_calibration/analysis.py
@@ -263,7 +263,7 @@ def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> Tuple[xr.Dataset, di
         t2_star[q] = tau.sel(qubit=q).values
 
         # Success criterion: fit parameters are finite and flux offset is within swept range
-        success[q] = (
+        success[q] = bool(
             np.isfinite(a[q])
             and np.isfinite(flux_offset[q])
             and np.isfinite(freq_offset[q])

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/80_calibration_graph_bringup_flux_tunable_transmon.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/80_calibration_graph_bringup_flux_tunable_transmon.py
@@ -1,9 +1,9 @@
 # %%
 from typing import List
-from qualibrate.orchestration.basic_orchestrator import BasicOrchestrator
+from qualibrate.core.orchestration.basic_orchestrator import BasicOrchestrator
 from qualibrate.core.parameters import GraphParameters
-from qualibrate.qualibration_graph import QualibrationGraph
-from qualibrate.qualibration_library import QualibrationLibrary
+from qualibrate import QualibrationGraph
+from qualibrate import QualibrationLibrary
 
 library = QualibrationLibrary.get_active_library()
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/81_calibration_graph_retuning_flux_tunable_transmon.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/81_calibration_graph_retuning_flux_tunable_transmon.py
@@ -1,9 +1,9 @@
 # %%
 from typing import List
-from qualibrate.orchestration.basic_orchestrator import BasicOrchestrator
+from qualibrate.core.orchestration.basic_orchestrator import BasicOrchestrator
 from qualibrate.core.parameters import GraphParameters
-from qualibrate.qualibration_graph import QualibrationGraph
-from qualibrate.qualibration_library import QualibrationLibrary
+from qualibrate import QualibrationGraph
+from qualibrate import QualibrationLibrary
 
 library = QualibrationLibrary.get_active_library()
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/90_calibration_graph_bringup_fixed_frequency_transmon.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/90_calibration_graph_bringup_fixed_frequency_transmon.py
@@ -1,9 +1,9 @@
 # %%
 from typing import List
-from qualibrate.orchestration.basic_orchestrator import BasicOrchestrator
+from qualibrate.core.orchestration.basic_orchestrator import BasicOrchestrator
 from qualibrate.core.parameters import GraphParameters
-from qualibrate.qualibration_graph import QualibrationGraph
-from qualibrate.qualibration_library import QualibrationLibrary
+from qualibrate import QualibrationGraph
+from qualibrate import QualibrationLibrary
 
 library = QualibrationLibrary.get_active_library()
 

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/91_calibration_graph_retuning_fixed_frequency_transmon.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/91_calibration_graph_retuning_fixed_frequency_transmon.py
@@ -1,9 +1,9 @@
 # %%
 from typing import List
-from qualibrate.orchestration.basic_orchestrator import BasicOrchestrator
+from qualibrate.core.orchestration.basic_orchestrator import BasicOrchestrator
 from qualibrate.core.parameters import GraphParameters
-from qualibrate.qualibration_graph import QualibrationGraph
-from qualibrate.qualibration_library import QualibrationLibrary
+from qualibrate import QualibrationGraph
+from qualibrate import QualibrationLibrary
 
 library = QualibrationLibrary.get_active_library()
 


### PR DESCRIPTION
a. updated the imports on the four calibration graphs to ones supported on qualibrate 1.x,
b. updated the analysis.py of two specific nodes- cast np.bool to a general bool (np.bool is not supported in JSON and it produced a bug).

both were tested on IQCC usng my local environment.