### PR TITLE
Three tone spectroscopy to find coupler frequency

### DIFF
--- a/qualibration_graphs/superconducting/calibration_utils/common_utils/flux_distortions/lo_shift.py
+++ b/qualibration_graphs/superconducting/calibration_utils/common_utils/flux_distortions/lo_shift.py
@@ -67,16 +67,21 @@ def plan_lo_shift_for_frequency_window(
     qubits: Sequence[AnyTransmon],
     dfs: NDArray[np.integer] | NDArray[np.floating],
     *,
+    if_base_hz: Optional[Sequence[float]] = None,
     log_callable: Optional[LogCallable] = None,
 ) -> LoShiftPlan:
-    """Decide LO shifts so ``intermediate_frequency + dfs`` stays in usable IF reach.
+    """Decide LO shifts so ``if_base + dfs`` stays in usable IF reach.
 
     Parameters
     ----------
     qubits
-        Qubit-like objects with ``xy`` (and ``name``).
+        Qubit-like objects with ``xy`` (and ``name``). LO shifts apply to these channels.
     dfs
         Relative frequency sweep axis in Hz (same array used in QUA ``from_array``).
+    if_base_hz
+        Optional per-qubit IF centre for the sweep (same length as ``qubits``).
+        Defaults to each qubit's ``xy.intermediate_frequency``. Use this for three-tone
+        spectroscopy where the drive IF is ``coupler_RF - LO`` rather than the qubit idle IF.
 
     Returns
     -------
@@ -89,8 +94,8 @@ def plan_lo_shift_for_frequency_window(
     dfs_mid = int((dfs.min() + dfs.max()) / 2)
     plan = LoShiftPlan()
 
-    for q in qubits:
-        if_lo = q.xy.intermediate_frequency
+    for i, q in enumerate(qubits):
+        if_lo = int(if_base_hz[i]) if if_base_hz is not None else q.xy.intermediate_frequency
         if_low = if_lo + int(dfs.min())
         if_high = if_lo + int(dfs.max())
 

--- a/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_flux_pulse/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_flux_pulse/__init__.py
@@ -1,0 +1,14 @@
+"""Three-tone coupler spectroscopy with coupler flux pulse (22a)."""
+
+from .analysis import FitResults, fit_raw_data, log_fitted_results, process_raw_dataset
+from .parameters import Parameters
+from .plotting import plot_raw_data_with_fit
+
+__all__ = [
+    "Parameters",
+    "FitResults",
+    "process_raw_dataset",
+    "fit_raw_data",
+    "log_fitted_results",
+    "plot_raw_data_with_fit",
+]

--- a/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_flux_pulse/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_flux_pulse/analysis.py
@@ -1,0 +1,88 @@
+"""Analysis for three-tone coupler spectroscopy with flux pulse (22a)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+import numpy as np
+import xarray as xr
+from qualibrate import QualibrationNode
+
+from .parameters import resolve_coupler_rf_centers_by_pair
+
+LogCallable = Callable[[str], None]
+
+
+@dataclass
+class FitResults:
+    """Per-pair coupler frequency extracted from the three-tone dip."""
+
+    success: bool
+    coupler_frequency_hz: float
+    coupler_flux_v: float
+
+
+def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode) -> xr.Dataset:
+    """Add derived coordinates and IQ amplitude when needed."""
+    qubit_pairs = node.namespace["qubit_pairs"]
+    dfs = node.namespace["dfs"]
+    coupler_rf_centers = node.namespace.get("coupler_rf_centers") or resolve_coupler_rf_centers_by_pair(
+        qubit_pairs,
+        node.parameters.rf_frequency_startpoint_in_hz,
+        coupler_band=node.parameters.coupler_band,
+        idle_detuning_hz=abs(float(node.parameters.coupler_idle_detuning_in_ghz)) * 1e9,
+    )
+    rf_freq = np.array([dfs + coupler_rf_centers[qp.name] for qp in qubit_pairs])
+    ds = ds.assign_coords(freq_full_control=(["qubit", "freq"], rf_freq))
+    ds.freq_full_control.attrs["long_name"] = "Coupler drive frequency"
+    ds.freq_full_control.attrs["units"] = "Hz"
+
+    flux_values = np.array(
+        [node.parameters.coupler_flux_in_v + qp.coupler.decouple_offset for qp in qubit_pairs],
+        dtype=float,
+    )
+    ds = ds.assign_coords(flux_full=(["qubit"], flux_values))
+    ds.flux_full.attrs["long_name"] = "Coupler flux bias"
+    ds.flux_full.attrs["units"] = "V"
+
+    if not node.parameters.use_state_discrimination and "IQ_abs" not in ds:
+        ds = ds.assign(IQ_abs=np.sqrt(ds["I"] ** 2 + ds["Q"] ** 2))
+    return ds
+
+
+def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> tuple[xr.Dataset, Dict[str, FitResults]]:
+    """Locate the coupler resonance from the target-qubit response vs drive frequency."""
+    if node.parameters.use_state_discrimination:
+        min_idx = ds.state.argmin(dim="freq")
+        signal_name = "state"
+    else:
+        min_idx = ds.I.argmax(dim="freq")
+        signal_name = "I"
+
+    fit_results: Dict[str, FitResults] = {}
+    for qp in node.namespace["qubit_pairs"]:
+        pair_name = qp.name
+        freq_hz = float(ds.freq_full_control.sel(qubit=pair_name).isel(freq=min_idx.sel(qubit=pair_name)).values)
+        flux_v = float(ds.flux_full.sel(qubit=pair_name).values)
+        fit_results[pair_name] = FitResults(
+            success=np.isfinite(freq_hz),
+            coupler_frequency_hz=freq_hz,
+            coupler_flux_v=flux_v,
+        )
+
+    ds_fit = ds.assign_attrs(signal_used=signal_name)
+    return ds_fit, fit_results
+
+
+def log_fitted_results(fit_results: Dict[str, FitResults], log_callable: Optional[LogCallable] = None) -> None:
+    """Log extracted coupler frequencies."""
+    log = log_callable or print
+    for pair_name, fit in fit_results.items():
+        if fit.success:
+            log(
+                f"{pair_name}: coupler frequency = {fit.coupler_frequency_hz * 1e-9:.4f} GHz "
+                f"at flux {fit.coupler_flux_v * 1e3:.2f} mV"
+            )
+        else:
+            log(f"{pair_name}: coupler frequency extraction failed")

--- a/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_flux_pulse/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_flux_pulse/parameters.py
@@ -1,0 +1,130 @@
+"""Parameters for three-tone coupler spectroscopy with a coupler flux pulse (22a)."""
+
+from typing import Callable, ClassVar, Literal, Optional, Sequence
+
+import numpy as np
+from qualibrate import NodeParameters
+from qualibrate.core.parameters import RunnableParameters
+from qualibration_libs.parameters import CommonNodeParameters, QubitPairExperimentNodeParameters
+
+
+class NodeSpecificParameters(RunnableParameters):
+    """Three-tone spectroscopy at fixed coupler flux pulse amplitude."""
+
+    num_shots: int = 100
+    """Number of averages per frequency point."""
+    control_drive_operation: str = "x180"
+    """Control-qubit operation used to drive the coupler."""
+    control_pulse_duration_in_ns: int = 500
+    """Duration of the control drive pulse in ns."""
+    control_pulse_amplitude: float = 0.1
+    """Amplitude scale for the control drive pulse."""
+    target_drive_operation: str = "saturation"
+    """Weak probe operation on the target qubit."""
+    target_pulse_amplitude: float = 0.02
+    """Amplitude scale for the target probe pulse."""
+    target_pulse_duration_in_ns: Optional[int] = 400
+    """Target probe duration in ns; default uses the operation length from state."""
+    frequency_span_in_mhz: float = 800.0
+    """Total frequency span of the coupler drive sweep in MHz."""
+    frequency_step_in_mhz: float = 1.0
+    """Frequency step in MHz."""
+    coupler_flux_in_v: float = 0.02
+    """Coupler flux pulse amplitude in V (played relative to decouple_offset)."""
+    coupler_flux_settle_in_ns: int = 25
+    """Wait after the coupler flux pulse before the control drive, in ns."""
+    coupler_band: Literal["above", "below"] = "above"
+    """Where the coupler sits relative to the qubit pair (used only for the RF guess).
+
+    ``above``: idle above the higher qubit (BAQ). ``below``: idle below the lower qubit (BBQ).
+    Ignored when ``rf_frequency_startpoint_in_hz`` or ``coupler.RF_frequency`` is set.
+    """
+    coupler_idle_detuning_in_ghz: float = 1.2
+    """Idle detuning from the nearest qubit used for the RF guess, in GHz.
+
+    Typical literature parks are ~1–1.5 GHz away. ``above`` uses ``max(f) + detuning``;
+    ``below`` uses ``min(f) - detuning``. Ignored when
+    ``rf_frequency_startpoint_in_hz`` or ``coupler.RF_frequency`` is set.
+    """
+    rf_frequency_startpoint_in_hz: Optional[float] = None
+    """Optional coupler RF sweep centre in Hz for all pairs.
+
+    When ``None`` (default), each pair uses ``coupler.RF_frequency`` from state if set,
+    otherwise an estimate from the qubit XY frequencies and ``coupler_band``.
+    """
+    update_state: bool = False
+    """Write fitted ``coupler.RF_frequency`` into state when analysis succeeds."""
+
+
+class Parameters(
+    NodeParameters,
+    CommonNodeParameters,
+    NodeSpecificParameters,
+    QubitPairExperimentNodeParameters,
+):
+    """Combined parameters for 22a three-tone coupler spectroscopy (flux pulse)."""
+
+    targets_name: ClassVar[str] = "qubit_pairs"
+
+
+LogCallable = Callable[[str], None]
+CouplerBand = Literal["above", "below"]
+DEFAULT_COUPLER_IDLE_DETUNING_HZ = 1.2e9
+
+
+def estimate_coupler_rf_from_qubits(
+    f_control: float,
+    f_target: float,
+    coupler_band: CouplerBand,
+    idle_detuning_hz: float = DEFAULT_COUPLER_IDLE_DETUNING_HZ,
+) -> float:
+    """Guess idle coupler RF from the two qubit XY frequencies.
+
+    ``above``: ``max(f) + detuning`` (BAQ, typically ~1–1.5 GHz above).
+    ``below``: ``min(f) - detuning`` (BBQ).
+    """
+    f_high = max(f_control, f_target)
+    f_low = min(f_control, f_target)
+    detuning = abs(float(idle_detuning_hz))
+    if coupler_band == "below":
+        return f_low - detuning
+    return f_high + detuning
+
+
+def resolve_coupler_rf_centers_by_pair(
+    qubit_pairs: Sequence,
+    rf_override_hz: Optional[float] = None,
+    *,
+    coupler_band: CouplerBand = "above",
+    idle_detuning_hz: float = DEFAULT_COUPLER_IDLE_DETUNING_HZ,
+    log_callable: Optional[LogCallable] = None,
+) -> dict[str, float]:
+    """Resolve per-pair coupler RF sweep centres.
+
+    Uses ``rf_override_hz`` if set, else ``coupler.RF_frequency`` from state,
+    else :func:`estimate_coupler_rf_from_qubits` with ``coupler_band``.
+    """
+    centers: dict[str, float] = {}
+    for qp in qubit_pairs:
+        if rf_override_hz is not None:
+            centers[qp.name] = float(rf_override_hz)
+            continue
+
+        coupler_rf = getattr(getattr(qp, "coupler", None), "RF_frequency", None)
+        if coupler_rf is not None and np.isfinite(coupler_rf) and coupler_rf > 1e9:
+            centers[qp.name] = float(coupler_rf)
+            continue
+
+        f_control = float(qp.qubit_control.xy.RF_frequency)
+        f_target = float(qp.qubit_target.xy.RF_frequency)
+        estimate_hz = estimate_coupler_rf_from_qubits(
+            f_control, f_target, coupler_band, idle_detuning_hz=idle_detuning_hz
+        )
+        if log_callable is not None:
+            log_callable(
+                f"{qp.name}: no coupler.RF_frequency in state; "
+                f"estimating sweep centre {estimate_hz * 1e-9:.4f} GHz ({coupler_band}) from "
+                f"qubit XY ({f_control * 1e-9:.4f}, {f_target * 1e-9:.4f} GHz)"
+            )
+        centers[qp.name] = estimate_hz
+    return centers

--- a/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_flux_pulse/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_flux_pulse/plotting.py
@@ -34,15 +34,9 @@ def plot_raw_data_with_fit(
 
         fit = fit_results.get(pair_name)
         if fit is not None and fit.get("success", getattr(fit, "success", False)):
-            freq_ghz = (
-                fit["coupler_frequency_hz"] * 1e-9
-                if isinstance(fit, dict)
-                else fit.coupler_frequency_hz * 1e-9
-            )
+            freq_ghz = fit["coupler_frequency_hz"] * 1e-9 if isinstance(fit, dict) else fit.coupler_frequency_hz * 1e-9
             ax.axvline(freq_ghz, color="red", linestyle="--", alpha=0.5)
-            flux_mv = (
-                fit["coupler_flux_v"] * 1e3 if isinstance(fit, dict) else fit.coupler_flux_v * 1e3
-            )
+            flux_mv = fit["coupler_flux_v"] * 1e3 if isinstance(fit, dict) else fit.coupler_flux_v * 1e3
             ax.set_title(f"{pair_name}\nCoupler flux = {flux_mv:.2f} mV")
         else:
             ax.set_title(pair_name)

--- a/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_flux_pulse/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_flux_pulse/plotting.py
@@ -1,0 +1,53 @@
+"""Plotting for three-tone coupler spectroscopy with flux pulse (22a)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import matplotlib.pyplot as plt
+import xarray as xr
+from calibration_utils.pair_grid import QubitPairGrid, grid_pair_names
+from qualibration_libs.plotting import grid_iter
+
+from .analysis import FitResults
+
+
+def plot_raw_data_with_fit(
+    ds: xr.Dataset,
+    qubit_pairs,
+    fit_results: Dict[str, Any],
+) -> plt.Figure:
+    """Plot target response vs coupler drive frequency with the extracted resonance marked."""
+    grid_names, pair_names = grid_pair_names(qubit_pairs)
+    grid = QubitPairGrid(grid_names, pair_names)
+
+    use_state = "state" in ds
+    for ax, qp_info in grid_iter(grid):
+        pair_name = qp_info["qubit"]
+        ds_g = ds.assign_coords(freq_GHz=ds.freq_full_control / 1e9)
+        if use_state:
+            ds_g.sel(qubit=pair_name).state.plot(ax=ax, x="freq_GHz")
+            ax.set_ylabel("Target qubit state")
+        else:
+            ds_g.sel(qubit=pair_name).I.plot(ax=ax, x="freq_GHz")
+            ax.set_ylabel("I")
+
+        fit = fit_results.get(pair_name)
+        if fit is not None and fit.get("success", getattr(fit, "success", False)):
+            freq_ghz = (
+                fit["coupler_frequency_hz"] * 1e-9
+                if isinstance(fit, dict)
+                else fit.coupler_frequency_hz * 1e-9
+            )
+            ax.axvline(freq_ghz, color="red", linestyle="--", alpha=0.5)
+            flux_mv = (
+                fit["coupler_flux_v"] * 1e3 if isinstance(fit, dict) else fit.coupler_flux_v * 1e3
+            )
+            ax.set_title(f"{pair_name}\nCoupler flux = {flux_mv:.2f} mV")
+        else:
+            ax.set_title(pair_name)
+        ax.set_xlabel("Frequency (GHz)")
+
+    grid.fig.suptitle("Three-tone coupler spectroscopy (flux pulse)")
+    grid.fig.tight_layout()
+    return grid.fig

--- a/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_vs_coupler_flux/__init__.py
+++ b/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_vs_coupler_flux/__init__.py
@@ -1,0 +1,14 @@
+"""Three-tone coupler spectroscopy vs coupler flux (22b)."""
+
+from .analysis import FitResults, fit_raw_data, log_fitted_results, process_raw_dataset
+from .parameters import Parameters
+from .plotting import plot_raw_data_with_fit
+
+__all__ = [
+    "Parameters",
+    "FitResults",
+    "process_raw_dataset",
+    "fit_raw_data",
+    "log_fitted_results",
+    "plot_raw_data_with_fit",
+]

--- a/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_vs_coupler_flux/analysis.py
+++ b/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_vs_coupler_flux/analysis.py
@@ -1,0 +1,84 @@
+"""Analysis for three-tone coupler spectroscopy vs coupler flux (22b)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+import numpy as np
+import xarray as xr
+from calibration_utils.three_tone_coupler_spectroscopy_flux_pulse.parameters import (
+    resolve_coupler_rf_centers_by_pair,
+)
+from qualibrate import QualibrationNode
+
+LogCallable = Callable[[str], None]
+
+
+@dataclass
+class FitResults:
+    """Per-pair tracking resonance vs flux (optional summary)."""
+
+    success: bool
+    coupler_frequency_hz: float
+    coupler_flux_v: float
+
+
+def process_raw_dataset(ds: xr.Dataset, node: QualibrationNode) -> xr.Dataset:
+    """Add absolute frequency coordinates and IQ amplitude when needed."""
+    qubit_pairs = node.namespace["qubit_pairs"]
+    dfs = node.namespace["dfs"]
+    coupler_rf_centers = node.namespace.get("coupler_rf_centers") or resolve_coupler_rf_centers_by_pair(
+        qubit_pairs,
+        node.parameters.rf_frequency_startpoint_in_hz,
+        coupler_band=node.parameters.coupler_band,
+        idle_detuning_hz=abs(float(node.parameters.coupler_idle_detuning_in_ghz)) * 1e9,
+    )
+    rf_freq = np.array([dfs + coupler_rf_centers[qp.name] for qp in qubit_pairs])
+    ds = ds.assign_coords(freq_full_control=(["qubit", "freq"], rf_freq))
+    ds.freq_full_control.attrs["long_name"] = "Coupler drive frequency"
+    ds.freq_full_control.attrs["units"] = "Hz"
+
+    if not node.parameters.use_state_discrimination and "IQ_abs" not in ds:
+        ds = ds.assign(IQ_abs=np.sqrt(ds["I"] ** 2 + ds["Q"] ** 2))
+    return ds
+
+
+def fit_raw_data(ds: xr.Dataset, node: QualibrationNode) -> tuple[xr.Dataset, Dict[str, FitResults]]:
+    """Track the minimum-response coupler frequency at each flux bias."""
+    if node.parameters.use_state_discrimination:
+        min_idx = ds.state.argmin(dim="freq")
+    else:
+        min_idx = ds.IQ_abs.argmin(dim="freq")
+
+    min_freqs = ds.freq_full_control.isel(freq=min_idx)
+    fit_results: Dict[str, FitResults] = {}
+    flux_coord = "flux" if "flux" in ds.dims else "coupler_flux"
+
+    for qp in node.namespace["qubit_pairs"]:
+        pair_name = qp.name
+        freq_trace = min_freqs.sel(qubit=pair_name)
+        flux_vals = ds[flux_coord].values
+        best_i = int(np.nanargmin(freq_trace.values)) if freq_trace.size else 0
+        freq_hz = float(freq_trace.isel({flux_coord: best_i}).values)
+        flux_v = float(flux_vals[best_i]) if len(flux_vals) else np.nan
+        fit_results[pair_name] = FitResults(
+            success=np.isfinite(freq_hz),
+            coupler_frequency_hz=freq_hz,
+            coupler_flux_v=flux_v,
+        )
+
+    return ds, fit_results
+
+
+def log_fitted_results(fit_results: Dict[str, FitResults], log_callable: Optional[LogCallable] = None) -> None:
+    """Log a single reference point from the 2D map per pair."""
+    log = log_callable or print
+    for pair_name, fit in fit_results.items():
+        if fit.success:
+            log(
+                f"{pair_name}: reference coupler frequency = {fit.coupler_frequency_hz * 1e-9:.4f} GHz "
+                f"at flux {fit.coupler_flux_v * 1e3:.2f} mV"
+            )
+        else:
+            log(f"{pair_name}: coupler frequency extraction failed")

--- a/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_vs_coupler_flux/parameters.py
+++ b/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_vs_coupler_flux/parameters.py
@@ -1,0 +1,68 @@
+"""Parameters for three-tone coupler spectroscopy vs coupler flux (22b)."""
+
+from typing import ClassVar, Literal, Optional
+
+from qualibrate import NodeParameters
+from qualibrate.core.parameters import RunnableParameters
+from qualibration_libs.parameters import CommonNodeParameters, QubitPairExperimentNodeParameters
+
+
+class NodeSpecificParameters(RunnableParameters):
+    """Three-tone 2D spectroscopy sweeping coupler flux-pulse amplitude and drive frequency."""
+
+    num_shots: int = 100
+    """Number of averages per (flux, frequency) point."""
+    control_drive_operation: str = "x180"
+    """Control-qubit operation used to drive the coupler."""
+    control_pulse_duration_in_ns: int = 500
+    """Duration of the control drive pulse in ns."""
+    control_pulse_amplitude: float = 0.1
+    """Amplitude scale for the control drive pulse."""
+    target_drive_operation: str = "saturation"
+    """Weak probe operation on the target qubit."""
+    target_pulse_amplitude: float = 0.02
+    """Amplitude scale for the target probe pulse."""
+    target_pulse_duration_in_ns: Optional[int] = 400
+    """Target probe duration in ns; default uses the operation length from state."""
+    frequency_span_in_mhz: float = 800.0
+    """Total frequency span of the coupler drive sweep in MHz."""
+    frequency_step_in_mhz: float = 1.0
+    """Frequency step in MHz."""
+    coupler_flux_min_in_v: float = -0.025
+    """Minimum coupler flux-pulse amplitude in V (played relative to decouple_offset)."""
+    coupler_flux_max_in_v: float = 0.025
+    """Maximum coupler flux-pulse amplitude in V (played relative to decouple_offset)."""
+    num_coupler_flux_points: int = 11
+    """Number of coupler flux-pulse amplitudes."""
+    coupler_flux_settle_in_ns: int = 25
+    """Wait after the coupler flux pulse starts, before the control drive, in ns."""
+    coupler_band: Literal["above", "below"] = "above"
+    """Where the coupler sits relative to the qubit pair (used only for the RF guess).
+
+    ``above``: idle above the higher qubit (BAQ). ``below``: idle below the lower qubit (BBQ).
+    Ignored when ``rf_frequency_startpoint_in_hz`` or ``coupler.RF_frequency`` is set.
+    """
+    coupler_idle_detuning_in_ghz: float = 1.2
+    """Idle detuning from the nearest qubit used for the RF guess, in GHz.
+
+    Typical literature parks are ~1–1.5 GHz away. ``above`` uses ``max(f) + detuning``;
+    ``below`` uses ``min(f) - detuning``. Ignored when
+    ``rf_frequency_startpoint_in_hz`` or ``coupler.RF_frequency`` is set.
+    """
+    rf_frequency_startpoint_in_hz: Optional[float] = None
+    """Optional coupler RF sweep centre in Hz for all pairs.
+
+    When ``None`` (default), each pair uses ``coupler.RF_frequency`` from state if set,
+    otherwise an estimate from the qubit XY frequencies and ``coupler_band``.
+    """
+
+
+class Parameters(
+    NodeParameters,
+    CommonNodeParameters,
+    NodeSpecificParameters,
+    QubitPairExperimentNodeParameters,
+):
+    """Combined parameters for 22b three-tone coupler spectroscopy vs flux."""
+
+    targets_name: ClassVar[str] = "qubit_pairs"

--- a/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_vs_coupler_flux/plotting.py
+++ b/qualibration_graphs/superconducting/calibration_utils/three_tone_coupler_spectroscopy_vs_coupler_flux/plotting.py
@@ -1,0 +1,31 @@
+"""Plotting for three-tone coupler spectroscopy vs coupler flux (22b)."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import xarray as xr
+from calibration_utils.pair_grid import QubitPairGrid, grid_pair_names
+from qualibration_libs.plotting import grid_iter
+
+
+def plot_raw_data_with_fit(ds: xr.Dataset, qubit_pairs) -> plt.Figure:
+    """Plot 2D target response vs coupler flux and drive frequency."""
+    grid_names, pair_names = grid_pair_names(qubit_pairs)
+    grid = QubitPairGrid(grid_names, pair_names)
+    flux_coord = "flux" if "flux" in ds.dims else "coupler_flux"
+    use_state = "state" in ds
+
+    for ax, qp_info in grid_iter(grid):
+        pair_name = qp_info["qubit"]
+        ds_g = ds.assign_coords(freq_GHz=ds.freq_full_control / 1e9)
+        if use_state:
+            ds_g.sel(qubit=pair_name).state.plot(ax=ax, y="freq_GHz", x=flux_coord)
+        else:
+            ds_g.sel(qubit=pair_name).IQ_abs.plot(ax=ax, y="freq_GHz", x=flux_coord)
+        ax.set_title(pair_name)
+        ax.set_ylabel("Frequency (GHz)")
+        ax.set_xlabel("Coupler flux pulse (V)")
+
+    grid.fig.suptitle("Three-tone coupler spectroscopy vs flux")
+    grid.fig.tight_layout()
+    return grid.fig

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22a_three_tone_coupler_spectroscopy_flux_pulse.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22a_three_tone_coupler_spectroscopy_flux_pulse.py
@@ -84,9 +84,7 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     )
     node.namespace["coupler_rf_centers"] = coupler_rf_centers
     coupler_ifs = {
-        qp.name: int(
-            coupler_rf_centers[qp.name] - qp.qubit_control.xy.opx_output.upconverter_frequency
-        )
+        qp.name: int(coupler_rf_centers[qp.name] - qp.qubit_control.xy.opx_output.upconverter_frequency)
         for qp in qubit_pairs
     }
 
@@ -151,9 +149,7 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
                         target = qp.qubit_target
                         control.reset(node.parameters.reset_type, node.parameters.simulate)
                         target.reset(node.parameters.reset_type, node.parameters.simulate)
-                        control.xy.update_frequency(
-                            df + coupler_ifs[qp.name] - if_update_by_pair[qp.name]
-                        )
+                        control.xy.update_frequency(df + coupler_ifs[qp.name] - if_update_by_pair[qp.name])
                     align()
 
                     for ii, qp in multiplexed_qubit_pairs.items():

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22a_three_tone_coupler_spectroscopy_flux_pulse.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22a_three_tone_coupler_spectroscopy_flux_pulse.py
@@ -31,19 +31,23 @@ from qualibration_libs.runtime import simulate_and_plot
 from quam_config import Quam
 
 description = """
-THREE-TONE COUPLER SPECTROSCOPY
+Three-tone coupler spectroscopy at a fixed coupler flux point.
 
-Without a dedicated coupler readout, drive the coupler through the control qubit at
-variable frequency while probing the target qubit. A coupler flux pulse sets the
-coupler bias before the drive.
+A tunable coupler has a flux line but no drive or readout line of its own, so it is
+probed through its neighbours. Three tones are involved: a long drive on the control
+qubit's XY line that reaches the coupler, a weak saturation tone on the target qubit
+that transduces the coupler excitation into a target-qubit response, and the target
+readout. Sweeping the drive tone, the target signal dips when the drive is resonant
+with the coupler. Same ancilla-based coupler spectroscopy as Marxer et al.,
+PRX Quantum 4, 010314 (2023), Appendix F.
 
 Prerequisites:
 - Target-qubit readout calibrated (IQ blobs / state discrimination)
 - Control- and target-qubit XY gates calibrated
 
 Outputs and state updates:
-- Extracts coupler ``RF_frequency`` from the three-tone dip.
-- Set ``update_state=True`` to write ``coupler.RF_frequency`` into state.
+- Results: processed dataset, fit results, and figures are saved under ``node.results``.
+- If ``update_state=True`` and the fit succeeds, writes ``coupler.RF_frequency``.
 """
 
 node = QualibrationNode[Parameters, Quam](

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22a_three_tone_coupler_spectroscopy_flux_pulse.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22a_three_tone_coupler_spectroscopy_flux_pulse.py
@@ -1,0 +1,329 @@
+"""Three-tone coupler spectroscopy with coupler flux pulse — 22a."""
+
+# %%
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from calibration_utils.common_utils.flux_distortions import plan_lo_shift_for_frequency_window
+from calibration_utils.three_tone_coupler_spectroscopy_flux_pulse import (
+    Parameters,
+    fit_raw_data,
+    log_fitted_results,
+    plot_raw_data_with_fit,
+    process_raw_dataset,
+)
+from calibration_utils.three_tone_coupler_spectroscopy_flux_pulse.parameters import (
+    resolve_coupler_rf_centers_by_pair,
+)
+from qm.qua import *
+from qualang_tools.loops import from_array
+from qualang_tools.multi_user import qm_session
+from qualang_tools.results import progress_counter
+from qualang_tools.units import unit
+from qualibrate import QualibrationNode
+from qualibration_libs.data import XarrayDataFetcher
+from qualibration_libs.parameters import get_qubit_pairs
+from qualibration_libs.runtime import simulate_and_plot
+from quam_config import Quam
+
+description = """
+THREE-TONE COUPLER SPECTROSCOPY
+
+Without a dedicated coupler readout, drive the coupler through the control qubit at
+variable frequency while probing the target qubit. A coupler flux pulse sets the
+coupler bias before the drive.
+
+Prerequisites:
+- Target-qubit readout calibrated (IQ blobs / state discrimination)
+- Control- and target-qubit XY gates calibrated
+
+Outputs and state updates:
+- Extracts coupler ``RF_frequency`` from the three-tone dip.
+- Set ``update_state=True`` to write ``coupler.RF_frequency`` into state.
+"""
+
+node = QualibrationNode[Parameters, Quam](
+    name="22a_three_tone_coupler_spectroscopy_flux_pulse",
+    description=description,
+    parameters=Parameters(),
+    machine=Quam.load(),
+)
+
+
+# %% {Custom_param}
+@node.run_action(skip_if=node.modes.external)
+def custom_param(node: QualibrationNode[Parameters, Quam]):
+    """Allow the user to locally set the node parameters."""
+
+
+stored_machine = Quam.load()
+stored_update_state = node.parameters.update_state
+
+
+# %% {Create_qua_program}
+@node.run_action(skip_if=node.parameters.load_data_id is not None)
+def create_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Create sweep axes and generate the three-tone QUA program."""
+    u = unit(coerce_to_integer=True)
+    node.namespace["qubit_pairs"] = qubit_pairs = get_qubit_pairs(node)
+    num_qubit_pairs = len(qubit_pairs)
+
+    span = node.parameters.frequency_span_in_mhz * u.MHz
+    step = node.parameters.frequency_step_in_mhz * u.MHz
+    dfs = np.arange(-span / 2, span / 2, step, dtype=np.int64)
+    coupler_rf_centers = resolve_coupler_rf_centers_by_pair(
+        qubit_pairs,
+        node.parameters.rf_frequency_startpoint_in_hz,
+        coupler_band=node.parameters.coupler_band,
+        idle_detuning_hz=abs(float(node.parameters.coupler_idle_detuning_in_ghz)) * 1e9,
+        log_callable=node.log,
+    )
+    node.namespace["coupler_rf_centers"] = coupler_rf_centers
+    coupler_ifs = {
+        qp.name: int(
+            coupler_rf_centers[qp.name] - qp.qubit_control.xy.opx_output.upconverter_frequency
+        )
+        for qp in qubit_pairs
+    }
+
+    control_qubits = [qp.qubit_control for qp in qubit_pairs]
+    lo_plan = plan_lo_shift_for_frequency_window(
+        control_qubits,
+        dfs,
+        if_base_hz=[coupler_ifs[qp.name] for qp in qubit_pairs],
+        log_callable=node.log,
+    )
+    if lo_plan.force_thermal_reset:
+        node.parameters.reset_type = "thermal"
+    if_update_by_pair = {qp.name: lo_plan.if_update[i] for i, qp in enumerate(qubit_pairs)}
+    node.namespace["if_update_by_pair"] = if_update_by_pair
+    node.namespace["tracked_qubits"] = lo_plan.tracked_qubits
+
+    node.namespace["dfs"] = dfs
+    node.namespace["coupler_ifs"] = coupler_ifs
+
+    flux_settle = node.parameters.coupler_flux_settle_in_ns // 4
+    coupler_flux = node.parameters.coupler_flux_in_v
+
+    node.namespace["sweep_axes"] = {
+        "qubit_pair": xr.DataArray(qubit_pairs.get_names()),
+        "freq": xr.DataArray(dfs, attrs={"long_name": "coupler drive detuning", "units": "Hz"}),
+    }
+
+    with program() as qua_prog:
+        I, I_st, Q, Q_st, n, n_st = node.machine.declare_qua_variables(num_IQ_pairs=num_qubit_pairs)
+        if node.parameters.use_state_discrimination:
+            state = [declare(int) for _ in range(num_qubit_pairs)]
+            state_st = [declare_stream() for _ in range(num_qubit_pairs)]
+        df = declare(int)
+
+        for multiplexed_qubit_pairs in qubit_pairs.batch():
+            for qp in multiplexed_qubit_pairs.values():
+                node.machine.initialize_qpu(target=qp.qubit_control)
+                node.machine.initialize_qpu(target=qp.qubit_target)
+            align()
+
+            control_durations = {}
+            target_durations = {}
+            for ii, qp in multiplexed_qubit_pairs.items():
+                control = qp.qubit_control
+                target = qp.qubit_target
+                control_durations[ii] = (
+                    node.parameters.control_pulse_duration_in_ns * u.ns
+                    if node.parameters.control_pulse_duration_in_ns is not None
+                    else control.xy.operations[node.parameters.control_drive_operation].length * u.ns
+                ) // 4
+                target_durations[ii] = (
+                    node.parameters.target_pulse_duration_in_ns * u.ns
+                    if node.parameters.target_pulse_duration_in_ns is not None
+                    else target.xy.operations[node.parameters.target_drive_operation].length * u.ns
+                ) // 4
+
+            with for_(n, 0, n < node.parameters.num_shots, n + 1):
+                save(n, n_st)
+                with for_(*from_array(df, dfs)):
+                    for ii, qp in multiplexed_qubit_pairs.items():
+                        control = qp.qubit_control
+                        target = qp.qubit_target
+                        control.reset(node.parameters.reset_type, node.parameters.simulate)
+                        target.reset(node.parameters.reset_type, node.parameters.simulate)
+                        control.xy.update_frequency(
+                            df + coupler_ifs[qp.name] - if_update_by_pair[qp.name]
+                        )
+                    align()
+
+                    for ii, qp in multiplexed_qubit_pairs.items():
+                        qp.coupler.play(
+                            "const",
+                            amplitude_scale=coupler_flux / qp.coupler.operations["const"].amplitude,
+                            duration=flux_settle + control_durations[ii],
+                        )
+                    for ii, qp in multiplexed_qubit_pairs.items():
+                        qp.qubit_control.xy.wait(flux_settle)
+                    align()
+
+                    for ii, qp in multiplexed_qubit_pairs.items():
+                        qp.qubit_control.xy.play(
+                            node.parameters.control_drive_operation,
+                            amplitude_scale=node.parameters.control_pulse_amplitude,
+                            duration=control_durations[ii],
+                        )
+                    align()
+
+                    for ii, qp in multiplexed_qubit_pairs.items():
+                        qp.qubit_target.xy.play(
+                            node.parameters.target_drive_operation,
+                            amplitude_scale=node.parameters.target_pulse_amplitude,
+                            duration=target_durations[ii],
+                        )
+                    align()
+
+                    for ii, qp in multiplexed_qubit_pairs.items():
+                        target = qp.qubit_target
+                        if node.parameters.use_state_discrimination:
+                            target.readout_state(state[ii])
+                            save(state[ii], state_st[ii])
+                        else:
+                            target.resonator.measure("readout", qua_vars=(I[ii], Q[ii]))
+                            save(I[ii], I_st[ii])
+                            save(Q[ii], Q_st[ii])
+                    align()
+
+            if not node.parameters.multiplexed:
+                align()
+
+        with stream_processing():
+            n_st.save("n")
+            for i in range(num_qubit_pairs):
+                if node.parameters.use_state_discrimination:
+                    state_st[i].buffer(len(dfs)).average().save(f"state{i + 1}")
+                else:
+                    I_st[i].buffer(len(dfs)).average().save(f"I{i + 1}")
+                    Q_st[i].buffer(len(dfs)).average().save(f"Q{i + 1}")
+
+    node.namespace["qua_program"] = qua_prog
+
+
+# %% {Simulate_qua_program}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or not node.parameters.simulate)
+def simulate_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Connect to the QOP and simulate the QUA program."""
+    qmm = node.machine.connect()
+    config = node.machine.generate_config()
+    samples, fig, wf_report = simulate_and_plot(qmm, config, node.namespace["qua_program"], node.parameters)
+    node.results["simulation"] = {"figure": fig, "wf_report": wf_report, "samples": samples}
+    plt.show()
+
+
+# %% {Execute_qua_program}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or node.parameters.simulate)
+def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Execute the QUA program and fetch raw data."""
+    qmm = node.machine.connect()
+    config = node.machine.generate_config()
+    with qm_session(qmm, config, timeout=node.parameters.timeout) as qm:
+        node.namespace["job"] = job = qm.execute(node.namespace["qua_program"])
+        data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
+        for dataset in data_fetcher:
+            progress_counter(
+                data_fetcher.get("n", 0),
+                node.parameters.num_shots,
+                start_time=data_fetcher.t_start,
+            )
+        node.log(job.execution_report())
+
+    if "qubit_pair" in dataset.dims:
+        qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
+        dataset = dataset.rename({"qubit_pair": "qubit"})
+        dataset = dataset.assign_coords(qubit=qubit_pair_names)
+    node.results["ds_raw"] = dataset
+
+
+# %% {Load_data}
+@node.run_action(skip_if=node.parameters.load_data_id is None)
+def load_data(node: QualibrationNode[Parameters, Quam]):
+    """Load a previously acquired dataset."""
+    load_data_id = node.parameters.load_data_id
+    node.load_from_id(node.parameters.load_data_id)
+    node.parameters.load_data_id = load_data_id
+
+    node.namespace["qubit_pairs"] = get_qubit_pairs(node)
+    if "freq" in node.results["ds_raw"].dims:
+        node.namespace["dfs"] = node.results["ds_raw"].freq.values
+    if "qubit_pair" in node.results["ds_raw"].dims:
+        qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
+        node.results["ds_raw"] = node.results["ds_raw"].rename({"qubit_pair": "qubit"})
+        node.results["ds_raw"] = node.results["ds_raw"].assign_coords(qubit=qubit_pair_names)
+
+    node.parameters.update_state = stored_update_state
+    if node.parameters.update_state:
+        node.machine = stored_machine
+
+
+# %% {Analyse_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def analyse_data(node: QualibrationNode[Parameters, Quam]):
+    """Process raw data and extract coupler resonance frequencies."""
+    ds_proc = process_raw_dataset(node.results["ds_raw"], node)
+    node.results["ds_proc"] = ds_proc
+    ds_fit, fit_results = fit_raw_data(ds_proc, node)
+    node.results["ds_fit"] = ds_fit
+    node.results["fit_results"] = {k: asdict(v) for k, v in fit_results.items()}
+    log_fitted_results(fit_results, log_callable=node.log)
+
+    qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
+    node.outcomes = {
+        pair_name: ("successful" if node.results["fit_results"].get(pair_name, {}).get("success", False) else "failed")
+        for pair_name in qubit_pair_names
+    }
+
+
+# %% {Plot_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def plot_data(node: QualibrationNode[Parameters, Quam]):
+    """Plot three-tone spectra with extracted coupler frequencies."""
+    if "ds_fit" not in node.results:
+        return
+    fig = plot_raw_data_with_fit(
+        node.results["ds_fit"],
+        node.namespace["qubit_pairs"],
+        node.results["fit_results"],
+    )
+    node.results["figures"] = {"coupler_spectroscopy": fig}
+    plt.show()
+
+
+# %% {Update_state}
+@node.run_action(skip_if=node.parameters.simulate)
+def update_state(node: QualibrationNode[Parameters, Quam]):
+    """Write extracted coupler RF frequencies into state."""
+    if not node.parameters.update_state:
+        return
+
+    with node.record_state_updates():
+        for qp in node.namespace["qubit_pairs"]:
+            if node.outcomes.get(qp.name) == "failed":
+                continue
+            fit = node.results["fit_results"].get(qp.name)
+            if fit and fit.get("success"):
+                qp.coupler.RF_frequency = float(fit["coupler_frequency_hz"])
+                node.log(f"Updated {qp.coupler.name} RF_frequency = {qp.coupler.RF_frequency * 1e-9:.4f} GHz")
+
+
+# %% {Save_results}
+@node.run_action()
+def save_results(node: QualibrationNode[Parameters, Quam]):
+    """Save all node results and state updates."""
+    for qubit in node.namespace.get("tracked_qubits", []):
+        try:
+            qubit.revert_changes()
+        except Exception:
+            pass
+    node.save()
+
+
+# %%

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22b_three_tone_coupler_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22b_three_tone_coupler_spectroscopy_vs_coupler_flux.py
@@ -85,9 +85,7 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
     )
     node.namespace["coupler_rf_centers"] = coupler_rf_centers
     coupler_ifs = {
-        qp.name: int(
-            coupler_rf_centers[qp.name] - qp.qubit_control.xy.opx_output.upconverter_frequency
-        )
+        qp.name: int(coupler_rf_centers[qp.name] - qp.qubit_control.xy.opx_output.upconverter_frequency)
         for qp in qubit_pairs
     }
 
@@ -155,9 +153,7 @@ def create_qua_program(node: QualibrationNode[Parameters, Quam]):
                             target = qp.qubit_target
                             control.reset(node.parameters.reset_type, node.parameters.simulate)
                             target.reset(node.parameters.reset_type, node.parameters.simulate)
-                            control.xy.update_frequency(
-                                df + coupler_ifs[qp.name] - if_update_by_pair[qp.name]
-                            )
+                            control.xy.update_frequency(df + coupler_ifs[qp.name] - if_update_by_pair[qp.name])
                         align()
 
                         for ii, qp in multiplexed_qubit_pairs.items():

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22b_three_tone_coupler_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22b_three_tone_coupler_spectroscopy_vs_coupler_flux.py
@@ -1,0 +1,308 @@
+"""Three-tone coupler spectroscopy vs coupler flux — 22b."""
+
+# %%
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from calibration_utils.common_utils.flux_distortions import plan_lo_shift_for_frequency_window
+from calibration_utils.three_tone_coupler_spectroscopy_flux_pulse.parameters import (
+    resolve_coupler_rf_centers_by_pair,
+)
+from calibration_utils.three_tone_coupler_spectroscopy_vs_coupler_flux import (
+    Parameters,
+    fit_raw_data,
+    log_fitted_results,
+    plot_raw_data_with_fit,
+    process_raw_dataset,
+)
+from qm.qua import *
+from qualang_tools.loops import from_array
+from qualang_tools.multi_user import qm_session
+from qualang_tools.results import progress_counter
+from qualang_tools.units import unit
+from qualibrate import QualibrationNode
+from qualibration_libs.data import XarrayDataFetcher
+from qualibration_libs.parameters import get_qubit_pairs
+from qualibration_libs.runtime import simulate_and_plot
+from quam_config import Quam
+
+description = """
+THREE-TONE COUPLER SPECTROSCOPY VS COUPLER FLUX
+
+Maps coupler frequency vs coupler flux-pulse amplitude using three-tone
+spectroscopy: a coupler ``const`` pulse sets the bias (relative to decouple_offset),
+a strong control-qubit drive sweeps coupler frequency, and a weak target-qubit
+probe maps the coupler response.
+
+Prerequisites:
+- Target-qubit readout calibrated (IQ blobs / state discrimination)
+- Control- and target-qubit XY gates calibrated
+
+Outputs:
+- 2D dataset and heatmap of target response vs coupler flux pulse and drive frequency.
+"""
+
+node = QualibrationNode[Parameters, Quam](
+    name="22b_three_tone_coupler_spectroscopy_vs_coupler_flux",
+    description=description,
+    parameters=Parameters(),
+    machine=Quam.load(),
+)
+
+
+# %% {Custom_param}
+@node.run_action(skip_if=node.modes.external)
+def custom_param(node: QualibrationNode[Parameters, Quam]):
+    """Allow the user to locally set the node parameters."""
+
+
+# %% {Create_qua_program}
+@node.run_action(skip_if=node.parameters.load_data_id is not None)
+def create_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Create sweep axes and generate the three-tone 2D QUA program."""
+    u = unit(coerce_to_integer=True)
+    node.namespace["qubit_pairs"] = qubit_pairs = get_qubit_pairs(node)
+    num_qubit_pairs = len(qubit_pairs)
+
+    span = node.parameters.frequency_span_in_mhz * u.MHz
+    step = node.parameters.frequency_step_in_mhz * u.MHz
+    dfs = np.arange(-span / 2, span / 2, step, dtype=np.int64)
+    fluxes = np.linspace(
+        node.parameters.coupler_flux_min_in_v,
+        node.parameters.coupler_flux_max_in_v,
+        node.parameters.num_coupler_flux_points,
+    )
+    coupler_rf_centers = resolve_coupler_rf_centers_by_pair(
+        qubit_pairs,
+        node.parameters.rf_frequency_startpoint_in_hz,
+        coupler_band=node.parameters.coupler_band,
+        idle_detuning_hz=abs(float(node.parameters.coupler_idle_detuning_in_ghz)) * 1e9,
+        log_callable=node.log,
+    )
+    node.namespace["coupler_rf_centers"] = coupler_rf_centers
+    coupler_ifs = {
+        qp.name: int(
+            coupler_rf_centers[qp.name] - qp.qubit_control.xy.opx_output.upconverter_frequency
+        )
+        for qp in qubit_pairs
+    }
+
+    control_qubits = [qp.qubit_control for qp in qubit_pairs]
+    lo_plan = plan_lo_shift_for_frequency_window(
+        control_qubits,
+        dfs,
+        if_base_hz=[coupler_ifs[qp.name] for qp in qubit_pairs],
+        log_callable=node.log,
+    )
+    if lo_plan.force_thermal_reset:
+        node.parameters.reset_type = "thermal"
+    if_update_by_pair = {qp.name: lo_plan.if_update[i] for i, qp in enumerate(qubit_pairs)}
+    node.namespace["if_update_by_pair"] = if_update_by_pair
+    node.namespace["tracked_qubits"] = lo_plan.tracked_qubits
+
+    node.namespace["dfs"] = dfs
+    node.namespace["fluxes"] = fluxes
+    node.namespace["coupler_ifs"] = coupler_ifs
+
+    flux_settle = node.parameters.coupler_flux_settle_in_ns // 4
+
+    node.namespace["sweep_axes"] = {
+        "qubit_pair": xr.DataArray(qubit_pairs.get_names()),
+        "flux": xr.DataArray(fluxes, attrs={"long_name": "coupler flux pulse amplitude", "units": "V"}),
+        "freq": xr.DataArray(dfs, attrs={"long_name": "coupler drive detuning", "units": "Hz"}),
+    }
+
+    with program() as qua_prog:
+        I, I_st, Q, Q_st, n, n_st = node.machine.declare_qua_variables(num_IQ_pairs=num_qubit_pairs)
+        if node.parameters.use_state_discrimination:
+            state = [declare(int) for _ in range(num_qubit_pairs)]
+            state_st = [declare_stream() for _ in range(num_qubit_pairs)]
+        flux_bias = declare(fixed)
+        df = declare(int)
+
+        for multiplexed_qubit_pairs in qubit_pairs.batch():
+            for qp in multiplexed_qubit_pairs.values():
+                node.machine.initialize_qpu(target=qp.qubit_control)
+                node.machine.initialize_qpu(target=qp.qubit_target)
+            align()
+
+            control_durations = {}
+            target_durations = {}
+            for ii, qp in multiplexed_qubit_pairs.items():
+                control = qp.qubit_control
+                target = qp.qubit_target
+                control_durations[ii] = (
+                    node.parameters.control_pulse_duration_in_ns * u.ns
+                    if node.parameters.control_pulse_duration_in_ns is not None
+                    else control.xy.operations[node.parameters.control_drive_operation].length * u.ns
+                ) // 4
+                target_durations[ii] = (
+                    node.parameters.target_pulse_duration_in_ns * u.ns
+                    if node.parameters.target_pulse_duration_in_ns is not None
+                    else target.xy.operations[node.parameters.target_drive_operation].length * u.ns
+                ) // 4
+
+            with for_(n, 0, n < node.parameters.num_shots, n + 1):
+                save(n, n_st)
+                with for_(*from_array(flux_bias, fluxes)):
+                    with for_(*from_array(df, dfs)):
+                        for ii, qp in multiplexed_qubit_pairs.items():
+                            control = qp.qubit_control
+                            target = qp.qubit_target
+                            control.reset(node.parameters.reset_type, node.parameters.simulate)
+                            target.reset(node.parameters.reset_type, node.parameters.simulate)
+                            control.xy.update_frequency(
+                                df + coupler_ifs[qp.name] - if_update_by_pair[qp.name]
+                            )
+                        align()
+
+                        for ii, qp in multiplexed_qubit_pairs.items():
+                            qp.coupler.play(
+                                "const",
+                                amplitude_scale=flux_bias / qp.coupler.operations["const"].amplitude,
+                                duration=flux_settle + control_durations[ii] + target_durations[ii],
+                            )
+                        for ii, qp in multiplexed_qubit_pairs.items():
+                            qp.qubit_control.xy.wait(flux_settle)
+                        for ii, qp in multiplexed_qubit_pairs.items():
+                            qp.qubit_control.xy.play(
+                                node.parameters.control_drive_operation,
+                                amplitude_scale=node.parameters.control_pulse_amplitude,
+                                duration=control_durations[ii],
+                            )
+                        for ii, qp in multiplexed_qubit_pairs.items():
+                            qp.qubit_target.xy.wait(flux_settle + control_durations[ii])
+                        for ii, qp in multiplexed_qubit_pairs.items():
+                            qp.qubit_target.xy.play(
+                                node.parameters.target_drive_operation,
+                                amplitude_scale=node.parameters.target_pulse_amplitude,
+                                duration=target_durations[ii],
+                            )
+                        align()
+
+                        for ii, qp in multiplexed_qubit_pairs.items():
+                            target = qp.qubit_target
+                            if node.parameters.use_state_discrimination:
+                                target.readout_state(state[ii])
+                                save(state[ii], state_st[ii])
+                            else:
+                                target.resonator.measure("readout", qua_vars=(I[ii], Q[ii]))
+                                save(I[ii], I_st[ii])
+                                save(Q[ii], Q_st[ii])
+                        align()
+
+            if not node.parameters.multiplexed:
+                align()
+
+        with stream_processing():
+            n_st.save("n")
+            for i in range(num_qubit_pairs):
+                if node.parameters.use_state_discrimination:
+                    state_st[i].buffer(len(dfs)).buffer(len(fluxes)).average().save(f"state{i + 1}")
+                else:
+                    I_st[i].buffer(len(dfs)).buffer(len(fluxes)).average().save(f"I{i + 1}")
+                    Q_st[i].buffer(len(dfs)).buffer(len(fluxes)).average().save(f"Q{i + 1}")
+
+    node.namespace["qua_program"] = qua_prog
+
+
+# %% {Simulate_qua_program}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or not node.parameters.simulate)
+def simulate_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Connect to the QOP and simulate the QUA program."""
+    qmm = node.machine.connect()
+    config = node.machine.generate_config()
+    samples, fig, wf_report = simulate_and_plot(qmm, config, node.namespace["qua_program"], node.parameters)
+    node.results["simulation"] = {"figure": fig, "wf_report": wf_report, "samples": samples}
+    plt.show()
+
+
+# %% {Execute_qua_program}
+@node.run_action(skip_if=node.parameters.load_data_id is not None or node.parameters.simulate)
+def execute_qua_program(node: QualibrationNode[Parameters, Quam]):
+    """Execute the QUA program and fetch raw data."""
+    qmm = node.machine.connect()
+    config = node.machine.generate_config()
+    with qm_session(qmm, config, timeout=node.parameters.timeout) as qm:
+        node.namespace["job"] = job = qm.execute(node.namespace["qua_program"])
+        data_fetcher = XarrayDataFetcher(job, node.namespace["sweep_axes"])
+        for dataset in data_fetcher:
+            progress_counter(
+                data_fetcher.get("n", 0),
+                node.parameters.num_shots,
+                start_time=data_fetcher.t_start,
+            )
+        node.log(job.execution_report())
+
+    if "qubit_pair" in dataset.dims:
+        qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
+        dataset = dataset.rename({"qubit_pair": "qubit"})
+        dataset = dataset.assign_coords(qubit=qubit_pair_names)
+    node.results["ds_raw"] = dataset
+
+
+# %% {Load_data}
+@node.run_action(skip_if=node.parameters.load_data_id is None)
+def load_data(node: QualibrationNode[Parameters, Quam]):
+    """Load a previously acquired dataset."""
+    load_data_id = node.parameters.load_data_id
+    node.load_from_id(node.parameters.load_data_id)
+    node.parameters.load_data_id = load_data_id
+
+    node.namespace["qubit_pairs"] = get_qubit_pairs(node)
+    if "freq" in node.results["ds_raw"].dims:
+        node.namespace["dfs"] = node.results["ds_raw"].freq.values
+    if "flux" in node.results["ds_raw"].dims:
+        node.namespace["fluxes"] = node.results["ds_raw"].flux.values
+    if "qubit_pair" in node.results["ds_raw"].dims:
+        qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
+        node.results["ds_raw"] = node.results["ds_raw"].rename({"qubit_pair": "qubit"})
+        node.results["ds_raw"] = node.results["ds_raw"].assign_coords(qubit=qubit_pair_names)
+
+
+# %% {Analyse_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def analyse_data(node: QualibrationNode[Parameters, Quam]):
+    """Process raw data and attach absolute frequency coordinates."""
+    ds_proc = process_raw_dataset(node.results["ds_raw"], node)
+    node.results["ds_proc"] = ds_proc
+    ds_fit, fit_results = fit_raw_data(ds_proc, node)
+    node.results["ds_fit"] = ds_fit
+    node.results["fit_results"] = {k: asdict(v) for k, v in fit_results.items()}
+    log_fitted_results(fit_results, log_callable=node.log)
+
+    qubit_pair_names = [qp.name for qp in node.namespace["qubit_pairs"]]
+    node.outcomes = {
+        pair_name: ("successful" if node.results["fit_results"].get(pair_name, {}).get("success", False) else "failed")
+        for pair_name in qubit_pair_names
+    }
+
+
+# %% {Plot_data}
+@node.run_action(skip_if=node.parameters.simulate)
+def plot_data(node: QualibrationNode[Parameters, Quam]):
+    """Plot 2D three-tone spectroscopy heatmaps."""
+    if "ds_fit" not in node.results:
+        return
+    fig = plot_raw_data_with_fit(node.results["ds_fit"], node.namespace["qubit_pairs"])
+    node.results["figures"] = {"coupler_spectroscopy": fig}
+    plt.show()
+
+
+# %% {Save_results}
+@node.run_action()
+def save_results(node: QualibrationNode[Parameters, Quam]):
+    """Save all node results."""
+    for qubit in node.namespace.get("tracked_qubits", []):
+        try:
+            qubit.revert_changes()
+        except Exception:
+            pass
+    node.save()
+
+
+# %%

--- a/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22b_three_tone_coupler_spectroscopy_vs_coupler_flux.py
+++ b/qualibration_graphs/superconducting/calibrations/1Q_calibrations/22b_three_tone_coupler_spectroscopy_vs_coupler_flux.py
@@ -31,19 +31,28 @@ from qualibration_libs.runtime import simulate_and_plot
 from quam_config import Quam
 
 description = """
-THREE-TONE COUPLER SPECTROSCOPY VS COUPLER FLUX
+Three-tone coupler spectroscopy vs coupler flux — the coupler flux arc.
 
-Maps coupler frequency vs coupler flux-pulse amplitude using three-tone
-spectroscopy: a coupler ``const`` pulse sets the bias (relative to decouple_offset),
-a strong control-qubit drive sweeps coupler frequency, and a weak target-qubit
-probe maps the coupler response.
+Same probe as **22a** — see ``22a_three_tone_coupler_spectroscopy_flux_pulse.py`` for the
+physics — repeated over a range of coupler flux-pulse amplitudes, so the coupler frequency
+is mapped as a function of its flux bias rather than measured at a single bias point.
+
+Workflow:
+For each coupler flux-pulse amplitude between ``coupler_flux_min_in_v`` and
+``coupler_flux_max_in_v`` (played relative to ``decouple_offset``), sweep the
+control-qubit drive across the coupler RF window and record the target-qubit response.
+The resulting 2D map traces the coupler flux arc, which sets where the coupler idles and
+how far it has to travel for a CZ gate.
 
 Prerequisites:
 - Target-qubit readout calibrated (IQ blobs / state discrimination)
 - Control- and target-qubit XY gates calibrated
+- **22a** run once so ``coupler.RF_frequency`` is in state; otherwise the sweep centre
+  falls back to the ``coupler_band`` estimate
 
 Outputs:
-- 2D dataset and heatmap of target response vs coupler flux pulse and drive frequency.
+- Results: 2D dataset and heatmap of target response vs coupler flux pulse and drive
+  frequency, saved under ``node.results``.
 """
 
 node = QualibrationNode[Parameters, Quam](


### PR DESCRIPTION
## Summary
- Add **22a** (`22a_three_tone_coupler_spectroscopy_flux_pulse`): drive the coupler through the control qubit while probing the target, at a fixed coupler flux pulse. Fit the three-tone dip and optionally write `coupler.RF_frequency`.
- Add **22b** (`22b_three_tone_coupler_spectroscopy_vs_coupler_flux`): same drive, sweeping coupler flux-pulse amplitude vs drive frequency.
- Sweep centre is `rf_frequency_startpoint_in_hz`, else `coupler.RF_frequency` from state, else an idle guess: **1.2 GHz above `max(f)` or below `min(f)`** (`coupler_band` / `coupler_idle_detuning_in_ghz`).
- Extend existing `plan_lo_shift_for_frequency_window` with optional `if_base_hz` so the coupler-drive IF (not the qubit XY IF) stays in MW-FEM reach. 17a/21a are unchanged if they omit the argument.

Independent of the 21a/21b/21c flux-distortion branch.

## Test plan
- Nodes were run end to end on a tunable-coupler chip (program, fetch, analysis, plots).
- Physics is still untested: we did not check that fitted coupler frequencies or flux maps are fully accurate.